### PR TITLE
Enable one Kokoro build.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,23 @@
+# Use the Google style in this project.
+BasedOnStyle: Google
+
+# Some folks prefer to write "int& foo" while others prefer "int &foo".  The
+# Google Style Guide only asks for consistency within a project, we chose
+# "int& foo" for this project:
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+IncludeBlocks: Merge
+IncludeCategories:
+- Regex: '^\"google/cloud/'
+  Priority: 1500
+- Regex: '^\"'
+  Priority: 1000
+- Regex: '^<grpc/'
+  Priority: 2000
+- Regex: '^<google/*'
+  Priority: 3000
+- Regex: '^<.*/.*'
+  Priority: 4000
+- Regex: '^<[^/]*>'
+  Priority: 5000

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,40 @@
+---
+# Configure clang-tidy for this project.
+
+# Disabled:
+#  -google-readability-namespace-comments the BIGTABLE_CLIENT_NS is a macro, and
+#   clang-tidy fails to match it against the initial value.
+Checks: >-
+  bugprone-*,
+  google-readability-*,
+  misc-*,
+  modernize-*,
+  readability-*,
+  performance-*,
+  -google-readability-namespace-comments,
+  -readability-named-parameter
+
+# Enable most warnings as errors.
+WarningsAsErrors: >-
+  bugprone-*,
+  clang-*,
+  google-*,
+  misc-*,
+  modernize-*,
+  readability-*,
+  performance-*
+
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,              value: CamelCase  }
+  - { key: readability-identifier-naming.StructCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,           value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
+  - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
+  - { key: readability-identifier-naming.MacroDefinitionCase,    value: UPPER_CASE }
+  - { key: readability-identifier-naming.EnumConstantCase,       value: UPPER_CASE }
+  - { key: readability-identifier-naming.ConstexprVariableCase,  value: UPPER_CASE }
+  - { key: readability-identifier-naming.GlobalConstantCase,     value: UPPER_CASE }
+  - { key: readability-identifier-naming.MemberConstantCase,     value: UPPER_CASE }

--- a/ci/check-include-guards.gawk
+++ b/ci/check-include-guards.gawk
@@ -1,0 +1,84 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Exit the script with an error status if any files had bad guards.
+BEGIN {
+    found_bad_include_guards = 0;
+}
+END {
+    if (found_bad_include_guards) {
+        exit 1;
+    }
+}
+
+# Reset the state at the beginning of each file.
+BEGINFILE {
+    # The guard must begin with the name of the project.
+    guard_prefix="GOOGLE_CLOUD_CPP_"
+    # The guard must end with "_"
+    guard_suffix="_"
+    # The guard name is the filename (including path from the root of the
+    # project), with "/" and "." characters replaced with "_", and all
+    # characters converted to uppercase:
+    guard_body=toupper(FILENAME)
+    gsub("[/\\.]", "_", guard_body)
+    guard=toupper(guard_prefix guard_body guard_suffix)
+    matches=0
+}
+
+# By the end of the file we expect to find 3 matches for the include guards.
+ENDFILE {
+    if (matches != 3) {
+        printf("%s has invalid include guards\n", FILENAME);
+        found_bad_include_guards = 1;
+    }
+}
+
+# Check only lines that start with #ifndef, #define, or #endif.
+/^#ifndef / {
+    # Ignore lines that do not look like guards at all.
+    if ($0 !~ "_H_$") { next; }
+    if (index($0, guard) == 9) {
+        matches++;
+    } else {
+        printf("%s:\n", FILENAME)
+        printf("expected: #ifndef %s\n", FILENAME, guard)
+        printf("   found: %s\n", $0);
+    }
+}
+
+/^#define / {
+    # Ignore lines that do not look like guards at all.
+    if ($0 !~ "_H_$") { next; }
+    if (index($0, guard) == 9) {
+      matches++;
+    } else {
+      printf("%s:\n", FILENAME)
+      printf("expected: #define %s\n", guard)
+      printf("   found: %s\n", $0);
+    }
+}
+
+/^#endif / {
+    # Ignore lines that do not look like guards at all.
+    if ($0 !~ "_H_$") { next; }
+    if (index($0, "// " guard) == 9) {
+        matches++;
+    } else {
+      printf("%s:\n", FILENAME)
+      printf("expected: #endif  // %s\n", guard)
+      printf("   found: %s\n", $0);
+    }
+}

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ "${CHECK_STYLE}" != "yes" ]]; then
+  echo "Skipping code style check as it is disabled for this build."
+  exit 0
+fi
+
+# This script assumes it is running the top-level google-cloud-cpp directory.
+
+readonly BINDIR="$(dirname "$0")"
+
+# Build paths to ignore in find(1) commands by reading .gitignore.
+declare -a ignore=( -path ./.git )
+if [[ -f .gitignore ]]; then
+  while read -r line; do
+    case "${line}" in
+    [^#]*/*) ignore+=( -o -path "./$(expr "${line}" : '\(.*\)/')" ) ;;
+    [^#]*)   ignore+=( -o -name "${line}" ) ;;
+    esac
+  done < .gitignore
+fi
+
+find google/cloud -name '*.h' -print0 |
+  xargs -0 awk -f "${BINDIR}/check-include-guards.gawk"
+
+replace_original_if_changed() {
+  if [[ $# != 2 ]]; then
+    return 1
+  fi
+
+  local original="$1"
+  local reformatted="$2"
+
+  chmod --reference="${original}" "${reformatted}"
+  if cmp -s "${original}" "${reformatted}"; then
+    rm -f "${reformatted}"
+  else
+    mv -f "${reformatted}" "${original}"
+  fi
+}
+
+# Apply cmake_format to all the CMake list files.
+#     https://github.com/cheshirekow/cmake_format
+find . \( "${ignore[@]}" \) -prune -o \
+       \( -name 'CMakeLists.txt' -o -name '*.cmake' \) \
+       -print0 |
+  while IFS= read -r -d $'\0' file; do
+    cmake-format "${file}" >"${file}.tmp"
+    replace_original_if_changed "${file}" "${file}.tmp"
+  done
+
+# Apply clang-format(1) to fix whitespace and other formatting rules.
+# The version of clang-format is important, different versions have slightly
+# different formatting output (sigh).
+find google/cloud \( -name '*.cc' -o -name '*.h' \) -print0 |
+  while IFS= read -r -d $'\0' file; do
+    clang-format "${file}" >"${file}.tmp"
+    replace_original_if_changed "${file}" "${file}.tmp"
+  done
+
+# Apply several transformations that cannot be enforced by clang-format:
+#     - Replace any #include for grpc++/* with grpcpp/*. The paths with grpc++
+#       are obsoleted by the gRPC team, so we should not use them in our code.
+#     - Replace grpc::<BLAH> with grpc::StatusCode::<BLAH>, the aliases in the
+#       `grpc::` namespace do not exist inside google.
+find google/cloud \( -name '*.cc' -o -name '*.h' \) -print0 |
+  while IFS= read -r -d $'\0' file; do
+    # We used to run run `sed -i` to apply these changes, but that touches the
+    # files even if there are no changes applied, forcing a rebuild each time.
+    # So we first apply the change to a temporary file, and replace the original
+    # only if something changed.
+    sed -e 's/grpc::\([A-Z][A-Z_][A-Z_]*\)/grpc::StatusCode::\1/g' \
+        -e 's;#include <grpc\\+\\+/grpc\+\+.h>;#include <grpcpp/grpcpp.h>;' \
+        -e 's;#include <grpc\\+\\+/;#include <grpcpp/;' \
+        "${file}" > "${file}.tmp"
+    replace_original_if_changed "${file}" "${file}.tmp"
+  done
+
+# Apply buildifier to fix the BUILD and .bzl formatting rules.
+#    https://github.com/bazelbuild/buildtools/tree/master/buildifier
+find . \( "${ignore[@]}" \) -prune -o \
+       \( -name BUILD -o -name '*.bzl' \) \
+       -print0 |
+  xargs -0 buildifier -mode=fix
+
+# Apply shellcheck(1) to emit warnings for common scripting mistakes.
+find . \( "${ignore[@]}" \) -prune -o \
+       -iname '*.sh' -exec shellcheck \
+         --exclude=SC1090 \
+         --exclude=SC2034 \
+         --exclude=SC2153 \
+         --exclude=SC2181 \
+       '{}' \;
+
+# Apply transformations to fix whitespace formatting in files not handled by
+# clang-format(1) above.  For now we simply remove trailing blanks.  Note that
+# we do not expand TABs (they currently only appear in Makefiles and Makefile
+# snippets).
+find . \( "${ignore[@]}" \) -prune -o \
+       -type f ! -name '*.gz' \
+       -print0 |
+  while IFS= read -r -d $'\0' file; do
+    sed -e 's/[[:blank:]][[:blank:]]*$//' \
+        "${file}" > "${file}.tmp"
+    replace_original_if_changed "${file}" "${file}.tmp"
+  done
+
+# Report any differences created by running the formatting tools.
+git diff --ignore-submodules=all --color --exit-code .

--- a/ci/colors.sh
+++ b/ci/colors.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "${COLOR_RESET+x}" ]; then
+  if type tput >/dev/null 2>&1; then
+    readonly COLOR_RED="$(tput setaf 1)"
+    readonly COLOR_GREEN="$(tput setaf 2)"
+    readonly COLOR_YELLOW="$(tput setaf 3)"
+    readonly COLOR_RESET="$(tput sgr0)"
+  else
+    readonly COLOR_RED=""
+    readonly COLOR_GREEN=""
+    readonly COLOR_YELLOW=""
+    readonly COLOR_RESET=""
+  fi
+fi

--- a/ci/define-dump-log.sh
+++ b/ci/define-dump-log.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################
+# Dump a log file to the console without going over CI system limits.
+# Globals:
+#   None
+# Arguments:
+#   logfile: the name of the logfile to print out.
+# Returns:
+#   None
+################################################
+dump_log() {
+  local -r logfile=$1
+  shift
+  local -r base="$(basename "${logfile}")"
+
+  if [ ! -r "${logfile}" ]; then
+    return
+  fi
+
+  echo "================ [begin ${base}] ================"
+  # Travis has a limit of ~10,000 lines, if the file is around 1,000 just print
+  # the full file.
+  if [ "$(wc -l "${logfile}" | awk '{print $1}')" -lt 200 ]; then
+    cat "${logfile}"
+  else
+    head -100 "${logfile}"
+    echo "==== [snip] [snip] [${base}] [snip] [snip] ===="
+    tail -100 "${logfile}"
+  fi
+  echo "================ [end ${base}] ================"
+}

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" \
+  |  tr '[:upper:]' '[:lower:]')
+
+readonly BAZEL_VERSION="0.24.0"
+readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
+readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
+wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"
+wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}.sha256"
+
+# We want to protect against accidents (i.e., we don't want to download and
+# execute a 404 page), not malice, so downloading the checksum and the file
+# from the same source is Okay.
+sha256sum --check "${SCRIPT_NAME}.sha256"
+
+chmod +x "${SCRIPT_NAME}"
+"./${SCRIPT_NAME}" --user
+
+rm -f "${SCRIPT_NAME}" "${SCRIPT_NAME}.sha256"

--- a/ci/install-retry.sh
+++ b/ci/install-retry.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Make three attempts to install the dependencies. It is rare, but from time to
+# time the downloading the packages, building the Docker images, or an installer
+# Bazel, or the Google Cloud SDK fails. To make the CI build more robust, try
+# again when that happens.
+
+if (( $# < 1 )); then
+  echo "Usage: $(basename "$0") program [arguments]"
+  exit 1
+fi
+readonly PROGRAM=${1}
+shift
+
+# Initially, wait at least 2 minutes (the times are in seconds), because it
+# makes no sense to try faster. This used to be 180 seconds, but that ends with
+# sleeps close to 10 minutes, and Travis aborts builds that do not output in
+# 10m.
+min_wait=120
+# Do not exit on failures for this loop.
+set +e
+for i in 1 2 3; do
+  "${PROGRAM}" "$@"
+  if [[ $? -eq 0 ]]; then
+    exit 0
+  fi
+  # Sleep for a few minutes before trying again.
+  period=$(( (RANDOM % 60) + min_wait ))
+  echo "${PROGRAM} failed; trying again in ${period} seconds."
+  sleep ${period}s
+  min_wait=$(( min_wait * 2 ))
+done
+
+exit 1

--- a/ci/kokoro/Dockerfile.ubuntu
+++ b/ci/kokoro/Dockerfile.ubuntu
@@ -1,0 +1,55 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=18.04
+FROM ubuntu:${DISTRO_VERSION}
+
+RUN apt update && \
+    apt install -y \
+        clang \
+        cmake \
+        curl \
+        doxygen \
+        gawk \
+        git \
+        gcc \
+        g++ \
+        cmake \
+        pkg-config \
+	python-pip \
+        shellcheck \
+        tar \
+	unzip \
+        wget
+
+# By default, Ubuntu 18.04 does not install the alternatives for clang-format
+# and clang-tidy, so we need to manually install those.
+RUN if grep -q 18.04 /etc/lsb-release; then \
+      apt update && apt install -y clang-tidy clang-format-7; \
+      update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100; \
+      update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7 100; \
+    fi
+
+# Install the the buildifier tool, which does not compile with the default
+# golang compiler for Ubuntu 16.04 and Ubuntu 18.04.
+RUN wget -q -O /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier
+RUN chmod 755 /usr/bin/buildifier
+
+# Install cmake_format to automatically format the CMake list files.
+#     https://github.com/cheshirekow/cmake_format
+# Pin this to an specific version because the formatting changes when the
+# "latest" version is updated, and we do not want the builds to break just
+# because some third party changed something.
+RUN pip install --upgrade pip
+RUN pip install numpy cmake_format==0.5.1

--- a/ci/kokoro/build-docker.sh
+++ b/ci/kokoro/build-docker.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# This script is supposed to run inside a Docker container, see
+# ci/kokoro/build.sh for the expected setup.  The /v directory is a volume
+# pointing to a (clean-ish) checkout of google-cloud-cpp:
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  readonly PROJECT_ROOT="/v"
+fi
+source "${PROJECT_ROOT}/ci/kokoro/linux-config.sh"
+source "${PROJECT_ROOT}/ci/colors.sh"
+
+# Run the "bazel build"/"bazel test" cycle inside a Docker image.
+# This script is designed to work in the context created by the
+# ci/Dockerfile.* build scripts.
+
+echo
+echo "${COLOR_YELLOW}Starting docker build $(date) with ${NCPU} cores${COLOR_RESET}"
+echo
+
+echo "================================================================"
+echo "Update or Install Bazel $(date)."
+echo "================================================================"
+(cd /var/tmp ; "${PROJECT_ROOT}/ci/install-bazel.sh")
+
+echo "================================================================"
+echo "Verify formattting $(date)"
+echo "================================================================"
+(cd "${PROJECT_ROOT}" ; ./ci/check-style.sh)
+
+
+readonly BAZEL_BIN="$HOME/bin/bazel"
+echo "Using Bazel in ${BAZEL_BIN}"
+
+echo "================================================================"
+echo "Compiling and running unit tests $(date)"
+echo "================================================================"
+"${BAZEL_BIN}" test \
+    --test_output=errors \
+    --verbose_failures=true \
+    --keep_going \
+    -- //google/cloud/...:all
+
+echo "================================================================"
+echo "Compiling all the code, including integration tests $(date)"
+echo "================================================================"
+# Then build everything else (integration tests, examples, etc). So we can run
+# them next.
+"${BAZEL_BIN}" build \
+    --test_output=errors \
+    --verbose_failures=true \
+    --keep_going \
+    -- //google/cloud/...:all
+
+echo "================================================================"
+echo "Build finished at $(date)"
+echo "================================================================"
+
+exit 0

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+export CC=gcc
+export CXX=g++
+export DISTRO=ubuntu
+export DISTRO_VERSION=18.04
+
+if [[ "${BUILD_NAME+x}" != "x" ]]; then
+ echo "The BUILD_NAME is not defined or is empty. Fix the Kokoro .cfg file."
+ exit 1
+elif [[ "${BUILD_NAME}" = "clang-tidy" ]]; then
+  # Compile with clang-tidy(1) turned on. The build treats clang-tidy warnings
+  # as errors.
+  export BUILD_TYPE=Debug
+  export CC=clang
+  export CXX=clang++
+  export CMAKE_FLAGS="-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes"
+  export CHECK_STYLE=yes
+  export GENERATE_DOCS=yes
+else
+  echo "Unknown BUILD_NAME (${BUILD_NAME}). Fix the Kokoro .cfg file."
+  exit 1
+fi
+
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/kokoro/linux-config.sh"
+source "${PROJECT_ROOT}/ci/define-dump-log.sh"
+
+echo "================================================================"
+NCPU=$(nproc)
+export NCPU
+cd "${PROJECT_ROOT}"
+echo "Building with ${NCPU} cores $(date) on ${PWD}."
+
+
+echo "================================================================"
+echo "Capture Docker version to troubleshoot $(date)."
+sudo docker version
+echo "================================================================"
+
+echo "================================================================"
+echo "Creating Docker image with all the development tools $(date)."
+# We do not want to print the log unless there is an error, so disable the -e
+# flag. Later, we will want to print out the emulator(s) logs *only* if there
+# is an error, so disabling from this point on is the right choice.
+set +e
+mkdir -p "${BUILD_OUTPUT}"
+"${PROJECT_ROOT}/ci/install-retry.sh" \
+  "${PROJECT_ROOT}/ci/kokoro/install-linux.sh" \
+      >"${BUILD_OUTPUT}/create-build-docker-image.log" 2>&1 </dev/null
+if [[ "$?" != 0 ]]; then
+  dump_log "${BUILD_OUTPUT}/create-build-docker-image.log"
+  exit 1
+fi
+echo "Docker image created $(date)."
+sudo docker image ls
+echo "================================================================"
+
+echo "================================================================"
+echo "Running the full build $(date)."
+# When running on Travis the build gets a tty, and docker can produce nicer
+# output in that case, but on Kokoro the script does not get a tty, and Docker
+# terminates the program if we pass the `-it` flag in that case.
+interactive_flag=""
+if [[ -t 0 ]]; then
+  interactive_flag="-it"
+fi
+
+# Make sure the user has a $HOME directory inside the Docker container.
+mkdir -p "${BUILD_HOME}"
+
+sudo docker run \
+     --cap-add SYS_PTRACE \
+     --env DISTRO="${DISTRO}" \
+     --env DISTRO_VERSION="${DISTRO_VERSION}" \
+     --env CXX="${CXX}" \
+     --env CC="${CC}" \
+     --env NCPU="${NCPU:-2}" \
+     --env BUILD_TYPE="${BUILD_TYPE:-Release}" \
+     --env CHECK_STYLE="${CHECK_STYLE:-}" \
+     --env GENERATE_DOCS="${GENERATE_DOCS:-}" \
+     --env CMAKE_FLAGS="${CMAKE_FLAGS:-}" \
+     --env TERM="${TERM:-dumb}" \
+     --env HOME="/v/${BUILD_HOME}" \
+     --env USER="${USER}" \
+     --user "${UID:-0}" \
+     --volume "${PWD}":/v \
+     --workdir /v \
+     "${IMAGE}:tip" \
+     "/v/ci/kokoro/build-docker.sh"
+
+exit_status=$?
+echo "Build finished with ${exit_status} exit status $(date)."
+echo "================================================================"
+
+if [[ "${exit_status}" != 0 ]]; then
+  echo "================================================================"
+  echo "Build failed, printing out logs $(date)."
+  "${PROJECT_ROOT}/ci/kokoro/dump-logs.sh"
+  echo "================================================================"
+fi
+
+exit ${exit_status}

--- a/ci/kokoro/docker/clang-tidy-presubmit.cfg
+++ b/ci/kokoro/docker/clang-tidy-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "clang-tidy"
+}

--- a/ci/kokoro/docker/clang-tidy.cfg
+++ b/ci/kokoro/docker/clang-tidy.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "clang-tidy"
+}

--- a/ci/kokoro/dump-logs.sh
+++ b/ci/kokoro/dump-logs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/kokoro/linux-config.sh"
+source "${PROJECT_ROOT}/ci/define-dump-log.sh"
+
+# Dump the image installation log.
+echo
+dump_log "cmake-out/install-linux.log"
+
+# Dump the emulator log file. Tests run in the google/cloud/bigtable/tests directory.
+echo
+dump_log "${BUILD_OUTPUT}/google/cloud/bigtable/tests/emulator.log"
+dump_log "${BUILD_OUTPUT}/google/cloud/bigtable/tests/instance-admin-emulator.log"

--- a/ci/kokoro/install-linux.sh
+++ b/ci/kokoro/install-linux.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Create a Docker image with all the dependencies necessary to build the
+# project.
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/kokoro/linux-config.sh"
+
+cd "${PROJECT_ROOT}"
+sudo docker build -t "${IMAGE}:tip" \
+     --build-arg NCPU="${NCPU:-2}" \
+     --build-arg DISTRO_VERSION="${DISTRO_VERSION}" \
+     -f "ci/kokoro/Dockerfile.${DISTRO}" ci

--- a/ci/kokoro/linux-config.sh
+++ b/ci/kokoro/linux-config.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ -n "${IMAGE+x}" ]]; then
+  echo "IMAGE is already defined."
+else
+  readonly IMAGE="spanci-${DISTRO}-${DISTRO_VERSION}"
+  suffix=""
+  if [[ -n "${CC:-}" ]]; then
+    suffix="${suffix}-${CC}"
+  fi
+  suffix="${suffix}-${BUILD_TYPE:-Release}"
+  if [[ "${SCAN_BUILD+x}" = "yes" ]]; then
+    suffix="${suffix}-scan"
+  fi
+  if [[ -z "${CMAKE_FLAGS:-}" ]]; then
+      /bin/true
+  elif echo "${CMAKE_FLAGS}" | grep -Eq BUILD_SHARED_LIBS=yes; then
+      suffix="${suffix}-shared"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq GOOGLE_CLOUD_CPP_CLANG_TIDY=yes; then
+      suffix="${suffix}-tidy"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq TEST_INSTALL=yes; then
+      suffix="${suffix}-install"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq SANITIZE_ADDRESS=yes; then
+      suffix="${suffix}-asan"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq SANITIZE_UNDEFINED=yes; then
+      suffix="${suffix}-ubsan"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq SANITIZE_MEMORY=yes; then
+      suffix="${suffix}-msan"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq SANITIZE_THREAD=yes; then
+      suffix="${suffix}-tsan"
+  elif echo "${CMAKE_FLAGS}" | grep -Eq GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS=no; then
+      suffix="${suffix}-noex"
+  fi
+  readonly BUILD_OUTPUT="cmake-out/${IMAGE}${suffix}"
+  readonly BUILD_HOME="cmake-out/home/${IMAGE}${suffix}"
+  readonly DOCKER_CCACHE_DIR="cmake-out/ccache/${IMAGE}${suffix}"
+fi

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -24,19 +24,19 @@ set(SPANNER_CLIENT_COPYRIGHT_YEAR 2019)
 set(DOXYGEN_PROJECT_NAME "Google Cloud Spanner C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Spanner")
 set(
-    DOXYGEN_PROJECT_NUMBER
-    "${SPANNER_CLIENT_VERSION_MAJOR}.${SPANNER_CLIENT_VERSION_MINOR}.${SPANNER_CLIENT_VERSION_PATCH}"
-    )
+  DOXYGEN_PROJECT_NUMBER
+  "${SPANNER_CLIENT_VERSION_MAJOR}.${SPANNER_CLIENT_VERSION_MINOR}.${SPANNER_CLIENT_VERSION_PATCH}"
+  )
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/examples)
 set(DOXYGEN_PREDEFINED "SPANNER_CLIENT_NS=v${SPANNER_CLIENT_VERSION_MAJOR}")
 set(DOXYGEN_EXCLUDE_PATTERNS "*/google/cloud/spanner/README.md"
-    "*/google/cloud/spanner/*_test.cc")
+                             "*/google/cloud/spanner/*_test.cc")
 set(DOXYGEN_TAGFILES "${PROJECT_BINARY_DIR}/google/cloud/cloud.tag=../common")
 
 include(GoogleCloudCppCommon)
