### PR TITLE
Use /dev/shm as default KOKORO_GFILE_DIR

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -116,7 +116,7 @@ sudo docker run \
      --env USER="${USER}" \
      --user "${UID:-0}" \
      --volume "${PWD}":/v \
-     --volume "${KOKORO_GFILE_DIR}":/c \
+     --volume "${KOKORO_GFILE_DIR:-/dev/shm}":/c \
      --workdir /v \
      "${IMAGE}:tip" \
      "/v/ci/kokoro/build-docker.sh"


### PR DESCRIPTION
This keeps the script from failing when run locally, and
KOKORO_GFILE_DIR is not important in that case.