### PR TITLE
Install Bazel as part of the Docker image.

### DIFF
--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -30,6 +30,10 @@ wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}.sha256"
 sha256sum --check "${SCRIPT_NAME}.sha256"
 
 chmod +x "${SCRIPT_NAME}"
-"./${SCRIPT_NAME}" --user
+if [[ "${USER:-}" = "root" ]] || [[ "${USER+x}" = "" ]]; then
+  "./${SCRIPT_NAME}"
+else
+  "./${SCRIPT_NAME}" --user
+fi
 
 rm -f "${SCRIPT_NAME}" "${SCRIPT_NAME}.sha256"

--- a/ci/kokoro/Dockerfile.ubuntu
+++ b/ci/kokoro/Dockerfile.ubuntu
@@ -53,3 +53,7 @@ RUN chmod 755 /usr/bin/buildifier
 # because some third party changed something.
 RUN pip install --upgrade pip
 RUN pip install numpy cmake_format==0.5.1
+
+WORKDIR /var/tmp/ci
+COPY install-bazel.sh /var/tmp/ci
+RUN /var/tmp/ci/install-bazel.sh

--- a/ci/kokoro/build-docker.sh
+++ b/ci/kokoro/build-docker.sh
@@ -33,17 +33,11 @@ echo "${COLOR_YELLOW}Starting docker build $(date) with ${NCPU} cores${COLOR_RES
 echo
 
 echo "================================================================"
-echo "Update or Install Bazel $(date)."
-echo "================================================================"
-(cd /var/tmp ; "${PROJECT_ROOT}/ci/install-bazel.sh")
-
-echo "================================================================"
-echo "Verify formattting $(date)"
-echo "================================================================"
+echo "Verify formatting $(date)"
 (cd "${PROJECT_ROOT}" ; ./ci/check-style.sh)
+echo "================================================================"
 
-
-readonly BAZEL_BIN="${HOME}/bin/bazel"
+readonly BAZEL_BIN="/usr/local/bin/bazel"
 echo "Using Bazel in ${BAZEL_BIN}"
 
 bazel_args=(--test_output=errors --verbose_failures=true --keep_going)


### PR DESCRIPTION
This makes local builds faster, because otherwise Bazel is installed
each time you run `BUILD_NAME=foo ./ci/kokoro/docker/build.sh`. It makes
little or no difference on the actual Kokoro builds.