### PR TITLE
Implements spanner::Value skeleton with support for BOOL, INT64, FLOAT64, and STRING

### DIFF
--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -17,9 +17,11 @@
 """Automatically generated source lists for spanner_client - DO NOT EDIT."""
 
 spanner_client_hdrs = [
+    "value.h",
     "version.h",
 ]
 
 spanner_client_srcs = [
+    "value.cc",
     "version.cc",
 ]

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -17,5 +17,6 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 spanner_client_unit_tests = [
+    "value_test.cc",
     "spanner_version_test.cc",
 ]

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -36,6 +36,7 @@ Status CheckValidity(Value const& v) {
 }
 
 }  // namespace
+
 Value::Value(bool v) {
   type_.set_code(google::spanner::v1::TypeCode::BOOL);
   value_.set_bool_value(v);

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -131,8 +131,6 @@ std::int64_t Value::GetValue(std::int64_t) const {
   std::size_t processed = 0;
   long long x = std::stoll(s, &processed, 10);
   if (processed != s.size()) {
-    // This should never happen, because we only parse strings that we created
-    // using std::to_string(), but it's good to be careful anyway.
     std::string const err = "Failed to parse number from string: \"" + s + "\"";
     google::cloud::Terminate(err.c_str());
   }

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/value.h"
+#include <cmath>
 #include <ios>
 #include <sstream>
-#include <cmath>
 
 namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-
 Value::Value(bool v) {
   type_.set_code(google::spanner::v1::TypeCode::BOOL);
   value_.set_bool_value(v);

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -1,0 +1,136 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/value.h"
+#include <ios>
+#include <sstream>
+#include <cmath>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+Value::Value(bool v) {
+  type_.set_code(google::spanner::v1::TypeCode::BOOL);
+  value_.set_bool_value(v);
+}
+
+Value::Value(std::int64_t v) {
+  type_.set_code(google::spanner::v1::TypeCode::INT64);
+  std::stringstream ss;
+  ss << std::dec << v;
+  value_.set_string_value(ss.str());
+}
+
+Value::Value(double v) {
+  type_.set_code(google::spanner::v1::TypeCode::FLOAT64);
+  if (std::isnan(v)) {
+    value_.set_string_value("NaN");
+  } else if (std::isinf(v)) {
+    std::string const s = v < 0 ? "-Infinity" : "Infinity";
+    value_.set_string_value(s);
+  } else {
+    value_.set_number_value(v);
+  }
+}
+
+Value::Value(std::string v) {
+  type_.set_code(google::spanner::v1::TypeCode::STRING);
+  value_.set_string_value(v);
+}
+
+bool operator==(Value a, Value b) {
+  auto const& at = a.type_;
+  auto const& bt = b.type_;
+  auto const& av = a.value_;
+  auto const& bv = b.value_;
+  if (at.code() != bt.code() || av.kind_case() != bv.kind_case()) return false;
+  switch (av.kind_case()) {
+    case google::protobuf::Value::kNullValue:
+      return true;
+    case google::protobuf::Value::kNumberValue:
+      return av.number_value() == bv.number_value();
+    case google::protobuf::Value::kStringValue:
+      return av.string_value() == bv.string_value();
+    default:
+      return false;
+  }
+}
+
+//
+// Value::is_null
+//
+
+bool Value::is_null() const {
+  return value_.kind_case() == google::protobuf::Value::kNullValue;
+}
+
+//
+// Value::IsType
+//
+
+bool Value::IsType(bool) const {
+  return type_.code() == google::spanner::v1::TypeCode::BOOL;
+}
+
+bool Value::IsType(std::int64_t) const {
+  return type_.code() == google::spanner::v1::TypeCode::INT64;
+}
+
+bool Value::IsType(double) const {
+  return type_.code() == google::spanner::v1::TypeCode::FLOAT64;
+}
+
+bool Value::IsType(std::string) const {
+  return type_.code() == google::spanner::v1::TypeCode::STRING;
+}
+
+//
+// Value::GetValue
+//
+
+bool Value::GetValue(bool) const {
+  if (is_null()) return {};
+  return value_.bool_value();
+}
+
+std::int64_t Value::GetValue(std::int64_t) const {
+  if (is_null()) return {};
+  std::int64_t n;
+  std::istringstream(value_.string_value()) >> std::dec >> n;
+  return n;
+}
+
+double Value::GetValue(double) const {
+  if (is_null()) return {};
+  if (value_.kind_case() == google::protobuf::Value::kStringValue) {
+    std::string const& s = value_.string_value();
+    auto const inf = std::numeric_limits<double>::infinity();
+    if (s == "-Infinity") return -inf;
+    if (s == "Infinity") return inf;
+    return std::nan(s.c_str());
+  }
+  return value_.number_value();
+}
+
+std::string Value::GetValue(std::string) const {
+  if (is_null()) return {};
+  return value_.string_value();
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -1,0 +1,132 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H_
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/optional.h"
+#include <google/protobuf/struct.pb.h>
+#include <google/spanner/v1/type.pb.h>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+/**
+ * This class represents a type-safe, nullable Spanner value. The available
+ * Spanner types are shown at https://cloud.google.com/spanner/docs/data-types,
+ * and the following table shows how they map to C++ types.
+ *
+ *   Spanner Type | C++ Type
+ *   -----------------------
+ *   BOOL         | bool
+ *   INT64        | std::int64_t
+ *   FLOAT64      | double
+ *   STRING       | std::string
+ *
+ * This is a regular C++ value type with support for copy, move, equality, etc,
+ * but there is no default constructor. This is a type-erased class so it can
+ * be stored in standard C++ containers requiring homogeneity. Callers may
+ * create instances by passing any of the supported values (shown in the table
+ * above) to the constructor. To consruct a "null" value of a particular type,
+ * pass a disengaged google::cloud::optional<T> to the Value constructor.
+ *
+ * Example with a non-null value:
+ *
+ *   std::string msg = "hello";
+ *   spanner::Value v(msg);
+ *   assert(v.is<std::string>());
+ *   assert(!v.is_null());
+ *   std::string copy = v.get<std::string>();
+ *   assert(msg == copy);
+ *
+ * Example with a null:
+ *
+ *   spanner::Value v(google::cloud::optional<std::int64_t>{});
+ *   assert(v.is<std::int64_t>());
+ *   assert(v.is_null());
+ */
+class Value {
+ public:
+  Value() = delete;
+
+  // Copy and move.
+  Value(Value const&) = default;
+  Value(Value&&) = default;
+  Value& operator=(Value const&) = default;
+  Value& operator=(Value&&) = default;
+
+  // Value constructors.
+  explicit Value(bool v);
+  explicit Value(std::int64_t v);
+  explicit Value(double v);
+  explicit Value(std::string v);
+  template <typename T>
+  explicit Value(google::cloud::optional<T> opt) {
+    if (opt) {
+      *this = Value(*opt);
+    } else {
+      *this = Value(T{});
+      value_.set_null_value(google::protobuf::NullValue::NULL_VALUE);
+    }
+  }
+
+  bool is_null() const;
+
+  template <typename T>
+  bool is() const {
+    return IsType(T{});
+  }
+
+  template <typename T>
+  T get() const {
+    return GetValue(T{});
+  }
+
+  friend bool operator==(Value a, Value b);
+  friend bool operator!=(Value a, Value b) { return !(a == b); }
+
+ private:
+  bool IsType(bool) const;
+  bool IsType(std::int64_t) const;
+  bool IsType(double) const;
+  bool IsType(std::string) const;
+  template <typename T>
+  bool IsType(google::cloud::optional<T> opt) const {
+    return IsType(T{});
+  }
+
+  bool GetValue(bool) const;
+  std::int64_t GetValue(std::int64_t) const;
+  double GetValue(double) const;
+  std::string GetValue(std::string) const;
+  template <typename T>
+  google::cloud::optional<T> GetValue(google::cloud::optional<T> opt) const {
+    if (!is_null()) return GetValue(T{});
+    return {};
+  }
+
+  google::spanner::v1::Type type_;
+  google::protobuf::Value value_;
+};
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H_

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -27,19 +27,23 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 /**
- * This class represents a type-safe, nullable Spanner value. It's conceptually
- * similar to a `std::any` except the only allowed types are those supported by
- * Spanner, and a "null" value (similar to a `std::any` without a value) still
- * has an associated type that can be queried with `Value::is<T>()`. The
- * supported types are shown in the following table along with how they map to
- * the Spanner types (https://cloud.google.com/spanner/docs/data-types):
+ * The Value class represents a type-safe, nullable Spanner value.
  *
+ * It is conceptually similar to a `std::any` except the only allowed types are
+ * those supported by Spanner, and a "null" value (similar to a `std::any`
+ * without a value) still has an associated type that can be queried with
+ * `Value::is<T>()`. The supported types are shown in the following table along
+ * with how they map to the Spanner types
+ * (https://cloud.google.com/spanner/docs/data-types):
+ *
+ * @code
  *   Spanner Type | C++ Type
  *   -----------------------
  *   BOOL         | bool
  *   INT64        | std::int64_t
  *   FLOAT64      | double
  *   STRING       | std::string
+ * @endcode
  *
  * This is a regular C++ value type with support for copy, move, equality, etc,
  * but there is no default constructor because there is no default type.
@@ -52,18 +56,22 @@ inline namespace SPANNER_CLIENT_NS {
  *
  * Example with a non-null value:
  *
+ * @code
  *   std::string msg = "hello";
  *   spanner::Value v(msg);
  *   assert(v.is<std::string>());
  *   assert(!v.is_null());
  *   std::string copy = v.get<std::string>();
  *   assert(msg == copy);
+ * @endcode
  *
  * Example with a null:
  *
+ * @code
  *   spanner::Value v(google::cloud::optional<std::int64_t>{});
  *   assert(v.is<std::int64_t>());
  *   assert(v.is_null());
+ * @endcode
  */
 class Value {
  public:
@@ -95,44 +103,53 @@ class Value {
   friend bool operator==(Value a, Value b);
   friend bool operator!=(Value a, Value b) { return !(a == b); }
 
-  // Returns true if there is no contained value.
+  /**
+   * Returns true if there is no contained value.
+   */
   bool is_null() const;
 
-  // Returns true if the contained value is of the specified type `T`. All
-  // Value instances have some type, even null values. Since all Values are
-  // potentially nullable, `v.is<T>()` will return true if and only if
-  // `v.is<google::cloud::optional<T>>()` returns true.
-  //
-  // Example:
-  //
-  //   spanner::Value v{true};
-  //   assert(v.is<bool>());
-  //   assert(v.is<google::cloud::optional<bool>>());
-  //
+  /**
+   * Returns true if the contained value is of the specified type `T`.
+   *
+   * All Value instances have some type, even null values. Since all Values are
+   * potentially nullable, `v.is<T>()` will return true if and only if
+   * `v.is<google::cloud::optional<T>>()` returns true.
+   *
+   * Example:
+   *
+   * @code
+   *   spanner::Value v{true};
+   *   assert(v.is<bool>());
+   *   assert(v.is<google::cloud::optional<bool>>());
+   * @endcode
+   */
   template <typename T>
   bool is() const {
     return IsType(T{});
   }
 
-  // Returns the contained value if the specified type `T` matches the Value's
-  // type and if the contained value is not null. Otherwise, a default
-  // constructed `T` is returned.
-  //
-  // If the requested type is specified as `google::cloud::optional<T>`, then
-  // the returned optional will contain the value if it was not null,
-  // otherwise, the optional will contain no value.
-  //
-  // Example:
-  //
-  //   spanner::Value v{true};
-  //   assert(true == v.get<bool>());
-  //   assert(true == *v.get<google::cloud::optional<bool>>());
-  //
-  //   // Now using a "null" std::int64_t
-  //   v = spanner::Value(google::cloud::optional<std::int64_t>{});
-  //   assert(v.is_null());
-  //   assert(!v.get<google::cloud::optional<std::int64_t>());
-  //
+  /**
+   * Returns the contained value if the specified type `T` matches the Value's
+   * type and if the contained value is not null. Otherwise, a default
+   * constructed `T` is returned.
+   *
+   * If the requested type is specified as `google::cloud::optional<T>`, then
+   * the returned optional will contain the value if it was not null,
+   * otherwise, the optional will contain no value.
+   *
+   * Example:
+   *
+   * @code
+   *   spanner::Value v{true};
+   *   assert(true == v.get<bool>());
+   *   assert(true == *v.get<google::cloud::optional<bool>>());
+   *
+   *   // Now using a "null" std::int64_t
+   *   v = spanner::Value(google::cloud::optional<std::int64_t>{});
+   *   assert(v.is_null());
+   *   assert(!v.get<google::cloud::optional<std::int64_t>());
+   * @endcode
+   */
   template <typename T>
   T get() const {
     return GetValue(T{});
@@ -144,7 +161,7 @@ class Value {
   friend std::ostream& operator<<(std::ostream& os, Value v);
 
  private:
-  // Tag-dispatched function overloads. The arugment type is important, the
+  // Tag-dispatched function overloads. The argument type is important, the
   // value is ignored.
   bool IsType(bool) const;
   bool IsType(std::int64_t) const;
@@ -155,7 +172,7 @@ class Value {
     return IsType(T{});
   }
 
-  // Tag-dispatched function overloads. The arugment type is important, the
+  // Tag-dispatched function overloads. The argument type is important, the
   // value is ignored.
   bool GetValue(bool) const;
   std::int64_t GetValue(std::int64_t) const;

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -15,8 +15,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H_
 
-#include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
+#include "google/cloud/spanner/version.h"
 #include <google/protobuf/struct.pb.h>
 #include <google/spanner/v1/type.pb.h>
 #include <string>
@@ -25,7 +25,6 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-
 /**
  * This class represents a type-safe, nullable Spanner value. The available
  * Spanner types are shown at https://cloud.google.com/spanner/docs/data-types,

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -94,7 +94,6 @@ class Value {
 
   friend bool operator==(Value a, Value b);
   friend bool operator!=(Value a, Value b) { return !(a == b); }
-  friend std::ostream& operator<<(std::ostream& os, Value v);
 
   // Returns true if there is no contained value.
   bool is_null() const;
@@ -138,6 +137,11 @@ class Value {
   T get() const {
     return GetValue(T{});
   }
+
+  // Output the contained value and type. Intended for debugging and human
+  // consumption only, not machine consumption as the output format may change
+  // without notice.
+  friend std::ostream& operator<<(std::ostream& os, Value v);
 
  private:
   // Tag-dispatched function overloads. The arugment type is important, the

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -36,14 +36,12 @@ inline namespace SPANNER_CLIENT_NS {
  * with how they map to the Spanner types
  * (https://cloud.google.com/spanner/docs/data-types):
  *
- * @code
- *   Spanner Type | C++ Type
- *   -----------------------
- *   BOOL         | bool
- *   INT64        | std::int64_t
- *   FLOAT64      | double
- *   STRING       | std::string
- * @endcode
+ *     Spanner Type | C++ Type
+ *     -----------------------
+ *     BOOL         | bool
+ *     INT64        | std::int64_t
+ *     FLOAT64      | double
+ *     STRING       | std::string
  *
  * This is a regular C++ value type with support for copy, move, equality, etc,
  * but there is no default constructor because there is no default type.
@@ -56,40 +54,43 @@ inline namespace SPANNER_CLIENT_NS {
  *
  * Example with a non-null value:
  *
- * @code
- *   std::string msg = "hello";
- *   spanner::Value v(msg);
- *   assert(v.is<std::string>());
- *   assert(!v.is_null());
- *   std::string copy = v.get<std::string>();
- *   assert(msg == copy);
- * @endcode
+ *     std::string msg = "hello";
+ *     spanner::Value v(msg);
+ *     assert(v.is<std::string>());
+ *     assert(!v.is_null());
+ *     std::string copy = v.get<std::string>();
+ *     assert(msg == copy);
  *
  * Example with a null:
  *
- * @code
- *   spanner::Value v(google::cloud::optional<std::int64_t>{});
- *   assert(v.is<std::int64_t>());
- *   assert(v.is_null());
- * @endcode
+ *     spanner::Value v(google::cloud::optional<std::int64_t>{});
+ *     assert(v.is<std::int64_t>());
+ *     assert(v.is_null());
  */
 class Value {
  public:
   Value() = delete;
 
-  // Copy and move.
+  /// Copy and move.
   Value(Value const&) = default;
   Value(Value&&) = default;
   Value& operator=(Value const&) = default;
   Value& operator=(Value&&) = default;
 
-  // Constructs a non-null instance with the specified value and type.
+  /// Constructs a non-null instance with the specified value and type.
   explicit Value(bool v);
   explicit Value(std::int64_t v);
   explicit Value(double v);
   explicit Value(std::string v);
 
-  // Constructs a possibly null instance from the optional value and type.
+  /**
+   * Constructs a possibly null instance from the optional value and type.
+   *
+   * If the given optional has no value, then a Value will be created whose
+   * `is_null()` method will return true. If the given optional contains a
+   * value, then `is_null()` will be false, and it is exactly the same as if
+   * the value were specified directly without the optional.
+   */
   template <typename T>
   explicit Value(google::cloud::optional<T> opt) {
     if (opt) {
@@ -103,9 +104,7 @@ class Value {
   friend bool operator==(Value a, Value b);
   friend bool operator!=(Value a, Value b) { return !(a == b); }
 
-  /**
-   * Returns true if there is no contained value.
-   */
+  /// Returns true if there is no contained value.
   bool is_null() const;
 
   /**
@@ -117,11 +116,9 @@ class Value {
    *
    * Example:
    *
-   * @code
-   *   spanner::Value v{true};
-   *   assert(v.is<bool>());
-   *   assert(v.is<google::cloud::optional<bool>>());
-   * @endcode
+   *     spanner::Value v{true};
+   *     assert(v.is<bool>());
+   *     assert(v.is<google::cloud::optional<bool>>());
    */
   template <typename T>
   bool is() const {
@@ -139,25 +136,26 @@ class Value {
    *
    * Example:
    *
-   * @code
-   *   spanner::Value v{true};
-   *   assert(true == v.get<bool>());
-   *   assert(true == *v.get<google::cloud::optional<bool>>());
+   *     spanner::Value v{true};
+   *     assert(true == v.get<bool>());
+   *     assert(true == *v.get<google::cloud::optional<bool>>());
    *
-   *   // Now using a "null" std::int64_t
-   *   v = spanner::Value(google::cloud::optional<std::int64_t>{});
-   *   assert(v.is_null());
-   *   assert(!v.get<google::cloud::optional<std::int64_t>());
-   * @endcode
+   *     // Now using a "null" std::int64_t
+   *     v = spanner::Value(google::cloud::optional<std::int64_t>{});
+   *     assert(v.is_null());
+   *     assert(!v.get<google::cloud::optional<std::int64_t>());
    */
   template <typename T>
   T get() const {
     return GetValue(T{});
   }
 
-  // Output the contained value and type. Intended for debugging and human
-  // consumption only, not machine consumption as the output format may change
-  // without notice.
+  /**
+   * Output the contained value and type formatted as a string.
+   *
+   * This is intended for debugging and human consumption only, not machine
+   * consumption as the output format may change without notice.
+   */
   friend std::ostream& operator<<(std::ostream& os, Value v);
 
  private:

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -90,8 +90,7 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(optional<double>{});
   }
 
-  for (auto x :
-       std::vector<std::string>{"", "f", "foo", "123456789012345678"}) {
+  for (auto x : std::vector<std::string>{"", "f", "foo", "12345678901234567"}) {
     SCOPED_TRACE("Testing: std::string " + std::string(x));
     TestBasicSemantics(x);
     TestBasicSemantics(optional<std::string>{x});

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -15,16 +15,15 @@
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/optional.h"
 #include <gmock/gmock.h>
+#include <cmath>
 #include <limits>
 #include <string>
 #include <vector>
-#include <cmath>
 
 namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-
 using google::cloud::optional;
 
 // A unit test that shows a brief demo of using the spanner::Value API.

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -1,0 +1,139 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/value.h"
+#include "google/cloud/optional.h"
+#include <gmock/gmock.h>
+#include <limits>
+#include <string>
+#include <vector>
+#include <cmath>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+using google::cloud::optional;
+
+// A unit test that shows a brief demo of using the spanner::Value API.
+TEST(Value, Demo) {
+  std::string s = "hello";
+  Value v(s);
+  EXPECT_TRUE(v.is<std::string>());
+  EXPECT_FALSE(v.is_null());
+  EXPECT_EQ(s, v.get<std::string>());
+  EXPECT_EQ(s, *v.get<optional<std::string>>());
+
+  // The value and type stored in `v` can be changed.
+  std::int64_t n = 42;
+  v = Value(n);
+  EXPECT_TRUE(v.is<std::int64_t>());
+  EXPECT_FALSE(v.is_null());
+  EXPECT_EQ(n, v.get<std::int64_t>());
+  EXPECT_EQ(n, *v.get<optional<std::int64_t>>());
+
+  // Sets a boolean "null" value.
+  v = Value(optional<bool>{});
+  EXPECT_TRUE(v.is<bool>());
+  EXPECT_TRUE(v.is<optional<bool>>());
+  EXPECT_TRUE(v.is_null());
+  EXPECT_EQ(bool{}, v.get<bool>());
+  EXPECT_EQ(optional<bool>{}, v.get<optional<bool>>());
+  optional<bool> const null_bool = v.get<optional<bool>>();
+  EXPECT_FALSE(null_bool);
+}
+
+TEST(Value, RegularTypeSemantics) {
+  Value v1(std::int64_t{123});
+  EXPECT_EQ(123, v1.get<std::int64_t>());
+
+  Value v2 = v1;
+  EXPECT_EQ(v1, v2);
+  EXPECT_EQ(123, v2.get<std::int64_t>());
+
+  Value v3(std::string("Hello"));
+  EXPECT_NE(v1, v3);
+
+  Value v4 = std::move(v3);
+  EXPECT_EQ("Hello", v4.get<std::string>());
+}
+
+template <typename T>
+void TestNonNullSemantics(T init) {
+  Value const v{init};
+  EXPECT_TRUE(v.is<T>());
+  EXPECT_EQ(init, v.get<T>());
+  EXPECT_EQ(init, *v.get<optional<T>>());
+}
+
+template <typename T>
+void TestNullSemantics() {
+  optional<T> const null;
+  Value v{null};
+  EXPECT_TRUE(v.is<T>());
+  EXPECT_TRUE(v.is_null());
+  EXPECT_EQ(T{}, v.get<T>());  // Defined to return T{} even if null
+  optional<T> const null_value = v.get<optional<T>>();
+  EXPECT_FALSE(null_value);
+}
+
+TEST(Value, Semantics) {
+  TestNullSemantics<bool>();
+  for (auto x : {false, true}) {
+    SCOPED_TRACE("Testing: bool " + std::to_string(x));
+    TestNonNullSemantics<bool>(x);
+    TestNonNullSemantics<optional<bool>>(x);
+  }
+
+  TestNullSemantics<std::int64_t>();
+  auto const min64 = std::numeric_limits<std::int64_t>::min();
+  auto const max64 = std::numeric_limits<std::int64_t>::max();
+  for (auto x : std::vector<std::int64_t>{min64, -1, 0, 1, max64}) {
+    SCOPED_TRACE("Testing: std::int64_t " + std::to_string(x));
+    TestNonNullSemantics<std::int64_t>(x);
+    TestNonNullSemantics<optional<std::int64_t>>(x);
+  }
+
+  // Note: We skip testing the NaN case here because NaN always compares not
+  // equal, even with itself. So NaN is handled in a separate test.
+  TestNullSemantics<double>();
+  auto const inf = std::numeric_limits<double>::infinity();
+  for (auto x : {-inf, -1.0, -0.5, 0.0, 0.5, 1.0, inf}) {
+    SCOPED_TRACE("Testing: double " + std::to_string(x));
+    TestNonNullSemantics<double>(x);
+    TestNonNullSemantics<optional<double>>(x);
+  }
+
+  TestNullSemantics<std::string>();
+  for (auto x : {"", "f", "foo", "12345678901234567890"}) {
+    SCOPED_TRACE("Testing: std::string " + std::string(x));
+    TestNonNullSemantics<std::string>(x);
+    TestNonNullSemantics<optional<std::string>>(x);
+  }
+}
+
+TEST(Value, DoubleNaN) {
+  double const d = std::nan("NaN");
+  Value v{d};
+  EXPECT_TRUE(v.is<double>());
+  EXPECT_FALSE(v.is_null());
+  EXPECT_TRUE(std::isnan(v.get<double>()));
+  EXPECT_TRUE(std::isnan(*v.get<optional<double>>()));
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/value.h"
-#include "google/cloud/optional.h"
 #include <gmock/gmock.h>
 #include <cmath>
 #include <limits>
@@ -24,51 +23,34 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-namespace {
-
-using google::cloud::optional;
-
-// When testing the basic semantics of a Value object, the result of
-// v.is_null() depends on whether the Value was constructed with an empty
-// optional<T> or not. Factoring this check for an an empty optional out allows
-// us to reuse the same TestBasicSemantics<T>() function template with and
-// without nulls.
-template <typename T>
-bool IsEmptyOptional(T) {
-  return false;
-}
-template <typename T>
-bool IsEmptyOptional(optional<T> opt) {
-  return !opt.has_value();
-}
-
-}  // namespace
-
 template <typename T>
 void TestBasicSemantics(T init) {
   Value const v{init};
 
-  EXPECT_EQ(IsEmptyOptional(init), v.is_null()) << v;
-
   EXPECT_TRUE(v.is<T>()) << v;
-  EXPECT_TRUE(v.is<optional<T>>()) << v;
+  EXPECT_FALSE(v.is_null()) << v;
 
-  EXPECT_EQ(init, v.get<T>()) << v;
-  EXPECT_EQ(init, *v.get<optional<T>>()) << v;
+  EXPECT_EQ(init, *v.get<T>()) << v;
+  EXPECT_EQ(init, static_cast<T>(v));
 
   Value const copy = v;
   EXPECT_EQ(copy, v);
 
   Value const moved = std::move(copy);
   EXPECT_EQ(moved, v);
+
+  // Tests a null Value of type `T`.
+  Value const null = Value::MakeNull<T>();
+  EXPECT_TRUE(null.is<T>());
+  EXPECT_TRUE(null.is_null());
+  EXPECT_FALSE(null.get<T>().ok());
+  EXPECT_NE(null, v);
 }
 
 TEST(Value, BasicSemantics) {
   for (auto x : {false, true}) {
     SCOPED_TRACE("Testing: bool " + std::to_string(x));
     TestBasicSemantics(x);
-    TestBasicSemantics(optional<bool>{x});
-    TestBasicSemantics(optional<bool>{});
   }
 
   auto const min64 = std::numeric_limits<std::int64_t>::min();
@@ -76,8 +58,6 @@ TEST(Value, BasicSemantics) {
   for (auto x : std::vector<std::int64_t>{min64, -1, 0, 1, max64}) {
     SCOPED_TRACE("Testing: std::int64_t " + std::to_string(x));
     TestBasicSemantics(x);
-    TestBasicSemantics(optional<std::int64_t>{x});
-    TestBasicSemantics(optional<std::int64_t>{});
   }
 
   // Note: We skip testing the NaN case here because NaN always compares not
@@ -86,15 +66,11 @@ TEST(Value, BasicSemantics) {
   for (auto x : {-inf, -1.0, -0.5, 0.0, 0.5, 1.0, inf}) {
     SCOPED_TRACE("Testing: double " + std::to_string(x));
     TestBasicSemantics(x);
-    TestBasicSemantics(optional<double>{x});
-    TestBasicSemantics(optional<double>{});
   }
 
   for (auto x : std::vector<std::string>{"", "f", "foo", "12345678901234567"}) {
     SCOPED_TRACE("Testing: std::string " + std::string(x));
     TestBasicSemantics(x);
-    TestBasicSemantics(optional<std::string>{x});
-    TestBasicSemantics(optional<std::string>{});
   }
 }
 
@@ -103,13 +79,54 @@ TEST(Value, DoubleNaN) {
   Value v{nan};
   EXPECT_TRUE(v.is<double>());
   EXPECT_FALSE(v.is_null());
-  EXPECT_TRUE(std::isnan(v.get<double>()));
-  EXPECT_TRUE(std::isnan(*v.get<optional<double>>()));
+  EXPECT_TRUE(std::isnan(*v.get<double>()));
 
   // Since IEEE 754 defines that nan is not equal to itself, then a Value with
   // NaN should not be equal to itself.
   EXPECT_NE(nan, nan);
   EXPECT_NE(v, v);
+}
+
+TEST(Value, MixingTypes) {
+  using A = bool;
+  using B = std::int64_t;
+
+  Value a(A{});
+  EXPECT_FALSE(a.is_null());
+  EXPECT_TRUE(a.is<A>());
+  EXPECT_TRUE(a.get<A>().ok());
+  EXPECT_FALSE(a.is<B>());
+  EXPECT_FALSE(a.get<B>().ok());
+
+  Value null_a = Value::MakeNull<A>();
+  EXPECT_TRUE(null_a.is_null());
+  EXPECT_TRUE(null_a.is<A>());
+  EXPECT_FALSE(null_a.get<A>().ok());
+  EXPECT_FALSE(null_a.is<B>());
+  EXPECT_FALSE(null_a.get<B>().ok());
+
+  EXPECT_NE(null_a, a);
+
+  Value b(B{});
+  EXPECT_FALSE(b.is_null());
+  EXPECT_TRUE(b.is<B>());
+  EXPECT_TRUE(b.get<B>().ok());
+  EXPECT_FALSE(b.is<A>());
+  EXPECT_FALSE(b.get<A>().ok());
+
+  EXPECT_NE(b, a);
+  EXPECT_NE(b, null_a);
+
+  Value null_b = Value::MakeNull<B>();
+  EXPECT_TRUE(null_b.is_null());
+  EXPECT_TRUE(null_b.is<B>());
+  EXPECT_FALSE(null_b.get<B>().ok());
+  EXPECT_FALSE(null_b.is<A>());
+  EXPECT_FALSE(null_b.get<A>().ok());
+
+  EXPECT_NE(null_b, b);
+  EXPECT_NE(null_b, null_a);
+  EXPECT_NE(null_b, a);
 }
 
 }  // namespace SPANNER_CLIENT_NS


### PR DESCRIPTION
closes #17 

This is just a skeleton of the class. It does not fully support all Spanner value types. Specifically it's missing

TIMESTAMP, DATE, BYTES, ARRAY, and STRUCT.

I will file separate GH issues to implement each of those separately.

(Note, I'm not actually working on a Saturday. I implemented this yesterday, but I wanted to trigger all the CI builds to see if this broke stuff.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/38)
<!-- Reviewable:end -->
