### PR TITLE
Enable integration test

### DIFF
--- a/ci/kokoro/build-docker.sh
+++ b/ci/kokoro/build-docker.sh
@@ -43,7 +43,7 @@ echo "================================================================"
 (cd "${PROJECT_ROOT}" ; ./ci/check-style.sh)
 
 
-readonly BAZEL_BIN="$HOME/bin/bazel"
+readonly BAZEL_BIN="${HOME}/bin/bazel"
 echo "Using Bazel in ${BAZEL_BIN}"
 
 echo "================================================================"
@@ -65,6 +65,29 @@ echo "================================================================"
     --verbose_failures=true \
     --keep_going \
     -- //google/cloud/...:all
+
+echo "================================================================"
+echo "Running the integration tests $(date)"
+echo "================================================================"
+if [[ ${RUN_INTEGRATION_TESTS} != "yes" ]]; then
+  echo "Skipped integration tests"
+else
+  source /c/spanner-integration-tests-config.sh
+  export GOOGLE_APPLICATION_CREDENTIALS=/c/spanner-credentials.json
+  readonly DATABASE_NAME="test-db-${RANDOM}-${RANDOM}"
+  echo "Running create-database"
+  "$("${BAZEL_BIN}" info bazel-bin)/google/cloud/spanner/spanner_tool" \
+      create-database "${PROJECT_ID}" "${SPANNER_INSTANCE_ID}" "${DATABASE_NAME}"
+  echo "Running list-databases [1]"
+  "$("${BAZEL_BIN}" info bazel-bin)/google/cloud/spanner/spanner_tool" \
+      list-databases "${PROJECT_ID}" "${SPANNER_INSTANCE_ID}"
+  echo "Running drop-database"
+  "$("${BAZEL_BIN}" info bazel-bin)/google/cloud/spanner/spanner_tool" \
+      drop-database "${PROJECT_ID}" "${SPANNER_INSTANCE_ID}" "${DATABASE_NAME}"
+  echo "Running list-databases [2]"
+  "$("${BAZEL_BIN}" info bazel-bin)/google/cloud/spanner/spanner_tool" \
+      list-databases "${PROJECT_ID}" "${SPANNER_INSTANCE_ID}"
+fi
 
 echo "================================================================"
 echo "Build finished at $(date)"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -32,6 +32,11 @@ elif [[ "${BUILD_NAME}" = "clang-tidy" ]]; then
   export CMAKE_FLAGS="-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes"
   export CHECK_STYLE=yes
   export GENERATE_DOCS=yes
+elif [[ "${BUILD_NAME}" = "integration" ]]; then
+  export BUILD_TYPE=Debug
+  export CC=gcc
+  export CXX=g++
+  export RUN_INTEGRATION_TESTS=yes
 else
   echo "Unknown BUILD_NAME (${BUILD_NAME}). Fix the Kokoro .cfg file."
   exit 1
@@ -96,12 +101,14 @@ sudo docker run \
      --env BUILD_TYPE="${BUILD_TYPE:-Release}" \
      --env CHECK_STYLE="${CHECK_STYLE:-}" \
      --env GENERATE_DOCS="${GENERATE_DOCS:-}" \
+     --env RUN_INTEGRATION_TESTS="${RUN_INTEGRATION_TESTS:-}" \
      --env CMAKE_FLAGS="${CMAKE_FLAGS:-}" \
      --env TERM="${TERM:-dumb}" \
      --env HOME="/v/${BUILD_HOME}" \
      --env USER="${USER}" \
      --user "${UID:-0}" \
      --volume "${PWD}":/v \
+     --volume "${KOKORO_GFILE_DIR}":/c \
      --workdir /v \
      "${IMAGE}:tip" \
      "/v/ci/kokoro/build-docker.sh"

