### PR TITLE
Enable clang-tidy and -Werror.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,8 @@ Checks: >-
   readability-*,
   performance-*,
   -google-readability-namespace-comments,
-  -readability-named-parameter
+  -readability-braces-around-statements,
+  -readability-magic-numbers
 
 # Enable most warnings as errors.
 WarningsAsErrors: >-
@@ -22,7 +23,9 @@ WarningsAsErrors: >-
   misc-*,
   modernize-*,
   readability-*,
-  performance-*
+  performance-*,
+  -readability-braces-around-statements,
+  -readability-magic-numbers
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
@@ -34,7 +37,11 @@ CheckOptions:
   - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
   - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
   - { key: readability-identifier-naming.MacroDefinitionCase,    value: UPPER_CASE }
-  - { key: readability-identifier-naming.EnumConstantCase,       value: UPPER_CASE }
-  - { key: readability-identifier-naming.ConstexprVariableCase,  value: UPPER_CASE }
-  - { key: readability-identifier-naming.GlobalConstantCase,     value: UPPER_CASE }
-  - { key: readability-identifier-naming.MemberConstantCase,     value: UPPER_CASE }
+  - { key: readability-identifier-naming.EnumConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantPrefix,     value: k }
+  - { key: readability-identifier-naming.ConstexprVariableCase,  value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix, value: k }
+  - { key: readability-identifier-naming.GlobalConstantCase,     value: CamelCase }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,   value: k }
+  - { key: readability-identifier-naming.MemberConstantCase,     value: CamelCase }
+  - { key: readability-identifier-naming.MemberConstantPrefix,   value: k }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >-
   readability-*,
   performance-*,
   -google-readability-namespace-comments,
+  -readability-named-parameter,
   -readability-braces-around-statements,
   -readability-magic-numbers
 

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -19,8 +19,9 @@ FROM fedora:${DISTRO_VERSION}
 # for `google-cloud-cpp`. Install these packages and additional development
 # tools to compile the dependencies:
 RUN dnf makecache && \
-    dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig zlib-devel \
-                   grpc-devel grpc-plugins \
+    dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
+                   grpc-devel grpc-plugins clang clang-tools-extra \
+                   libcxx-devel libcxxabi-devel \
                    libcurl-devel protobuf-compiler tar wget zlib-devel
 
 # There is no Fedora package for CRC32C, download and install from source.

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -47,15 +47,15 @@ fi
 cmake "-H${SOURCE_DIR}" "-B${BINARY_DIR}" "${cmake_flags[@]}"
 cmake --build "${BINARY_DIR}" -- -j "$(nproc)"
 
-echo "================================================================"
-echo "Running the unit tests $(date)"
-echo "================================================================"
 # When user a super-build the tests are hidden in a subdirectory. We can tell
 # that ${BINARY_DIR} does not have the tests by checking for this file:
-if [[ -f "${BINARY_DIR}/CTestTestFile.cmake}" ]]; then
+if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
+  echo "================================================================"
   # It is Okay to skip the tests in this case because the super build
   # automatically runs them.
   env -C "${BINARY_DIR}" ctest --output-on-failure -j "$(nproc)"
+  echo "Running the unit tests $(date)"
+  echo "================================================================"
 fi
 
 echo "================================================================"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -39,7 +39,12 @@ echo "================================================================"
 echo "Compiling on $(date)"
 echo "================================================================"
 cd "${PROJECT_ROOT}"
-cmake "-H${SOURCE_DIR}" "-B${BINARY_DIR}"
+cmake_flags=()
+if [[ "${CLANG_TIDY:-}" = "yes" ]]; then
+  cmake_flags+=("-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes")
+fi
+
+cmake "-H${SOURCE_DIR}" "-B${BINARY_DIR}" "${cmake_flags[@]}"
 cmake --build "${BINARY_DIR}" -- -j "$(nproc)"
 
 echo "================================================================"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -30,10 +30,14 @@ if [[ "${BUILD_NAME+x}" != "x" ]]; then
 elif [[ "${BUILD_NAME}" = "clang-tidy" ]]; then
   # Compile with clang-tidy(1) turned on. The build treats clang-tidy warnings
   # as errors.
+  export DISTRO=fedora-install
+  export DISTRO_VERSION=30
   export CC=clang
   export CXX=clang++
   export CHECK_STYLE=yes
   export GENERATE_DOCS=yes
+  export CLANG_TIDY=yes
+  in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "integration" ]]; then
   export CC=gcc
   export CXX=g++
@@ -119,6 +123,7 @@ sudo docker run \
      --env CC="${CC}" \
      --env NCPU="${NCPU:-2}" \
      --env CHECK_STYLE="${CHECK_STYLE:-}" \
+     --env CLANG_TIDY="${CLANG_TIDY:-}" \
      --env BAZEL_CONFIG="${BAZEL_CONFIG:-}" \
      --env RUN_INTEGRATION_TESTS="${RUN_INTEGRATION_TESTS:-}" \
      --env TERM="${TERM:-dumb}" \

