### PR TITLE
Add support for Doxygen and run it in a build.

### DIFF
--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -19,10 +19,9 @@ FROM fedora:${DISTRO_VERSION}
 # for `google-cloud-cpp`. Install these packages and additional development
 # tools to compile the dependencies:
 RUN dnf makecache && \
-    dnf install -y cmake gcc-c++ git make openssl-devel pkgconfig \
-                   grpc-devel grpc-plugins clang clang-tools-extra \
-                   libcxx-devel libcxxabi-devel \
-                   libcurl-devel protobuf-compiler tar wget zlib-devel
+    dnf install -y clang clang-tools-extra cmake doxygen gcc-c++ git \
+        grpc-devel grpc-plugins libcxx-devel libcxxabi-devel libcurl-devel \
+        make openssl-devel pkgconfig protobuf-compiler tar wget zlib-devel
 
 # There is no Fedora package for CRC32C, download and install from source.
 WORKDIR /var/tmp/build

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -58,6 +58,13 @@ if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
   echo "================================================================"
 fi
 
+if [[ "${GENERATE_DOCS:-}" = "yes" ]]; then
+  echo "================================================================"
+  echo "Validate Doxygen documentation $(date)"
+  cmake --build "${BUILD_OUTPUT}" --target doxygen-docs
+  echo "================================================================"
+fi
+
 echo "================================================================"
 echo "Build finished at $(date)"
 echo "================================================================"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -61,7 +61,7 @@ fi
 if [[ "${GENERATE_DOCS:-}" = "yes" ]]; then
   echo "================================================================"
   echo "Validate Doxygen documentation $(date)"
-  cmake --build "${BUILD_OUTPUT}" --target doxygen-docs
+  cmake --build "${BINARY_DIR}" --target doxygen-docs
   echo "================================================================"
 fi
 

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -124,6 +124,7 @@ sudo docker run \
      --env NCPU="${NCPU:-2}" \
      --env CHECK_STYLE="${CHECK_STYLE:-}" \
      --env CLANG_TIDY="${CLANG_TIDY:-}" \
+     --env GENERATE_DOCS="${GENERATE_DOCS:-}" \
      --env BAZEL_CONFIG="${BAZEL_CONFIG:-}" \
      --env RUN_INTEGRATION_TESTS="${RUN_INTEGRATION_TESTS:-}" \
      --env TERM="${TERM:-dumb}" \

