### PR TITLE
Removed dep on GCS.

### DIFF
--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -31,11 +31,11 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_googleapis_google_cloud_cpp" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp",
-            strip_prefix = "google-cloud-cpp-2ec0039ed1a91f7a0758feaf9d820a03a7c5f263",
+            strip_prefix = "google-cloud-cpp-7fc1586a855dfb728d3285b6c7392834e7234f67",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp/archive/2ec0039ed1a91f7a0758feaf9d820a03a7c5f263.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp/archive/7fc1586a855dfb728d3285b6c7392834e7234f67.tar.gz",
             ],
-            sha256 = "c765bca47bb1cfcf651b5399be59a3ea8b0a49040f0010869c7f1c32b8a18b78",
+            sha256 = "d7bd8767291ffbd74a325e30ec33a77ba59330cfd350ad4c3f82a0153937b07a",
         )
 
     # Load a newer version of google test than what gRPC does.

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -68,6 +68,6 @@ cc_binary(
     srcs = ["spanner_tool.cc"],
     deps = [
         ":spanner_client",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/storage:storage_client",
+        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
     ],
 )

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/status.h"
-#include "google/cloud/storage/internal/format_time_point.h"
+#include "google/cloud/internal/format_time_point.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
 #include <google/spanner/v1/spanner.grpc.pb.h>
@@ -272,8 +272,7 @@ int PopulateTimeseriesTable(std::vector<std::string> args) {
         " VALUES (@name, @time, @value)");
     auto& fields = *request.mutable_params()->mutable_fields();
     fields["name"].set_string_value(std::move(series_name));
-    fields["time"].set_string_value(
-        google::cloud::storage::internal::FormatRfc3339(ts));
+    fields["time"].set_string_value(google::cloud::internal::FormatRfc3339(ts));
     fields["value"].set_string_value(std::to_string(value));
     auto& types = *request.mutable_param_types();
     types["time"].set_code(spanner::TIMESTAMP);

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/status.h"
 #include "google/cloud/internal/format_time_point.h"
+#include "google/cloud/status.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
 #include <google/spanner/v1/spanner.grpc.pb.h>


### PR DESCRIPTION
We only had a dep on GCS because of a time formatting library, that was
moved out of GCS into google/cloud/internal/.

	modified:   bazel/google_cloud_cpp_spanner_deps.bzl
	modified:   google/cloud/spanner/BUILD
	modified:   google/cloud/spanner/spanner_tool.cc

Fixes #44

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/56)
<!-- Reviewable:end -->
