### PR TITLE
Refactoring to make it easier to add spanner ARRAY support.

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -14,8 +14,6 @@
 
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/log.h"
-#include <google/protobuf/util/field_comparator.h>
-#include <google/protobuf/util/message_differencer.h>
 #include <cmath>
 #include <ios>
 #include <string>
@@ -36,29 +34,6 @@ Status CheckValidity(Value const& v) {
   if (v.is_null()) return Status(StatusCode::kInvalidArgument, "null value");
   return {};  // OK status
 }
-
-// A custom protobuf comparator to make Spanner-encoded FLOAT64 "NaN" values
-// compare not equal to each other. This is the behavior required by IEEE 754.
-class CustomComparator : public google::protobuf::util::DefaultFieldComparator {
- public:
-  ComparisonResult Compare(
-      const google::protobuf::Message& message_1,
-      const google::protobuf::Message& message_2,
-      const google::protobuf::FieldDescriptor* field, int index_1, int index_2,
-      const google::protobuf::util::FieldContext* field_context) override {
-    auto const* const reflection = message_1.GetReflection();
-    // Spanner requires that FLOAT64 values (i.e., double) that represent nan
-    // are stored as the string "NaN". But IEEE 754 requires that NaN compares
-    // not equal to anything, including itself.
-    if (field->name() == "string_value") {
-      if (reflection->GetString(message_1, field) == "NaN") {
-        return DIFFERENT;
-      }
-    }
-    return DefaultFieldComparator::Compare(message_1, message_2, field, index_1,
-                                           index_2, field_context);
-  }
-};
 
 }  // namespace
 
@@ -89,10 +64,21 @@ Value::Value(std::string v) {
 }
 
 bool operator==(Value a, Value b) {
-  google::protobuf::util::MessageDifferencer diff;
-  CustomComparator comp;
-  diff.set_field_comparator(&comp);
-  return diff.Compare(a.type_, b.type_) && diff.Compare(a.value_, b.value_);
+  if (a.type_.code() != b.type_.code()) return false;
+  if (a.is_null() != b.is_null()) return false;
+  if (a.is_null()) return true;  // They are both null
+  switch (a.type_.code()) {
+    case google::spanner::v1::TypeCode::BOOL:
+      return *a.get<bool>() == *b.get<bool>();
+    case google::spanner::v1::TypeCode::INT64:
+      return *a.get<std::int64_t>() == *b.get<std::int64_t>();
+    case google::spanner::v1::TypeCode::FLOAT64:
+      return *a.get<double>() == *b.get<double>();
+    case google::spanner::v1::TypeCode::STRING:
+      return *a.get<std::string>() == *b.get<std::string>();
+    default:
+      return false;
+  }
 }
 
 void PrintTo(Value const& v, std::ostream* os) {

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -113,7 +113,7 @@ class Value {
    */
   template <typename T>
   bool is() const {
-    return IsType(T{});
+    return type_.code() == TypeCodeMap::GetCode(T{});
   }
 
   /**
@@ -168,12 +168,13 @@ class Value {
   }
 
   /**
-   * Outputs the contained value and type, formatted as a string.
+   * Allows Google Test to print internall debugging information when test
+   * assertions fail.
    *
-   * This is intended for debugging and human consumption only, not machine
-   * consumption as the output format may change without notice.
+   * @warning This is intended for debugging and human consumption only, not
+   * machine consumption as the output format may change without notice.
    */
-  friend std::ostream& operator<<(std::ostream& os, Value v);
+  friend void PrintTo(Value const& v, std::ostream* os);
 
  private:
   // A private argument type and constructor that's used by the public
@@ -187,12 +188,15 @@ class Value {
     value_.set_null_value(google::protobuf::NullValue::NULL_VALUE);
   }
 
-  // Tag-dispatched function overloads. The argument type is important, the
-  // value is ignored.
-  bool IsType(bool) const;
-  bool IsType(std::int64_t) const;
-  bool IsType(double) const;
-  bool IsType(std::string) const;
+  struct TypeCodeMap {
+    using Code = google::spanner::v1::TypeCode;
+    // Tag-dispatched function overloads. The argument type is important, the
+    // value is ignored.
+    static Code GetCode(bool) { return Code::BOOL; }
+    static Code GetCode(std::int64_t) { return Code::INT64; }
+    static Code GetCode(double) { return Code::FLOAT64; }
+    static Code GetCode(std::string) { return Code::STRING; }
+  };
 
   // Tag-dispatched function overloads. The argument type is important, the
   // value is ignored.

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -168,7 +168,7 @@ class Value {
   }
 
   /**
-   * Allows Google Test to print internall debugging information when test
+   * Allows Google Test to print internal debugging information when test
    * assertions fail.
    *
    * @warning This is intended for debugging and human consumption only, not

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -27,10 +27,10 @@ template <typename T>
 void TestBasicSemantics(T init) {
   Value const v{init};
 
-  EXPECT_TRUE(v.is<T>()) << v;
-  EXPECT_FALSE(v.is_null()) << v;
+  EXPECT_TRUE(v.is<T>());
+  EXPECT_FALSE(v.is_null());
 
-  EXPECT_EQ(init, *v.get<T>()) << v;
+  EXPECT_EQ(init, *v.get<T>());
   EXPECT_EQ(init, static_cast<T>(v));
 
   Value const copy = v;


### PR DESCRIPTION
Removed the switch statement in operator==() in favor of a custom
protobuf message differencer, which will grow/expand with any
data/values that we stuff in the proto. A custom differencer was needed
so that we could make encoded "NaN" values still appear unequal to each
other, as they're supposed to.

Removed the switch statement in operator<<() and changed to directly
printing the internal protobuf contents with `.ShortDebugString()`.
Since this format exposes internal implementation details that we don't
want external users or computers to depend on, I changed op<< ->
PrintTo() to make it clearer that this "formatting" is only inteded for
nice output during failed gtest assertions.

Changed the IsType() functions that used to return bool to instead
return the type code so that it can later be used in other places. Also
refactored those functions into a small, private TypeCodeMap struct.

	modified:   value.cc
	modified:   value.h
	modified:   value_test.cc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/55)
<!-- Reviewable:end -->