--- a/ci/kokoro/docker/integration-presubmit.cfg
+++ b/ci/kokoro/docker/integration-presubmit.cfg
@@ -16,7 +16,7 @@
 build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
 timeout_mins: 120
 
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-integration-tests-config.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-credentials.json"
 
 env_vars {

--- a/ci/kokoro/docker/integration-presubmit.cfg
+++ b/ci/kokoro/docker/integration-presubmit.cfg
@@ -1,0 +1,25 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-credentials.json"
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "integration"
+}

--- a/ci/kokoro/docker/integration.cfg
+++ b/ci/kokoro/docker/integration.cfg
@@ -16,7 +16,7 @@
 build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
 timeout_mins: 120
 
-gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-integration-tests-config.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-credentials.json"
 
 env_vars {

--- a/ci/kokoro/docker/integration.cfg
+++ b/ci/kokoro/docker/integration.cfg
@@ -1,0 +1,25 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-configuration.sh"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-credentials.json"
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "integration"
+}

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -144,7 +144,8 @@ int DropDatabase(std::vector<std::string> args) {
 
   spanner::DropDatabaseRequest request;
   google::protobuf::Empty response;
-  request.set_database("projects/" + project + "/instances/" + instance + "/databases/" + database);
+  request.set_database("projects/" + project + "/instances/" + instance +
+                       "/databases/" + database);
 
   grpc::ClientContext context;
   grpc::Status status = stub->DropDatabase(&context, request, &response);

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -108,7 +108,7 @@ int CreateDatabase(std::vector<std::string> args) {
   spanner::CreateDatabaseRequest request;
   google::longrunning::Operation operation;
   request.set_parent("projects/" + project + "/instances/" + instance);
-  request.set_create_statement("CREATE DATABASE " + database);
+  request.set_create_statement("CREATE DATABASE `" + database + "`");
 
   grpc::ClientContext context;
   grpc::Status status = stub->CreateDatabase(&context, request, &operation);
@@ -123,6 +123,39 @@ int CreateDatabase(std::vector<std::string> args) {
   std::cout << operation.DebugString() << "\n";
 
   return WaitForOperation(std::move(channel), std::move(operation));
+}
+
+int DropDatabase(std::vector<std::string> args) {
+  if (args.size() != 3U) {
+    std::cerr << "drop-database <project> <instance> <database>\n";
+    return 1;
+  }
+  auto const& project = args[0];
+  auto const& instance = args[1];
+  auto const& database = args[2];
+
+  namespace spanner = google::spanner::admin::database::v1;
+
+  std::shared_ptr<grpc::ChannelCredentials> cred =
+      grpc::GoogleDefaultCredentials();
+  std::shared_ptr<grpc::Channel> channel =
+      grpc::CreateChannel("spanner.googleapis.com", cred);
+  auto stub = spanner::DatabaseAdmin::NewStub(channel);
+
+  spanner::DropDatabaseRequest request;
+  google::protobuf::Empty response;
+  request.set_database("projects/" + project + "/instances/" + instance + "/databases/" + database);
+
+  grpc::ClientContext context;
+  grpc::Status status = stub->DropDatabase(&context, request, &response);
+
+  if (!status.ok()) {
+    std::cerr << "FAILED: " << status.error_code() << ": "
+              << status.error_message() << "\n";
+    return 1;
+  }
+
+  return 0;
 }
 
 int CreateTimeseriesTable(std::vector<std::string> args) {
@@ -354,6 +387,7 @@ int main(int argc, char* argv[]) {
   std::map<std::string, CommandType> commands = {
       {"list-databases", &ListDatabases},
       {"create-database", &CreateDatabase},
+      {"drop-database", &DropDatabase},
       {"create-timeseries-table", &CreateTimeseriesTable},
       {"populate-timeseries", &PopulateTimeseriesTable},
   };


### PR DESCRIPTION
Change ci/kokoro scripts to (optionally) run integration tests.
Add a skeleton integration tests using the spanner tool.