--- a/cmake/EnableDoxygen.cmake
+++ b/cmake/EnableDoxygen.cmake
@@ -1,0 +1,78 @@
+# ~~~
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+if (${CMAKE_VERSION} VERSION_LESS "3.9")
+
+    # Old versions of CMake have really poor support for Doxygen generation.
+    message(STATUS "Doxygen generation only enabled for cmake 3.9 and higher")
+else()
+    # Automatically download the Doxygen documentation for `std::` from
+    # https://cppreference.com
+
+    find_package(Doxygen)
+    if (Doxygen_FOUND)
+        set(DOXYGEN_RECURSIVE YES)
+        set(DOXYGEN_FILE_PATTERNS *.h *.cc *.proto *.dox)
+        set(DOXYGEN_EXAMPLE_RECURSIVE YES)
+        set(DOXYGEN_EXCLUDE "third_party" "cmake-build-debug" "cmake-out")
+        set(DOXYGEN_EXCLUDE_SYMLINKS YES)
+        set(DOXYGEN_QUIET YES)
+        set(DOXYGEN_WARN_AS_ERROR YES)
+        set(DOXYGEN_INLINE_INHERITED_MEMB YES)
+        set(DOXYGEN_JAVADOC_AUTOBRIEF YES)
+        set(DOXYGEN_BUILTIN_STL_SUPPORT YES)
+        set(DOXYGEN_IDL_PROPERTY_SUPPORT NO)
+        set(DOXYGEN_EXTRACT_ALL YES)
+        set(DOXYGEN_EXTRACT_STATIC YES)
+        set(DOXYGEN_SORT_MEMBERS_CTORS_1ST YES)
+        set(DOXYGEN_GENERATE_TODOLIST NO)
+        set(DOXYGEN_GENERATE_BUGLIST NO)
+        set(DOXYGEN_GENERATE_TESTLIST NO)
+        set(DOXYGEN_CLANG_ASSISTED_PARSING YES)
+        set(DOXYGEN_CLANG_OPTIONS
+                "-std=c++11 -I${PROJECT_SOURCE_DIR} -I${PROJECT_BINARY_DIR}")
+        set(DOXYGEN_GENERATE_LATEX NO)
+        set(DOXYGEN_GRAPHICAL_HIERARCHY NO)
+        set(DOXYGEN_DIRECTORY_GRAPH NO)
+        set(DOXYGEN_CLASS_GRAPH NO)
+        set(DOXYGEN_COLLABORATION_GRAPH NO)
+        set(DOXYGEN_INCLUDE_GRAPH NO)
+        set(DOXYGEN_INCLUDED_BY_GRAPH NO)
+        set(DOXYGEN_DOT_TRANSPARENT YES)
+        set(DOXYGEN_MACRO_EXPANSION YES)
+        set(DOXYGEN_EXPAND_ONLY_PREDEF YES)
+        set(DOXYGEN_HTML_TIMESTAMP)
+        set(DOXYGEN_STRIP_FROM_INC_PATH "${PROJECT_SOURCE_DIR}")
+        set(DOXYGEN_SHOW_USED_FILES NO)
+        set(DOXYGEN_REFERENCES_LINK_SOURCE NO)
+        set(DOXYGEN_SOURCE_BROWSER YES)
+        set(DOXYGEN_GENERATE_TAGFILE
+                "${CMAKE_CURRENT_BINARY_DIR}/${GOOGLE_CLOUD_CPP_SUBPROJECT}.tag")
+        set(DOXYGEN_EXCLUDE_SYMBOL "internal")
+        set(DOXYGEN_PREDEFINED "SPANNER_CLIENT_NS=v${SPANNER_CLIENT_VERSION_MAJOR}")
+        set(DOXYGEN_EXCLUDE_PATTERNS
+                "*/google/cloud/spanner/README.md"
+                "*/google/cloud/spanner/internal/*"
+                "*/google/cloud/spanner/*_test.cc")
+
+        doxygen_add_docs(doxygen-docs
+                ${CMAKE_CURRENT_SOURCE_DIR}
+                WORKING_DIRECTORY
+                ${CMAKE_CURRENT_SOURCE_DIR}
+                COMMENT
+                "Generate HTML documentation")
+    endif ()
+endif ()

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -19,6 +19,10 @@ find_package(googleapis CONFIG REQUIRED)
 
 include(EnableClangTidy)
 include(EnableWerror)
+set(DOXYGEN_PROJECT_NAME "Google Cloud Spanner C++ Client")
+set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Spanner")
+set(DOXYGEN_PROJECT_NUMBER "${SPANNER_VERSION}")
+include(EnableDoxygen)
 
 # TODO(#43) - generate version_info.h in the source directory and commit it.
 configure_file(version_info.h.in version_info.h)

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -38,16 +38,16 @@ inline namespace SPANNER_CLIENT_NS {
  * with how they map to the Spanner types
  * (https://cloud.google.com/spanner/docs/data-types):
  *
- *     Spanner Type | C++ Type
- *     -----------------------
- *     BOOL         | bool
- *     INT64        | std::int64_t
- *     FLOAT64      | double
- *     STRING       | std::string
- *     ARRAY        | std::vector<T>  // [1]
+ * Spanner Type | C++ Type
+ * ------------ | --------
+ * BOOL         | `bool`
+ * INT64        | `std::int64_t`
+ * FLOAT64      | `double`
+ * STRING       | `std::string`
+ * ARRAY        | `std::vector<T>`  // [1]
  *
  * [1] The type `T` may be any of the other supported types, except for
- *     ARRAY/std::vector.
+ *     ARRAY/`std::vector`.
  *
  * Value is a regular C++ value type with support for copy, move, equality,
  * etc, but there is no default constructor because there is no default type.
@@ -219,7 +219,7 @@ class Value {
   }
 
   /**
-   * Returns the contained value iff is<T>() and !is_null<T>().
+   * Returns the contained value iff `is<T>()` and `!is_null<T>()`.
    *
    * It is the caller's responsibility to ensure that the specified type
    * `T` is correct (e.g., with `is<T>()`) and that the value is not "null"


### PR DESCRIPTION
This enables support for Doxygen in CMake. Assuming you have Doxygen
installed: `cmake --build cmake-out --target doxygen-docs` will generate
the Doxygen documentation (as HTML). I enabled this in one of the CI
builds because this checks that the documentation "compiles", for
example, any cross-references must be valid.

Part of the work for #8.
