### PR TITLE
Simplify WORKSPACE file.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,113 +14,18 @@
 
 workspace(name = "com_github_googleapis_google_cloud_cpp_spanner")
 
-###
-### Begin googleapis/WORKSPACE
-###
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-##############################################################################
-# Java
-##############################################################################
-
-#
-# gapic-generator
-#
-http_archive(
-    name = "com_google_api_codegen",
-    strip_prefix = "gapic-generator-8e930b79e846b9d4876462be9dc4c1dbc04e2903",
-    urls = ["https://github.com/googleapis/gapic-generator/archive/8e930b79e846b9d4876462be9dc4c1dbc04e2903.zip"],
-)
-
-#
-# java_gapic artifacts runtime dependencies (gax-java)
-#
-load("@com_google_api_codegen//rules_gapic/java:java_gapic_repositories.bzl", "java_gapic_repositories")
-
-java_gapic_repositories()
-
-load("@com_google_api_gax_java//:repository_rules.bzl", "com_google_api_gax_java_properties")
-
-com_google_api_gax_java_properties(
-    name = "com_google_api_gax_java_properties",
-    file = "@com_google_api_gax_java//:dependencies.properties",
-)
-
-load("@com_google_api_gax_java//:repositories.bzl", "com_google_api_gax_java_repositories")
-
-com_google_api_gax_java_repositories()
-
-#
-# gapic-generator transitive
-# (goes AFTER java-gax, since both java gax and gapic-generator are written in java and may conflict)
-#
-load("@com_google_api_codegen//:repository_rules.bzl", "com_google_api_codegen_properties")
-
-com_google_api_codegen_properties(
-    name = "com_google_api_codegen_properties",
-    file = "@com_google_api_codegen//:dependencies.properties",
-)
-
-load("@com_google_api_codegen//:repositories.bzl", "com_google_api_codegen_repositories")
-
-com_google_api_codegen_repositories()
-
-#
-# protoc-java-resource-names-plugin (loaded in com_google_api_codegen_repositories())
-# (required to support resource names feature in gapic generator)
-#
-load(
-    "@com_google_protoc_java_resource_names_plugin//:repositories.bzl",
-    "com_google_protoc_java_resource_names_plugin_repositories",
-)
-
-com_google_protoc_java_resource_names_plugin_repositories(omit_com_google_protobuf = True)
-
-##############################################################################
-# Go
-##############################################################################
-
-#
-# rules_go (support Golang under bazel)
-#
-http_archive(
-    name = "io_bazel_rules_go",
-    strip_prefix = "rules_go-7d17d496a6b32f6a573c6c22e29c58204eddf3d4",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/7d17d496a6b32f6a573c6c22e29c58204eddf3d4.zip"],
-)
-
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-
-go_rules_dependencies()
-
-go_register_toolchains()
-
-#
-# bazel-gazelle (support Golang under bazel)
-#
-http_archive(
-    name = "bazel_gazelle",
-    strip_prefix = "bazel-gazelle-0.16.0",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/0.16.0.zip"],
-)
-
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-
-gazelle_dependencies()
-
-#
-# go_gapic artifacts runtime dependencies (gax-go)
-#
-load("@com_google_api_codegen//rules_gapic/go:go_gapic_repositories.bzl", "go_gapic_repositories")
-
-go_gapic_repositories()
-
-###
-### END googleapis/WORKSPACE
-###
 load("//bazel:google_cloud_cpp_spanner_deps.bzl", "google_cloud_cpp_spanner_deps")
 
 google_cloud_cpp_spanner_deps()
+
+# Configure @com_google_googleapis to only compile C++ and gRPC libraries.
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,  # C++ support is only "Partially implemented", roll our own.
+    grpc = True,
+)
 
 # Have to manually call the corresponding function for google-cloud-cpp and
 # gRPC:

--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -54,10 +54,10 @@ def google_cloud_cpp_spanner_deps():
         http_archive(
             name = "com_google_googleapis",
             urls = [
-                "https://github.com/google/googleapis/archive/32a10f69e2c9ce15bba13ab1ff928bacebb25160.zip",
+                "https://github.com/googleapis/googleapis/archive/a8ee1416f4c588f2ab92da72e7c1f588c784d3e6.tar.gz",
             ],
-            strip_prefix = "googleapis-32a10f69e2c9ce15bba13ab1ff928bacebb25160",
-            sha256 = "2c5dc6d4575e0804ccf3ffb22ca36d68621013c0b2980042d6fb4a04a4447b17",
+            strip_prefix = "googleapis-a8ee1416f4c588f2ab92da72e7c1f588c784d3e6",
+            sha256 = "6b8a9b2bcb4476e9a5a9872869996f0d639c8d5df76dd8a893e79201f211b1cf",
             build_file = "//bazel:googleapis.BUILD",
         )
 