--- a/cmake/EnableClangTidy.cmake
+++ b/cmake/EnableClangTidy.cmake
@@ -1,0 +1,42 @@
+# ~~~
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+option(GOOGLE_CLOUD_CPP_CLANG_TIDY
+       "If set compiles the Cloud Cloud C++ Libraries with clang-tidy." "")
+
+if (${CMAKE_VERSION} VERSION_LESS "3.6")
+    message(STATUS "clang-tidy is not enabled because cmake version is too old")
+else()
+    if (${CMAKE_VERSION} VERSION_LESS "3.8")
+        message(WARNING "clang-tidy exit code ignored in this version of cmake")
+    endif ()
+    find_program(CLANG_TIDY_EXE
+                 NAMES "clang-tidy"
+                 DOC "Path to clang-tidy executable")
+
+    if (NOT CLANG_TIDY_EXE)
+        message(STATUS "clang-tidy not found.")
+    else()
+        message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+    endif ()
+endif ()
+
+function (google_cloud_cpp_add_clang_tidy target)
+    if (CLANG_TIDY_EXE AND GOOGLE_CLOUD_CPP_CLANG_TIDY)
+        set_target_properties(${target}
+                PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+    endif ()
+endfunction ()

--- a/cmake/EnableWerror.cmake
+++ b/cmake/EnableWerror.cmake
@@ -1,0 +1,40 @@
+# ~~~
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# Find out what flags turn on all available warnings and turn those warnings
+# into errors.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-Wall GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WALL)
+check_cxx_compiler_flag(-Wextra GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WEXTRA)
+check_cxx_compiler_flag(-Werror GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR)
+
+function (google_cloud_cpp_add_common_options target)
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WALL)
+        target_compile_options(${target} PRIVATE "-Wall")
+    endif ()
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WEXTRA)
+        target_compile_options(${target} PRIVATE "-Wextra")
+    endif ()
+    if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_WERROR)
+        target_compile_options(${target} PRIVATE "-Werror")
+    endif ()
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
+            AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 5.0)
+        # With GCC 4.x this warning is too noisy to be useful.
+        target_compile_options(${target}
+                PRIVATE "-Wno-missing-field-initializers")
+    endif ()
+endfunction ()

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -17,6 +17,9 @@
 find_package(google_cloud_cpp_common CONFIG REQUIRED)
 find_package(googleapis CONFIG REQUIRED)
 
+include(EnableClangTidy)
+include(EnableWerror)
+
 # TODO(#43) - generate version_info.h in the source directory and commit it.
 configure_file(version_info.h.in version_info.h)
 add_library(spanner_client
@@ -37,6 +40,8 @@ set_target_properties(spanner_client
                                  "${SPANNER_CLIENT_VERSION}"
                                  SOVERSION
                                  "${SPANNER_CLIENT_VERSION_MAJOR}")
+google_cloud_cpp_add_clang_tidy(spanner_client)
+google_cloud_cpp_add_common_options(spanner_client)
 
 add_library(googleapis-c++::spanner_client ALIAS spanner_client)
 
@@ -92,6 +97,9 @@ function (spanner_client_define_tests)
                                       GTest::gmock_main
                                       GTest::gmock
                                       GTest::gtest)
+        google_cloud_cpp_add_clang_tidy(${target})
+        google_cloud_cpp_add_common_options(${target})
+
         # With googletest it is relatively easy to exceed the default number of
         # sections (~65,000) in a single .obj file. Add the /bigobj option to
         # all the tests, even if it is not needed.

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -64,8 +64,8 @@ bool Equal(google::spanner::v1::Type const& pt1,
           return false;
         }
       }
+      return true;
     }
-    // FALLTHROUGH
     default:
       return true;
   }

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -45,8 +45,9 @@ bool Equal(google::spanner::v1::Type const& pt1,
       return pv1.string_value() == pv2.string_value();
     case google::spanner::v1::TypeCode::FLOAT64:
       // NaN should always compare not equal, even to itself.
-      if (pv1.string_value() == "NaN" || pv2.string_value() == "NaN")
+      if (pv1.string_value() == "NaN" || pv2.string_value() == "NaN") {
         return false;
+      }
       return pv1.string_value() == pv2.string_value() &&
              pv1.number_value() == pv2.number_value();
     case google::spanner::v1::TypeCode::STRING:
@@ -97,7 +98,7 @@ Value::Value(std::string v) {
   value_.set_string_value(std::move(v));
 }
 
-bool operator==(Value a, Value b) {
+bool operator==(Value const& a, Value const& b) {
   return Equal(a.type_, a.value_, b.type_, b.value_);
 }
 
@@ -153,7 +154,7 @@ std::int64_t Value::GetValue(std::int64_t, google::protobuf::Value const& pv) {
   if (processed != s.size()) {
     GCP_LOG(FATAL) << "Failed to parse number from string: \"" << s << "\"";
   }
-  return {x};
+  return x;
 }
 
 double Value::GetValue(double, google::protobuf::Value const& pv) {

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -65,6 +65,7 @@ bool Equal(google::spanner::v1::Type const& pt1,
         }
       }
     }
+    // FALLTHROUGH
     default:
       return true;
   }

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -133,8 +133,8 @@ class Value {
     }
   }
 
-  friend bool operator==(Value a, Value b);
-  friend bool operator!=(Value a, Value b) { return !(a == b); }
+  friend bool operator==(Value const& a, Value const& b);
+  friend bool operator!=(Value const& a, Value const& b) { return !(a == b); }
 
   /**
    * Returns true if the contained value is of the specified type `T`.

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -89,7 +89,8 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(v);
   }
 
-  for (auto x : std::vector<std::string>{"", "f", "foo", "12345678901234567"}) {
+  for (auto const& x :
+       std::vector<std::string>{"", "f", "foo", "12345678901234567"}) {
     SCOPED_TRACE("Testing: std::string " + std::string(x));
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<std::string>(5, x));


### PR DESCRIPTION
Enable clang-tidy (with warnings-as-errors), -Wall, -Wextra, and
-Werror. This commit will not fix any issues in the code, I want a build
that captures all the errors.

Fixes #62 and fixes #25.