### PR TITLE
Make spanner::Value::is_null() a template

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -105,10 +105,6 @@ void PrintTo(Value const& v, std::ostream* os) {
   *os << v.type_.ShortDebugString() << "; " << v.value_.ShortDebugString();
 }
 
-bool Value::is_null() const {
-  return value_.kind_case() == google::protobuf::Value::kNullValue;
-}
-
 bool Value::ProtoEqual(google::protobuf::Message const& m1,
                        google::protobuf::Message const& m2) {
   return google::protobuf::util::MessageDifferencer::Equals(m1, m2);

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -26,6 +26,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+
 /**
  * The Value class represents a type-safe, nullable Spanner value.
  *
@@ -58,7 +59,7 @@ inline namespace SPANNER_CLIENT_NS {
  *     std::string msg = "hello";
  *     spanner::Value v(msg);
  *     assert(v.is<std::string>());
- *     assert(!v.is_null());
+ *     assert(!v.is_null<std::string>());
  *     StatusOr<std::string> copy = v.get<std::string>();
  *     if (copy) {
  *       std::cout << *copy;  // prints "hello"
@@ -68,7 +69,7 @@ inline namespace SPANNER_CLIENT_NS {
  *
  *     spanner::Value v = spanner::Value::MakeNull<std::int64_t>();
  *     assert(v.is<std::int64_t>());
- *     assert(v.is_null());
+ *     assert(v.is_null<std::int64_t>());
  *     StatusOr<std::int64_t> i = v.get<std::int64_t>();
  *     if (!i) {
  *       std::cerr << "error: " << i.status();
@@ -114,9 +115,6 @@ class Value {
   friend bool operator==(Value a, Value b);
   friend bool operator!=(Value a, Value b) { return !(a == b); }
 
-  /// Returns true if there is no contained value.
-  bool is_null() const;
-
   /**
    * Returns true if the contained value is of the specified type `T`.
    *
@@ -136,6 +134,23 @@ class Value {
   }
 
   /**
+   * Returns true if is<T>() and the contained value is "null".
+   *
+   * Example:
+   *
+   *     spanner::Value v{true};
+   *     assert(!v.is_null<bool>());
+   *
+   *     spanner::Value null_v = spanner::Value::MakeNull<bool>();
+   *     assert(v.is_null<bool>());
+   *     assert(!v.is_null<std::int64_t>());
+   */
+  template <typename T>
+  bool is_null() const {
+    return is<T>() && value_.kind_case() == google::protobuf::Value::kNullValue;
+  }
+
+  /**
    * Returns the contained value wrapped in a `google::cloud::StatusOr<T>`.
    *
    * If the specified type `T` is wrong or if the contained value is "null",
@@ -151,7 +166,7 @@ class Value {
    *
    *     // Now using a "null" std::int64_t
    *     v = spanner::Value::MakeNull<std::int64_t>();
-   *     assert(v.is_null());
+   *     assert(v.is_null<std::int64_t>());
    *     StatusOr<std::int64_t> i = v.get<std::int64_t>();
    *     if (!i) {
    *       std::cerr << "Could not get integer: " << i.status();
@@ -165,12 +180,11 @@ class Value {
   }
 
   /**
-   * Returns the contained value iff it is not null and the the specified `T` is
-   * correct.
+   * Returns the contained value iff is<T>() and !is_null<T>().
    *
-   * It is the caller's responsibility to ensure that this the specifed type
+   * It is the caller's responsibility to ensure that the specifed type
    * `T` is correct (e.g., with `is<T>()`) and that the value is not "null"
-   * (e.g., with `!v.is_null()`). Otherwise, the behavior is undefined.
+   * (e.g., with `!v.is_null<T>()`). Otherwise, the behavior is undefined.
    *
    * This is mostly useful if writing generic code where casting is needed.
    *

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -26,7 +26,6 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-
 /**
  * The Value class represents a type-safe, nullable Spanner value.
  *

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -181,7 +181,7 @@ class Value {
   /**
    * Returns the contained value iff is<T>() and !is_null<T>().
    *
-   * It is the caller's responsibility to ensure that the specifed type
+   * It is the caller's responsibility to ensure that the specified type
    * `T` is correct (e.g., with `is<T>()`) and that the value is not "null"
    * (e.g., with `!v.is_null<T>()`). Otherwise, the behavior is undefined.
    *

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -100,6 +100,7 @@ TEST(Value, MixingTypes) {
   EXPECT_FALSE(a.is_null<A>());
   EXPECT_TRUE(a.get<A>().ok());
   EXPECT_FALSE(a.is<B>());
+  EXPECT_FALSE(a.is_null<B>());
   EXPECT_FALSE(a.get<B>().ok());
 
   Value null_a = Value::MakeNull<A>();
@@ -107,6 +108,7 @@ TEST(Value, MixingTypes) {
   EXPECT_TRUE(null_a.is_null<A>());
   EXPECT_FALSE(null_a.get<A>().ok());
   EXPECT_FALSE(null_a.is<B>());
+  EXPECT_FALSE(null_a.is_null<B>());
   EXPECT_FALSE(null_a.get<B>().ok());
 
   EXPECT_NE(null_a, a);
@@ -116,6 +118,7 @@ TEST(Value, MixingTypes) {
   EXPECT_FALSE(b.is_null<B>());
   EXPECT_TRUE(b.get<B>().ok());
   EXPECT_FALSE(b.is<A>());
+  EXPECT_FALSE(b.is_null<A>());
   EXPECT_FALSE(b.get<A>().ok());
 
   EXPECT_NE(b, a);
@@ -126,6 +129,7 @@ TEST(Value, MixingTypes) {
   EXPECT_TRUE(null_b.is_null<B>());
   EXPECT_FALSE(null_b.get<B>().ok());
   EXPECT_FALSE(null_b.is<A>());
+  EXPECT_FALSE(null_b.is_null<A>());
   EXPECT_FALSE(null_b.get<A>().ok());
 
   EXPECT_NE(null_b, b);

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -28,7 +28,7 @@ void TestBasicSemantics(T init) {
   Value const v{init};
 
   EXPECT_TRUE(v.is<T>());
-  EXPECT_FALSE(v.is_null());
+  EXPECT_FALSE(v.is_null<T>());
 
   EXPECT_EQ(init, *v.get<T>());
   EXPECT_EQ(init, static_cast<T>(v));
@@ -42,7 +42,7 @@ void TestBasicSemantics(T init) {
   // Tests a null Value of type `T`.
   Value const null = Value::MakeNull<T>();
   EXPECT_TRUE(null.is<T>());
-  EXPECT_TRUE(null.is_null());
+  EXPECT_TRUE(null.is_null<T>());
   EXPECT_FALSE(null.get<T>().ok());
   EXPECT_NE(null, v);
 }
@@ -82,7 +82,7 @@ TEST(Value, DoubleNaN) {
   double const nan = std::nan("NaN");
   Value v{nan};
   EXPECT_TRUE(v.is<double>());
-  EXPECT_FALSE(v.is_null());
+  EXPECT_FALSE(v.is_null<double>());
   EXPECT_TRUE(std::isnan(*v.get<double>()));
 
   // Since IEEE 754 defines that nan is not equal to itself, then a Value with
@@ -96,15 +96,15 @@ TEST(Value, MixingTypes) {
   using B = std::int64_t;
 
   Value a(A{});
-  EXPECT_FALSE(a.is_null());
   EXPECT_TRUE(a.is<A>());
+  EXPECT_FALSE(a.is_null<A>());
   EXPECT_TRUE(a.get<A>().ok());
   EXPECT_FALSE(a.is<B>());
   EXPECT_FALSE(a.get<B>().ok());
 
   Value null_a = Value::MakeNull<A>();
-  EXPECT_TRUE(null_a.is_null());
   EXPECT_TRUE(null_a.is<A>());
+  EXPECT_TRUE(null_a.is_null<A>());
   EXPECT_FALSE(null_a.get<A>().ok());
   EXPECT_FALSE(null_a.is<B>());
   EXPECT_FALSE(null_a.get<B>().ok());
@@ -112,8 +112,8 @@ TEST(Value, MixingTypes) {
   EXPECT_NE(null_a, a);
 
   Value b(B{});
-  EXPECT_FALSE(b.is_null());
   EXPECT_TRUE(b.is<B>());
+  EXPECT_FALSE(b.is_null<B>());
   EXPECT_TRUE(b.get<B>().ok());
   EXPECT_FALSE(b.is<A>());
   EXPECT_FALSE(b.get<A>().ok());
@@ -122,8 +122,8 @@ TEST(Value, MixingTypes) {
   EXPECT_NE(b, null_a);
 
   Value null_b = Value::MakeNull<B>();
-  EXPECT_TRUE(null_b.is_null());
   EXPECT_TRUE(null_b.is<B>());
+  EXPECT_TRUE(null_b.is_null<B>());
   EXPECT_FALSE(null_b.get<B>().ok());
   EXPECT_FALSE(null_b.is<A>());
   EXPECT_FALSE(null_b.get<A>().ok());
@@ -140,8 +140,8 @@ TEST(Value, SpannerArray) {
   ArrayInt64 const ai = {1, 2, 3};
   Value const vi(ai);
   EXPECT_EQ(vi, vi);
-  EXPECT_FALSE(vi.is_null());
   EXPECT_TRUE(vi.is<ArrayInt64>());
+  EXPECT_FALSE(vi.is_null<ArrayInt64>());
   EXPECT_FALSE(vi.is<ArrayDouble>());
   EXPECT_EQ(ai, static_cast<ArrayInt64>(vi));
   EXPECT_TRUE(vi.get<ArrayInt64>().ok());
@@ -152,8 +152,8 @@ TEST(Value, SpannerArray) {
   Value const vd(ad);
   EXPECT_EQ(vd, vd);
   EXPECT_NE(vi, vd);
-  EXPECT_FALSE(vd.is_null());
   EXPECT_TRUE(vd.is<ArrayDouble>());
+  EXPECT_FALSE(vd.is_null<ArrayDouble>());
   EXPECT_FALSE(vd.is<ArrayInt64>());
   EXPECT_EQ(ad, static_cast<ArrayDouble>(vd));
   EXPECT_TRUE(vd.get<ArrayDouble>().ok());


### PR DESCRIPTION
We choose to treat `spanner::Value` as `T(null, v1, v2, ...)`
rather than `null + T(v1, v2, ...)` or something between the
two.  That is, the null value is typed.  `v.is_null<T>()` is false if
`!v.is<T>()`, even when v is null, but the typical decision tree
would always test `v.is<T>()` first.

Fixes #49 .