--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -17,118 +17,6 @@ licenses(["notice"])  # Apache 2.0
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
-cc_proto_library(
-    name = "http_cc_proto",
-    deps = ["//google/api:http_proto"],
-)
-
-cc_grpc_library(
-    name = "google_api_http",
-    srcs = ["//google/api:http_proto"],
-    deps = [":http_cc_proto"],
-    grpc_only = True,
-    well_known_protos = True,
-    use_external = True,
-)
-
-cc_proto_library(
-name = "annotations_cc_proto",
-deps = ["//google/api:annotations_proto"],
-)
-
-cc_grpc_library(
-    name = "google_api_annotations",
-    srcs = ["//google/api:annotations_proto"],
-    deps = [":annotations_cc_proto", ":http_cc_proto"],
-    grpc_only = True,
-    well_known_protos = True,
-    use_external = True,
-)
-
-cc_proto_library(
-    name = "auth_cc_proto",
-    deps = ["//google/api:auth_proto"],
-)
-
-cc_grpc_library(
-    name = "google_api_auth",
-    srcs = ["//google/api:auth_proto"],
-    deps = [":annotations_cc_proto", ":auth_cc_proto", ":http_cc_proto"],
-    grpc_only = True,
-    well_known_protos = True,
-    use_external = True,
-)
-
-cc_proto_library(
-    name = "error_details_cc_proto",
-    deps = ["//google/rpc:error_details_proto"],
-    )
-
-cc_grpc_library(
-    name = "google_rpc_error_details",
-    srcs = ["//google/rpc:error_details_proto"],
-    deps = [":error_details_cc_proto"],
-    grpc_only = True,
-    well_known_protos = True,
-    use_external = True,
-)
-
-cc_proto_library(
-    name = "status_cc_proto",
-    deps = ["//google/rpc:status_proto"],
-)
-
-cc_grpc_library(
-    name = "google_rpc_status",
-    srcs = ["//google/rpc:status_proto"],
-    deps = [":status_cc_proto"],
-    grpc_only = True,
-    well_known_protos = True,
-    use_external = True,
-)
-
-cc_proto_library(
-    name = "operations_cc_proto",
-    deps = ["//google/longrunning:operations_proto"],
-)
-
-cc_grpc_library(
-    name = "google_longrunning_operations",
-    srcs = ["//google/longrunning:operations_proto"],
-    deps = [":operations_cc_proto"],
-    grpc_only = True,
-    well_known_protos = True,
-    use_external = True,
-)
-
-cc_proto_library(
-    name = "policy_cc_proto",
-    deps = ["//google/iam/v1:policy_proto"],
-)
-
-cc_grpc_library(
-    name = "google_iam_v1_policy",
-    srcs = ["//google/iam/v1:policy_proto"],
-    deps = [":policy_cc_proto"],
-    grpc_only = True,
-    well_known_protos = True,
-    use_external = True,
-)
-
-cc_proto_library(
-    name = "iam_policy_cc_proto",
-    deps = ["//google/iam/v1:iam_policy_proto"],
-)
-
-cc_grpc_library(
-    name = "google_iam_v1_iam_policy",
-    srcs = ["//google/iam/v1:iam_policy_proto"],
-    deps = [":iam_policy_cc_proto"],
-    grpc_only = True,
-    well_known_protos = True,
-    use_external = True,
-)
-
 ######################
 # BEGIN SPANNER PROTOS
 ######################
@@ -155,13 +43,17 @@ cc_grpc_library(
 cc_proto_library(
     name = "spanner_admin_instance_cc_proto",
     deps = ["//google/spanner/admin/instance/v1:spanner_admin_instance_proto"],
-    )
+)
 
 # Instance Admin
 cc_grpc_library(
     name = "google_spanner_admin_instance_v1_spanner_instance_admin",
     srcs = ["//google/spanner/admin/instance/v1:spanner_admin_instance_proto"],
-    deps = [":spanner_admin_instance_cc_proto", ":spanner_cc_proto"],
+    deps = [
+        ":spanner_admin_instance_cc_proto",
+        ":spanner_cc_proto",
+        "//google/longrunning:longrunning_cc_grpc",
+    ],
     grpc_only = True,
     well_known_protos = True,
     use_external = True,
@@ -176,7 +68,10 @@ cc_proto_library(
 cc_grpc_library(
     name = "google_spanner_admin_database_v1_spanner_database_admin",
     srcs = ["//google/spanner/admin/database/v1:spanner_admin_database_proto"],
-    deps = [":spanner_admin_database_cc_proto"],
+    deps = [
+        ":spanner_admin_database_cc_proto",
+        "//google/longrunning:longrunning_cc_grpc",
+    ],
     grpc_only = True,
     well_known_protos = True,
     use_external = True,

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -46,7 +46,6 @@ cc_library(
     hdrs = spanner_client_hdrs + ["version_info.h"],
     deps = [
         "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_google_googleapis//:google_longrunning_operations",
         "@com_google_googleapis//:spanner_protos",
     ],
 )


### PR DESCRIPTION
With the latest release of googleapis it is possible to disable Java and
Go dependencies.