-if (TARGET spanner-docs AND TARGET cloud-docs)
-    add_dependencies(spanner-docs cloud-docs)
-endif ()
+if(TARGET spanner-docs AND TARGET cloud-docs)
+  add_dependencies(spanner-docs cloud-docs)
+endif()
 
 # Define an interface library, i.e., a library that really has no sources, and
 # add public target options to it.  The targets then use the library via
@@ -66,10 +66,8 @@ export_variables_to_bazel("spanner_client_version.bzl"
 include(external/googleapis)
 
 # the client library
-add_library(spanner_client
-            ${CMAKE_CURRENT_BINARY_DIR}/version_info.h
-            version.h
-            version.cc)
+add_library(spanner_client ${CMAKE_CURRENT_BINARY_DIR}/version_info.h version.cc
+                           version.h)
 target_link_libraries(spanner_client
                       PUBLIC googleapis-c++::spanner_protos
                              google_cloud_cpp_common
@@ -81,12 +79,12 @@ target_include_directories(spanner_client
 target_compile_options(spanner_client
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 set_target_properties(
-    spanner_client
-    PROPERTIES
-        VERSION
-        ${SPANNER_CLIENT_VERSION_MAJOR}.${SPANNER_CLIENT_VERSION_MINOR}.${SPANNER_CLIENT_VERSION_PATCH}
-        SOVERSION
-        ${SPANNER_CLIENT_VERSION_MAJOR})
+  spanner_client
+  PROPERTIES
+    VERSION
+    ${SPANNER_CLIENT_VERSION_MAJOR}.${SPANNER_CLIENT_VERSION_MINOR}.${SPANNER_CLIENT_VERSION_PATCH}
+    SOVERSION
+    ${SPANNER_CLIENT_VERSION_MAJOR})
 add_library(spanner::client ALIAS spanner_client)
 
 add_executable(spanner_tool spanner_tool.cc)
@@ -100,87 +98,85 @@ include(CreateBazelConfig)
 create_bazel_config(spanner_client YEAR ${SPANNER_CLIENT_COPYRIGHT_YEAR})
 google_cloud_cpp_add_clang_tidy(spanner_client)
 
-if (BUILD_TESTING)
-    # List the unit tests, then setup the targets and dependencies.
-    set(spanner_client_unit_tests spanner_version_test.cc)
+if(BUILD_TESTING)
+  # List the unit tests, then setup the targets and dependencies.
+  set(spanner_client_unit_tests spanner_version_test.cc)
 
-    # Export the list of unit tests so the Bazel BUILD file can pick it up.
-    export_list_to_bazel("spanner_client_unit_tests.bzl"
-                         "spanner_client_unit_tests"
-                         YEAR
-                         ${SPANNER_CLIENT_COPYRIGHT_YEAR})
+  # Export the list of unit tests so the Bazel BUILD file can pick it up.
+  export_list_to_bazel("spanner_client_unit_tests.bzl"
+                       "spanner_client_unit_tests"
+                       YEAR
+                       ${SPANNER_CLIENT_COPYRIGHT_YEAR})
 
-    foreach (fname ${spanner_client_unit_tests})
-        string(REPLACE "/"
-                       "_"
-                       target
-                       ${fname})
-        string(REPLACE ".cc"
-                       ""
-                       target
-                       ${target})
-        add_executable(${target} ${fname})
-        target_link_libraries(${target}
-                              PRIVATE spanner_client
-                                      google_cloud_cpp_testing
-                                      google_cloud_cpp_common
-                                      GTest::gmock_main
-                                      GTest::gmock
-                                      GTest::gtest
-                                      spanner_common_options)
-        if (MSVC)
-            target_compile_options(${target} PRIVATE "/bigobj")
-        endif ()
-        add_test(NAME ${target} COMMAND ${target})
-    endforeach ()
-endif ()
+  foreach(fname ${spanner_client_unit_tests})
+    string(REPLACE "/"
+                   "_"
+                   target
+                   ${fname})
+    string(REPLACE ".cc"
+                   ""
+                   target
+                   ${target})
+    add_executable(${target} ${fname})
+    target_link_libraries(${target}
+                          PRIVATE spanner_client
+                                  google_cloud_cpp_testing
+                                  google_cloud_cpp_common
+                                  GTest::gmock_main
+                                  GTest::gmock
+                                  GTest::gtest
+                                  spanner_common_options)
+    if(MSVC)
+      target_compile_options(${target} PRIVATE "/bigobj")
+    endif()
+    add_test(NAME ${target} COMMAND ${target})
+  endforeach()
+endif()
 
 set(GOOGLE_CLOUD_CPP_SPANNER_ENABLE_INSTALL "ON")
 
-if ("${GOOGLE_CLOUD_CPP_SPANNER_ENABLE_INSTALL}")
-    # Install the libraries and headers in the locations determined by
-    # GNUInstallDirs
-    install(TARGETS spanner_common_options
-            EXPORT spanner-targets
-            RUNTIME DESTINATION bin
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if("${GOOGLE_CLOUD_CPP_SPANNER_ENABLE_INSTALL}")
+  # Install the libraries and headers in the locations determined by
+  # GNUInstallDirs
+  install(TARGETS spanner_common_options
+          EXPORT spanner-targets
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-    # Export the CMake targets to make it easy to create configuration files.
-    install(EXPORT spanner-targets
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/spanner_client")
+  # Export the CMake targets to make it easy to create configuration files.
+  install(EXPORT spanner-targets
+          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/spanner_client")
 
-    install(TARGETS spanner_client
-            EXPORT spanner-targets
-            RUNTIME DESTINATION bin
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    google_cloud_cpp_install_headers(
-        spanner_client include/google/cloud/spanner)
+  install(TARGETS spanner_client
+          EXPORT spanner-targets
+          RUNTIME DESTINATION bin
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  google_cloud_cpp_install_headers(spanner_client include/google/cloud/spanner)
 
-    # Setup global variables used in the following *.in files.
-    set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR ${SPANNER_CLIENT_VERSION_MAJOR})
-    set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MINOR ${SPANNER_CLIENT_VERSION_MINOR})
-    set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_PATCH ${SPANNER_CLIENT_VERSION_PATCH})
-    set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Spanner C++ Client Library")
-    set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-        "Provides C++ APIs to access Google Cloud Spanner.")
-    set(GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_common")
-    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lspanner_client")
+  # Setup global variables used in the following *.in files.
+  set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MAJOR ${SPANNER_CLIENT_VERSION_MAJOR})
+  set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_MINOR ${SPANNER_CLIENT_VERSION_MINOR})
+  set(GOOGLE_CLOUD_CPP_CONFIG_VERSION_PATCH ${SPANNER_CLIENT_VERSION_PATCH})
+  set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Spanner C++ Client Library")
+  set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+      "Provides C++ APIs to access Google Cloud Spanner.")
+  set(GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_common")
+  set(GOOGLE_CLOUD_CPP_PC_LIBS "-lspanner_client")
 
-    # Create and install the pkg-config files.
-    configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
-                   "spanner_client.pc" @ONLY)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/spanner_client.pc" DESTINATION
-                  "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+  # Create and install the pkg-config files.
+  configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config.pc.in"
+                 "spanner_client.pc" @ONLY)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/spanner_client.pc"
+          DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
-    # Create and install the CMake configuration files.
-    configure_file("config.cmake.in" "spanner_client-config.cmake" @ONLY)
-    configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config-version.cmake.in"
-                   "spanner_client-config-version.cmake" @ONLY)
-    install(
-        FILES "${CMAKE_CURRENT_BINARY_DIR}/spanner_client-config.cmake"
-              "${CMAKE_CURRENT_BINARY_DIR}/spanner_client-config-version.cmake"
-              DESTINATION
-              "${CMAKE_INSTALL_LIBDIR}/cmake/spanner_client")
-endif ()
+  # Create and install the CMake configuration files.
+  configure_file("config.cmake.in" "spanner_client-config.cmake" @ONLY)
+  configure_file("${PROJECT_SOURCE_DIR}/google/cloud/config-version.cmake.in"
+                 "spanner_client-config-version.cmake" @ONLY)
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/spanner_client-config.cmake"
+          "${CMAKE_CURRENT_BINARY_DIR}/spanner_client-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/spanner_client")
+endif()


### PR DESCRIPTION
Setup one build on Kokoro, it runs clang-format (same version
as google-cloud-cpp), and clang-tidy. It also reformats CMake files
and BUILD files. I chose a newer version of the CMake formatter because
why not?

This is largely a cut&paste from the similar scripts in google-cloud-cpp, I think refactoring those scripts to a common place would be great, but it will take us a while to figure that out, and I believe we need to start making progress on the client library itself.

This is part of the work for #4, a separate CL inside google will enable this build and then we can close the work item.
