### PR TITLE
Create file to support super-builds and test them.

### DIFF
--- a/ci/kokoro/Dockerfile.ubuntu
+++ b/ci/kokoro/Dockerfile.ubuntu
@@ -25,12 +25,14 @@ RUN apt update && \
         git \
         gcc \
         g++ \
-        cmake \
+        libssl-dev \
+        make \
+        ninja-build \
         pkg-config \
-	python-pip \
+        python-pip \
         shellcheck \
         tar \
-	unzip \
+        unzip \
         wget
 
 # By default, Ubuntu 18.04 does not install the alternatives for clang-format

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -15,13 +15,22 @@
 
 set -eu
 
+if [[ $# != 2 ]]; then
+  # The arugments are ignored, but required for compatibility with
+  # build-in-docker-cmake.sh
+  echo "Usage: $(basename "$0") <source-directory> <binary-directory>"
+  exit 1
+fi
+
+readonly SOURCE_DIR="$1"
+readonly BINARY_DIR="$2"
+
 # This script is supposed to run inside a Docker container, see
 # ci/kokoro/build.sh for the expected setup.  The /v directory is a volume
 # pointing to a (clean-ish) checkout of google-cloud-cpp:
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="/v"
 fi
-source "${PROJECT_ROOT}/ci/kokoro/linux-config.sh"
 source "${PROJECT_ROOT}/ci/colors.sh"
 
 # Run the "bazel build"/"bazel test" cycle inside a Docker image.

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -15,13 +15,20 @@
 
 set -eu
 
+if [[ $# != 2 ]]; then
+  echo "Usage: $(basename "$0") <source-directory> <binary-directory>"
+  exit 1
+fi
+
+readonly SOURCE_DIR="$1"
+readonly BINARY_DIR="$2"
+
 # This script is supposed to run inside a Docker container, see
 # ci/kokoro/cmake/installed-dependencies/build.sh for the expected setup.  The
 # /v directory is a volume pointing to a (clean-ish) checkout of the project:
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="/v"
 fi
-source "${PROJECT_ROOT}/ci/kokoro/linux-config.sh"
 source "${PROJECT_ROOT}/ci/colors.sh"
 
 echo
@@ -32,13 +39,13 @@ echo "================================================================"
 echo "Compiling on $(date)"
 echo "================================================================"
 cd "${PROJECT_ROOT}"
-cmake -H. -B"${BUILD_OUTPUT}"
-cmake --build "${BUILD_OUTPUT}" -- -j "$(nproc)"
+cmake "-H${SOURCE_DIR}" "-B${BINARY_DIR}"
+cmake --build "${BINARY_DIR}" -- -j "$(nproc)"
 
 echo "================================================================"
 echo "Running the unit tests $(date)"
 echo "================================================================"
-env -C "${BUILD_OUTPUT}" ctest --output-on-failure -j "$(nproc)"
+env -C "${BINARY_DIR}" ctest --output-on-failure -j "$(nproc)"
 
 echo "================================================================"
 echo "Build finished at $(date)"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -45,7 +45,13 @@ cmake --build "${BINARY_DIR}" -- -j "$(nproc)"
 echo "================================================================"
 echo "Running the unit tests $(date)"
 echo "================================================================"
-env -C "${BINARY_DIR}" ctest --output-on-failure -j "$(nproc)"
+# When user a super-build the tests are hidden in a subdirectory. We can tell
+# that ${BINARY_DIR} does not have the tests by checking for this file:
+if [[ -f "${BINARY_DIR}/CTestTestFile.cmake}" ]]; then
+  # It is Okay to skip the tests in this case because the super build
+  # automatically runs them.
+  env -C "${BINARY_DIR}" ctest --output-on-failure -j "$(nproc)"
+fi
 
 echo "================================================================"
 echo "Build finished at $(date)"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -20,6 +20,7 @@ export CXX=g++
 export DISTRO=ubuntu
 export DISTRO_VERSION=18.04
 export BAZEL_CONFIG=""
+export CMAKE_SOURCE_DIR="."
 
 in_docker_script="ci/kokoro/docker/build-in-docker-bazel.sh"
 
@@ -52,6 +53,11 @@ elif [[ "${BUILD_NAME}" = "tsan" ]]; then
 elif [[ "${BUILD_NAME}" = "cmake" ]]; then
   export DISTRO=fedora-install
   export DISTRO_VERSION=30
+  in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
+elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
+  export DISTRO=fedora-install
+  export DISTRO_VERSION=30
+  export CMAKE_SOURCE_DIR="."
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 else
   echo "Unknown BUILD_NAME (${BUILD_NAME}). Fix the Kokoro .cfg file."
@@ -125,7 +131,8 @@ sudo docker run \
      --volume "${KOKORO_GFILE_DIR:-/dev/shm}":/c \
      --workdir /v \
      "${IMAGE}:tip" \
-     "/v/${in_docker_script}"
+     "/v/${in_docker_script}" "${CMAKE_SOURCE_DIR}" \
+     "${BUILD_OUTPUT}-${BUILD_NAME}"
 
 exit_status=$?
 echo "Build finished with ${exit_status} exit status $(date)."

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -55,9 +55,7 @@ elif [[ "${BUILD_NAME}" = "cmake" ]]; then
   export DISTRO_VERSION=30
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
-  export DISTRO=fedora-install
-  export DISTRO_VERSION=30
-  export CMAKE_SOURCE_DIR="."
+  export CMAKE_SOURCE_DIR="ci/super"
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 else
   echo "Unknown BUILD_NAME (${BUILD_NAME}). Fix the Kokoro .cfg file."

--- a/ci/kokoro/docker/cmake-super-presubmit.cfg
+++ b/ci/kokoro/docker/cmake-super-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "cmake-super"
+}

--- a/ci/kokoro/docker/cmake-super.cfg
+++ b/ci/kokoro/docker/cmake-super.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "cmake-super"
+}

--- a/ci/super/CMakeLists.txt
+++ b/ci/super/CMakeLists.txt
@@ -1,0 +1,64 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.5)
+project(google-cloud-cpp-spanner-super-build CXX C)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(GOOGLE_CLOUD_CPP_SPANNER_ROOT "${PROJECT_SOURCE_DIR}/../../../..")
+list(APPEND CMAKE_MODULE_PATH "${GOOGLE_CLOUD_CPP_SPANNER_ROOT}/cmake")
+
+include(external/google-cloud-cpp)
+include(external/googletest)
+include(external/external-project-helpers)
+
+google_cloud_cpp_set_prefix_vars()
+
+include(ExternalProject)
+ExternalProject_Add(
+    google-cloud-cpp-spanner-as-external
+    DEPENDS google-cloud-cpp-project googletest-project
+    EXCLUDE_FROM_ALL OFF
+    BUILD_ALWAYS 1
+    PREFIX "${CMAKE_BINARY_DIR}/build/google-cloud-cpp-spanner"
+    INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+    SOURCE_DIR
+    "${GOOGLE_CLOUD_CPP_SPANNER_ROOT}"
+    LIST_SEPARATOR
+    |
+    CMAKE_ARGS -G${CMAKE_GENERATOR}
+               -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+               -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+               -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    BUILD_COMMAND ${CMAKE_COMMAND}
+                  --build
+                  <BINARY_DIR>
+                  TEST_COMMAND
+                  ${CMAKE_CTEST_COMMAND}
+                  --output-on-failure
+                  # TODO(#23) - Use this when install is implemented.
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD OFF
+    LOG_CONFIGURE OFF
+    LOG_BUILD OFF
+    LOG_INSTALL OFF)
+
+# This makes it easy to compile the dependencies before the code.
+add_custom_target(google-cloud-cpp-spanner-dependencies)
+add_dependencies(google-cloud-cpp-spanner-dependencies google-cloud-cpp-project
+                 googletest-project)

--- a/ci/super/CMakeLists.txt
+++ b/ci/super/CMakeLists.txt
@@ -20,7 +20,7 @@ project(google-cloud-cpp-spanner-super-build CXX C)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(GOOGLE_CLOUD_CPP_SPANNER_ROOT "${PROJECT_SOURCE_DIR}/../../../..")
+set(GOOGLE_CLOUD_CPP_SPANNER_ROOT "${PROJECT_SOURCE_DIR}/../..")
 list(APPEND CMAKE_MODULE_PATH "${GOOGLE_CLOUD_CPP_SPANNER_ROOT}/cmake")
 
 include(external/google-cloud-cpp)

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -1,0 +1,50 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(ExternalProject)
+include(external/external-project-helpers)
+
+if (NOT TARGET c-ares-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_C_ARES_URL
+        "https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz")
+    set(GOOGLE_CLOUD_CPP_C_ARES_SHA256
+        "62dd12f0557918f89ad6f5b759f0bf4727174ae9979499f5452c02be38d9d3e8")
+
+    google_cloud_cpp_set_prefix_vars()
+
+    ExternalProject_Add(
+        c-ares-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/c-ares"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_C_ARES_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_C_ARES_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -G${CMAKE_GENERATOR}
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/cmake/external/crc32c.cmake
+++ b/cmake/external/crc32c.cmake
@@ -1,0 +1,53 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(ExternalProject)
+include(external/external-project-helpers)
+
+if (NOT TARGET crc32c-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_CRC32C_URL
+        "https://github.com/google/crc32c/archive/1.0.6.tar.gz")
+    set(GOOGLE_CLOUD_CPP_CRC32C_SHA256
+        "6b3b1d861bb8307658b2407bc7a4c59e566855ef5368a60b35c893551e4788e9")
+
+    google_cloud_cpp_set_prefix_vars()
+
+    ExternalProject_Add(
+        crc32c-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/crc32c"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_CRC32C_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CRC32C_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -G${CMAKE_GENERATOR}
+                   -DCRC32C_BUILD_TESTS=OFF
+                   -DCRC32C_BUILD_BENCHMARKS=OFF
+                   -DCRC32C_USE_GLOG=OFF
+                   -DCMAKE_INSTALL_PATH=${GOOGLE_CLOUD_CPP_INSTALL_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -1,0 +1,60 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(ExternalProject)
+include(external/external-project-helpers)
+include(external/c-ares)
+include(external/ssl)
+include(external/zlib)
+
+if (NOT TARGET curl-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_CURL_URL
+        "https://curl.haxx.se/download/curl-7.60.0.tar.gz")
+    set(GOOGLE_CLOUD_CPP_CURL_SHA256
+        "e9c37986337743f37fd14fe8737f246e97aec94b39d1b71e8a5973f72a9fc4f5")
+
+    google_cloud_cpp_set_prefix_vars()
+
+    ExternalProject_Add(
+        curl-project
+        DEPENDS c-ares-project ssl-project zlib-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/curl"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_CURL_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_CURL_SHA256}
+        LIST_SEPARATOR |
+        # libcurl automatically enables a number of protocols. With static
+        # libraries this is a problem. The indirect dependencies, such as
+        # libldap, become hard to predict and manage. Setting HTTP_ONLY=ON and
+        # CMAKE_ENABLE_OPENSSL=ON disables most optional protocols and meets
+        # our needs. If the application needs a version of libcurl with other
+        # protocols enabled they can provide their own curl-project target.
+        CMAKE_ARGS -G${CMAKE_GENERATOR}
+                   -DHTTP_ONLY=ON
+                   -DCMAKE_ENABLE_OPENSSL=ON
+                   -DENABLE_ARES=ON
+                   -DCMAKE_INSTALL_PATH=${GOOGLE_CLOUD_CPP_INSTALL_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/cmake/external/external-project-helpers.cmake
+++ b/cmake/external/external-project-helpers.cmake
@@ -1,0 +1,50 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+set(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX
+    "${CMAKE_BINARY_DIR}/local"
+    CACHE STRING "Configure where are the external projects installed.")
+mark_as_advanced(GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX)
+
+function (google_cloud_cpp_set_prefix_vars)
+    # When passing a semi-colon delimited list to ExternalProject_Add, we need
+    # to escape the semi-colon. Quoting does not work and escaping the semi-
+    # colon does not seem to work (see https://reviews.llvm.org/D40257). A
+    # workaround is to use LIST_SEPARATOR to change the delimiter, which will
+    # then be replaced by an escaped semi-colon by CMake. This allows us to use
+    # multiple directories for our RPATH. Normally, it'd make sense to use : as
+    # a delimiter since it is a typical path-list separator, but it is a special
+    # character in CMake.
+    set(GOOGLE_CLOUD_CPP_PREFIX_PATH "${CMAKE_PREFIX_PATH};<INSTALL_DIR>")
+    string(REPLACE ";"
+                   "|"
+                   GOOGLE_CLOUD_CPP_PREFIX_PATH
+                   "${GOOGLE_CLOUD_CPP_PREFIX_PATH}")
+
+    # Depending on the platform libraries get installed in `lib` or `lib64`
+    set(GOOGLE_CLOUD_CPP_INSTALL_RPATH "<INSTALL_DIR>/lib;<INSTALL_DIR>/lib64")
+    string(REPLACE ";"
+                   "|"
+                   GOOGLE_CLOUD_CPP_INSTALL_RPATH
+                   "${GOOGLE_CLOUD_CPP_INSTALL_RPATH}")
+
+    set(GOOGLE_CLOUD_CPP_PREFIX_PATH
+        "${GOOGLE_CLOUD_CPP_PREFIX_PATH}"
+        PARENT_SCOPE)
+    set(GOOGLE_CLOUD_CPP_PREFIX_RPATH
+        "${GOOGLE_CLOUD_CPP_PREFIX_RPATH}"
+        PARENT_SCOPE)
+endfunction ()

--- a/cmake/external/google-cloud-cpp.cmake
+++ b/cmake/external/google-cloud-cpp.cmake
@@ -25,10 +25,10 @@ if (NOT TARGET google-cloud-cpp-project)
     # downloaded from GitHub.
     set(
         GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp/archive/92500a086cab360089fcb5581def5d62fcf1750a.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp/archive/7fc1586a855dfb728d3285b6c7392834e7234f67.tar.gz"
         )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "6562597a7f4c2c9bc9bcfe4cdec6d410544ed16513ef84e883f995275a2d7cd1")
+        "d7bd8767291ffbd74a325e30ec33a77ba59330cfd350ad4c3f82a0153937b07a")
     set(
         GOOGLEAPIS_URL
         "https://github.com/google/googleapis/archive/32a10f69e2c9ce15bba13ab1ff928bacebb25160.zip"

--- a/cmake/external/google-cloud-cpp.cmake
+++ b/cmake/external/google-cloud-cpp.cmake
@@ -1,0 +1,62 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(ExternalProject)
+include(external/external-project-helpers)
+include(external/curl)
+include(external/crc32c)
+include(external/grpc)
+
+if (NOT TARGET google-cloud-cpp-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(
+        GOOGLE_CLOUD_CPP_URL
+        "https://github.com/googleapis/google-cloud-cpp/archive/92500a086cab360089fcb5581def5d62fcf1750a.tar.gz"
+        )
+    set(GOOGLE_CLOUD_CPP_SHA256
+        "6562597a7f4c2c9bc9bcfe4cdec6d410544ed16513ef84e883f995275a2d7cd1")
+    set(
+        GOOGLEAPIS_URL
+        "https://github.com/google/googleapis/archive/32a10f69e2c9ce15bba13ab1ff928bacebb25160.zip"
+        )
+    set(GOOGLEAPIS_SHA56
+        "2c5dc6d4575e0804ccf3ffb22ca36d68621013c0b2980042d6fb4a04a4447b17")
+
+    google_cloud_cpp_set_prefix_vars()
+
+    ExternalProject_Add(
+        google-cloud-cpp-project
+        DEPENDS grpc-project curl-project crc32c-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/google-cloud-cpp"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -DBUILD_TESTING=OFF
+                   -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package
+                   -DGOOGLE_CLOUD_CPP_GOOGLEAPIS_URL=${GOOGLEAPIS_URL}
+                   -DGOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256=${GOOGLEAPIS_SHA256}
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE OFF
+        LOG_BUILD OFF
+        LOG_INSTALL OFF)
+endif ()

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -1,0 +1,52 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(ExternalProject)
+include(external/external-project-helpers)
+
+if (NOT TARGET googletest-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(
+        GOOGLE_CLOUD_CPP_GOOGLETEST_URL
+        "https://github.com/google/googletest/archive/b6cd405286ed8635ece71c72f118e659f4ade3fb.tar.gz"
+        )
+    set(GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256
+        "8d9aa381a6885fe480b7d0ce8ef747a0b8c6ee92f99d74ab07e3503434007cb0")
+
+    google_cloud_cpp_set_prefix_vars()
+
+    ExternalProject_Add(
+        googletest-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/googletest"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_GOOGLETEST_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLETEST_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -G${CMAKE_GENERATOR}
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -1,0 +1,59 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(ExternalProject)
+include(external/external-project-helpers)
+include(external/c-ares)
+include(external/ssl)
+include(external/protobuf)
+
+if (NOT TARGET gprc-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_GRPC_URL
+        "https://github.com/grpc/grpc/archive/v1.19.1.tar.gz")
+    set(GOOGLE_CLOUD_CPP_GRPC_SHA256
+        "f869c648090e8bddaa1260a271b1089caccbe735bf47ac9cd7d44d35a02fb129")
+
+    google_cloud_cpp_set_prefix_vars()
+
+    ExternalProject_Add(
+        grpc-project
+        DEPENDS c-ares-project protobuf-project ssl-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/grpc"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_GRPC_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GRPC_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -G${CMAKE_GENERATOR}
+                   -DgRPC_BUILD_TESTS=OFF
+                   -DgRPC_ZLIB_PROVIDER=package
+                   -DgRPC_SSL_PROVIDER=package
+                   -DgRPC_CARES_PROVIDER=package
+                   -DgRPC_PROTOBUF_PROVIDER=package
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -1,0 +1,59 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+find_package(Threads REQUIRED)
+include(ExternalProject)
+include(external/external-project-helpers)
+include(external/zlib)
+
+if (NOT TARGET protobuf-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_PROTOBUF_URL
+        "https://github.com/google/protobuf/archive/v3.6.1.tar.gz")
+    set(GOOGLE_CLOUD_CPP_PROTOBUF_SHA256
+        "3d4e589d81b2006ca603c1ab712c9715a76227293032d05b26fca603f90b3f5b")
+
+    google_cloud_cpp_set_prefix_vars()
+
+    ExternalProject_Add(
+        protobuf-project
+        DEPENDS zlib-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/protobuf"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_PROTOBUF_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_PROTOBUF_SHA256}
+        LIST_SEPARATOR |
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND}
+            -G${CMAKE_GENERATOR}
+            -Dprotobuf_BUILD_TESTS=OFF
+            -Dprotobuf_DEBUG_POSTFIX=
+            -H<SOURCE_DIR>/cmake
+            -B<BINARY_DIR>
+            -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+            -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/cmake/external/ssl.cmake
+++ b/cmake/external/ssl.cmake
@@ -1,0 +1,26 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+if (NOT TARGET ssl-project)
+    # For OpenSSL we don't really support external projects. OpenSSL build
+    # system is notoriously finicky. Use vcpkg on Windows, or install OpenSSL
+    # using your operating system packages instead.
+    #
+    # This file is here to simplify the definition of external projects, such as
+    # curl and gRPC, that depend on a SSL library.
+    find_package(OpenSSL REQUIRED)
+    add_custom_target(ssl-project)
+endif ()

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -1,0 +1,51 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(ExternalProject)
+include(external/external-project-helpers)
+
+if (NOT TARGET zlib-project)
+    # Give application developers a hook to configure the version and hash
+    # downloaded from GitHub.
+    set(GOOGLE_CLOUD_CPP_ZLIB_URL
+        "https://github.com/madler/zlib/archive/v1.2.11.tar.gz")
+    set(GOOGLE_CLOUD_CPP_ZLIB_SHA256
+        "629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff")
+
+    google_cloud_cpp_set_prefix_vars()
+
+    ExternalProject_Add(
+        zlib-project
+        EXCLUDE_FROM_ALL ON
+        PREFIX "${CMAKE_BINARY_DIR}/external/zlib"
+        INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
+        URL ${GOOGLE_CLOUD_CPP_ZLIB_URL}
+        URL_HASH SHA256=${GOOGLE_CLOUD_CPP_ZLIB_SHA256}
+        LIST_SEPARATOR |
+        CMAKE_ARGS -G${CMAKE_GENERATOR}
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
+                   -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
+                   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        BUILD_COMMAND ${CMAKE_COMMAND}
+                      --build
+                      <BINARY_DIR>
+                      ${PARALLEL}
+        BUILD_BYPRODUCTS ${zlib_byproducts}
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        LOG_INSTALL ON)
+endif ()

--- a/doc/setup-cmake-environment.md
+++ b/doc/setup-cmake-environment.md
@@ -39,6 +39,34 @@ The build takes a few minutes the first time, as it needs to create a Docker
 image with all the development tools and dependencies installed. Future builds
 (with no changes to the source) take only a few seconds.
 
+## Install the dependencies in `$HOME/local`.
+
+This is the recommended way to develop `google-cloud-cpp-spanner` using CMake.
+You will install the dependencies in `$HOME/local` (or a similar directory), and
+compile the project against these libraries. The installation needs to be done
+every time the version of the dependencies is changed, and it is not done
+automatically. But once installed you can use them for any build.
+
+Configure the super-build to install in `$HOME/local`:
+
+```console
+cmake -Hci/kokoro/cmake/super-build -Bcmake-out/super-install \
+    -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
+```
+
+Install the dependencies:
+
+```console
+cmake --build cmake-out/super-install -- -j $(nproc)
+```
+
+Now you can use these dependencies multiple times, configure the project to
+use them:
+
+```console
+cmake -H. -Bcmake-out/home -DCMAKE_PREFIX_PATH=$HOME/local
+```
+
 ## Using `vcpkg` to install the dependencies
 
 `vcpkg` is a package manager that installs dependencies from source. All the
@@ -101,7 +129,3 @@ Or:
 ```console
 cmake --build cmake-out/vcpkg --target test
 ```
-
-## Install the dependencies in `$HOME/local`.
-
-<!-- TODO(#40) - create instructions for this case -->

--- a/doc/setup-cmake-environment.md
+++ b/doc/setup-cmake-environment.md
@@ -50,7 +50,7 @@ automatically. But once installed you can use them for any build.
 Configure the super-build to install in `$HOME/local`:
 
 ```console
-cmake -Hci/kokoro/cmake/super-build -Bcmake-out/super-install \
+cmake -Hci/super -Bcmake-out/super-install \
     -DGOOGLE_CLOUD_CPP_EXTERNAL_PREFIX=$HOME/local
 ```
 
@@ -60,8 +60,8 @@ Install the dependencies:
 cmake --build cmake-out/super-install -- -j $(nproc)
 ```
 
-Now you can use these dependencies multiple times, configure the project to
-use them:
+Now you can use these dependencies multiple times. To use them, add the
+`$HOME/local` directory to `CMAKE_PREFIX_PATH` when you configure the project:
 
 ```console
 cmake -H. -Bcmake-out/home -DCMAKE_PREFIX_PATH=$HOME/local
@@ -75,8 +75,8 @@ However, some of the dependencies, such as `google-cloud-cpp` are only updated
 monthly. If at some point the Spanner client depends on recent changes on
 `google-cloud-cpp` this strategy will not work for you.
 
-With that out of the way, installing Ninja is recommended, because it makes the
-`vcpkg` builds faster, but not required:
+Though not required, we recommend that you install Ninja as it significantly
+speeds up the `vcpkg` builds:
 
 ```console
 sudo apt update && sudo apt install ninja-build
@@ -102,8 +102,8 @@ Once `vcpkg` is built, install all dependencies:
 ./vcpkg install google-cloud-cpp gtest
 ```
 
-Configure the project, using `vcpkg` to find the dependencies, we recommend
-using a sub-directory of `cmake-out` because the CI builds also use
+When you configure the project, set `CMAKE_TOOLCHAIN_FILE` to use `vcpkg`.
+We recommend using a sub-directory of `cmake-out` because the CI builds also use
 sub-directories of `cmake-out/`:
 
 ```console


### PR DESCRIPTION
Create configuration files to verify our CMake files can be used as part
of a super-build.  These should probably live in google-cloud-cpp, but we
need to do a lot of refactoring there to allow this.

As a side benefit, we get a relatively easy way to install all the
dependencies in $HOME/local (or a similar directory). This is more
flexible than `vcpkg`, and less cumbersome than installing in
`/usr/local/`.

Add CI build configuration to automatically test this, though an additional
internal CL will be needed to enable this. 

Fixes #40 and fixes #42.