### PR TITLE
Adds support for spanner ARRAYs.

### DIFF
--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -42,6 +42,10 @@ inline namespace SPANNER_CLIENT_NS {
  *     INT64        | std::int64_t
  *     FLOAT64      | double
  *     STRING       | std::string
+ *     ARRAY        | std::vector<T>  // [1]
+ *
+ * [1] The type `T` may be any of the other supported types, except for
+ *     ARRAY/std::vector.
  *
  * This is a regular C++ value type with support for copy, move, equality, etc,
  * but there is no default constructor because there is no default type.
@@ -86,11 +90,26 @@ class Value {
   Value& operator=(Value const&) = default;
   Value& operator=(Value&&) = default;
 
-  /// Constructs a non-null instance with the specified value and type.
+  /// Constructs a non-null instance with the specified type and value.
   explicit Value(bool v);
   explicit Value(std::int64_t v);
   explicit Value(double v);
   explicit Value(std::string v);
+
+  /**
+   * Constructs a non-null instance with a Spanner ARRAY of the specified type
+   * and values.
+   *
+   * The type `T` may be any valid type shown above, except vectors of vectors
+   * are not allowed.
+   */
+  template <typename T>  // Possibly add an enabler
+  explicit Value(std::vector<T> const& v) {
+    type_ = GetType(v);
+    for (auto const& e : v) {
+      *value_.mutable_list_value()->add_values() = std::move(Value(e).value_);
+    }
+  }
 
   friend bool operator==(Value a, Value b);
   friend bool operator!=(Value a, Value b) { return !(a == b); }
@@ -113,7 +132,7 @@ class Value {
    */
   template <typename T>
   bool is() const {
-    return type_.code() == TypeCodeMap::GetCode(T{});
+    return ProtoEqual(type_, GetType(T{}));
   }
 
   /**
@@ -140,7 +159,9 @@ class Value {
    */
   template <typename T>
   StatusOr<T> get() const {
-    return GetValue(T{});
+    auto const status = HasValue<T>(type_, value_);
+    if (!status.ok()) return status;
+    return GetValue(T{}, value_);
   }
 
   /**
@@ -164,7 +185,7 @@ class Value {
    */
   template <typename T>
   explicit operator T() const {
-    return *get<T>();
+    return GetValue(T{}, value_);
   }
 
   /**
@@ -188,22 +209,52 @@ class Value {
     value_.set_null_value(google::protobuf::NullValue::NULL_VALUE);
   }
 
-  struct TypeCodeMap {
-    using Code = google::spanner::v1::TypeCode;
-    // Tag-dispatched function overloads. The argument type is important, the
-    // value is ignored.
-    static Code GetCode(bool) { return Code::BOOL; }
-    static Code GetCode(std::int64_t) { return Code::INT64; }
-    static Code GetCode(double) { return Code::FLOAT64; }
-    static Code GetCode(std::string) { return Code::STRING; }
-  };
+  // Tag-dispatch overloads to convert a C++ type to a `Type` protobuf. The
+  // argument type is the tag, the argument value is ignored.
+  static google::spanner::v1::Type GetType(bool);
+  static google::spanner::v1::Type GetType(std::int64_t);
+  static google::spanner::v1::Type GetType(double);
+  static google::spanner::v1::Type GetType(std::string const&);
+  template <typename T>
+  static google::spanner::v1::Type GetType(std::vector<T> const&) {
+    google::spanner::v1::Type t;
+    t.set_code(google::spanner::v1::TypeCode::ARRAY);
+    *t.mutable_array_element_type() = GetType(T{});  // Recursive call
+    return t;
+  }
 
-  // Tag-dispatched function overloads. The argument type is important, the
-  // value is ignored.
-  StatusOr<bool> GetValue(bool) const;
-  StatusOr<std::int64_t> GetValue(std::int64_t) const;
-  StatusOr<double> GetValue(double) const;
-  StatusOr<std::string> GetValue(std::string) const;
+  // Returns true if the given `Type` and `Value` can be converted to the
+  // specified C++ type `T`.
+  template <typename T>
+  static Status HasValue(google::spanner::v1::Type const& pt,
+                         google::protobuf::Value const& pv) {
+    if (!ProtoEqual(GetType(T{}), pt))
+      return Status(StatusCode::kInvalidArgument, "wrong type");
+    if (pv.kind_case() == google::protobuf::Value::kNullValue)
+      return Status(StatusCode::kInvalidArgument, "null value");
+    return {};  // OK Status
+  }
+
+  // Tag-dispatch overloads to extract a C++ value from a `Value` protobuf. The
+  // first argument type is the tag, the first argument value is ignored.
+  static bool GetValue(bool, google::protobuf::Value const&);
+  static std::int64_t GetValue(std::int64_t, google::protobuf::Value const&);
+  static double GetValue(double, google::protobuf::Value const&);
+  static std::string GetValue(std::string const&,
+                              google::protobuf::Value const&);
+  template <typename T>
+  static std::vector<T> GetValue(std::vector<T> const&,
+                                 google::protobuf::Value const& pv) {
+    std::vector<T> v;
+    for (auto const& e : pv.list_value().values()) {
+      v.push_back(GetValue(T{}, e));
+    }
+    return v;
+  }
+
+  // Helper to compare protos for equality.
+  static bool ProtoEqual(google::protobuf::Message const& m1,
+                         google::protobuf::Message const& m2);
 
   google::spanner::v1::Type type_;
   google::protobuf::Value value_;

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -103,7 +103,7 @@ class Value {
    * The type `T` may be any valid type shown above, except vectors of vectors
    * are not allowed.
    */
-  template <typename T>  // Possibly add an enabler
+  template <typename T>  // Possibly add an enabler to disallow T==vector
   explicit Value(std::vector<T> const& v) {
     type_ = GetType(v);
     for (auto const& e : v) {

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -103,7 +103,7 @@ class Value {
    * The type `T` may be any valid type shown above, except vectors of vectors
    * are not allowed.
    */
-  template <typename T>  // Possibly add an enabler to disallow T==vector
+  template <typename T>  // TODO(#59): add an enabler to disallow T==vector
   explicit Value(std::vector<T> const& v) {
     type_ = GetType(v);
     for (auto const& e : v) {

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -175,13 +175,6 @@ TEST(Value, SpannerArray) {
   EXPECT_FALSE(null_vd.get<ArrayInt64>().ok());
 }
 
-TEST(Value, ArrayOfArray) {
-  using Type = std::vector<std::vector<bool>>;
-  Type vvb;
-  Value v(vvb);
-  EXPECT_TRUE(v.is<Type>());
-}
-
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -51,6 +51,7 @@ TEST(Value, BasicSemantics) {
   for (auto x : {false, true}) {
     SCOPED_TRACE("Testing: bool " + std::to_string(x));
     TestBasicSemantics(x);
+    TestBasicSemantics(std::vector<bool>(5, x));
   }
 
   auto const min64 = std::numeric_limits<std::int64_t>::min();
@@ -58,6 +59,7 @@ TEST(Value, BasicSemantics) {
   for (auto x : std::vector<std::int64_t>{min64, -1, 0, 1, max64}) {
     SCOPED_TRACE("Testing: std::int64_t " + std::to_string(x));
     TestBasicSemantics(x);
+    TestBasicSemantics(std::vector<std::int64_t>(5, x));
   }
 
   // Note: We skip testing the NaN case here because NaN always compares not
@@ -66,11 +68,13 @@ TEST(Value, BasicSemantics) {
   for (auto x : {-inf, -1.0, -0.5, 0.0, 0.5, 1.0, inf}) {
     SCOPED_TRACE("Testing: double " + std::to_string(x));
     TestBasicSemantics(x);
+    TestBasicSemantics(std::vector<double>(5, x));
   }
 
   for (auto x : std::vector<std::string>{"", "f", "foo", "12345678901234567"}) {
     SCOPED_TRACE("Testing: std::string " + std::string(x));
     TestBasicSemantics(x);
+    TestBasicSemantics(std::vector<std::string>(5, x));
   }
 }
 
@@ -127,6 +131,55 @@ TEST(Value, MixingTypes) {
   EXPECT_NE(null_b, b);
   EXPECT_NE(null_b, null_a);
   EXPECT_NE(null_b, a);
+}
+
+TEST(Value, SpannerArray) {
+  using ArrayInt64 = std::vector<std::int64_t>;
+  using ArrayDouble = std::vector<double>;
+
+  ArrayInt64 const ai = {1, 2, 3};
+  Value const vi(ai);
+  EXPECT_EQ(vi, vi);
+  EXPECT_FALSE(vi.is_null());
+  EXPECT_TRUE(vi.is<ArrayInt64>());
+  EXPECT_FALSE(vi.is<ArrayDouble>());
+  EXPECT_EQ(ai, static_cast<ArrayInt64>(vi));
+  EXPECT_TRUE(vi.get<ArrayInt64>().ok());
+  EXPECT_FALSE(vi.get<ArrayDouble>().ok());
+  EXPECT_EQ(ai, *vi.get<ArrayInt64>());
+
+  ArrayDouble const ad = {1.0, 2.0, 3.0};
+  Value const vd(ad);
+  EXPECT_EQ(vd, vd);
+  EXPECT_NE(vi, vd);
+  EXPECT_FALSE(vd.is_null());
+  EXPECT_TRUE(vd.is<ArrayDouble>());
+  EXPECT_FALSE(vd.is<ArrayInt64>());
+  EXPECT_EQ(ad, static_cast<ArrayDouble>(vd));
+  EXPECT_TRUE(vd.get<ArrayDouble>().ok());
+  EXPECT_EQ(ad, *vd.get<ArrayDouble>());
+
+  Value const null_vi = Value::MakeNull<ArrayInt64>();
+  EXPECT_EQ(null_vi, null_vi);
+  EXPECT_NE(null_vi, vi);
+  EXPECT_NE(null_vi, vd);
+  EXPECT_FALSE(null_vi.get<ArrayInt64>().ok());
+  EXPECT_FALSE(null_vi.get<ArrayDouble>().ok());
+
+  Value const null_vd = Value::MakeNull<ArrayDouble>();
+  EXPECT_EQ(null_vd, null_vd);
+  EXPECT_NE(null_vd, null_vi);
+  EXPECT_NE(null_vd, vd);
+  EXPECT_NE(null_vd, vi);
+  EXPECT_FALSE(null_vd.get<ArrayDouble>().ok());
+  EXPECT_FALSE(null_vd.get<ArrayInt64>().ok());
+}
+
+TEST(Value, ArrayOfArray) {
+  using Type = std::vector<std::vector<bool>>;
+  Type vvb;
+  Value v(vvb);
+  EXPECT_TRUE(v.is<Type>());
 }
 
 }  // namespace SPANNER_CLIENT_NS


### PR DESCRIPTION
A Spanner ARRAY is represented as a std::vector<T>, where T is any other
valid Spanenr type. Well, technically, arrays of arrays are not allowed,
but we don't currently forbid this. We could/should add an enabler to
this constructor to prevent this.

This PR also changes `op==` to do comparisons by looking at the data member protobuf contents instead of converting to C++ types and using their `op==`. This change makes it easier to recursively call the equality function for containers that can contain other values and containers.

Closes #53 

	modified:   value.cc
	modified:   value.h
	modified:   value_test.cc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/58)
<!-- Reviewable:end -->
