### PR TITLE
Cleanup: Prefer GetType() over type_.set_code; MakeNull is now a non-member

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -74,17 +74,17 @@ bool Equal(google::spanner::v1::Type const& pt1,
 }  // namespace
 
 Value::Value(bool v) {
-  type_.set_code(google::spanner::v1::TypeCode::BOOL);
+  type_ = GetType(bool{});
   value_.set_bool_value(v);
 }
 
 Value::Value(std::int64_t v) {
-  type_.set_code(google::spanner::v1::TypeCode::INT64);
+  type_ = GetType(std::int64_t{});
   value_.set_string_value(std::to_string(v));
 }
 
 Value::Value(double v) {
-  type_.set_code(google::spanner::v1::TypeCode::FLOAT64);
+  type_ = GetType(double{});
   if (std::isnan(v)) {
     value_.set_string_value("NaN");
   } else if (std::isinf(v)) {
@@ -95,7 +95,7 @@ Value::Value(double v) {
 }
 
 Value::Value(std::string v) {
-  type_.set_code(google::spanner::v1::TypeCode::STRING);
+  type_ = GetType(std::string{});
   value_.set_string_value(std::move(v));
 }
 

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -53,7 +53,7 @@ inline namespace SPANNER_CLIENT_NS {
  * etc, but there is no default constructor because there is no default type.
  * Callers may create instances by passing any of the supported values (shown
  * in the table above) to the constructor. "Null" values are created using the
- * `Value::MakeNull<T>()` factory function or by passing an empty `optional<T>`
+ * `MakeNullValue<T>()` factory function or by passing an empty `optional<T>`
  * to the Value constructor..
  *
  * Example with a non-null value:
@@ -69,7 +69,7 @@ inline namespace SPANNER_CLIENT_NS {
  *
  * Example with a null:
  *
- *     spanner::Value v = spanner::Value::MakeNull<std::int64_t>();
+ *     spanner::Value v = spanner::MakeNullValue<std::int64_t>();
  *     assert(v.is<std::int64_t>());
  *     assert(v.is_null<std::int64_t>());
  *     StatusOr<std::int64_t> i = v.get<std::int64_t>();
@@ -79,17 +79,6 @@ inline namespace SPANNER_CLIENT_NS {
  */
 class Value {
  public:
-  /**
-   * Factory to construct a "null" Value of the specified type `T`.
-   *
-   * This is equivalent to passing to the constructor an `optional<T>` without
-   * a value, though this factory may result in clearer code at the call site.
-   */
-  template <typename T>
-  static Value MakeNull() {
-    return Value(optional<T>{});
-  }
-
   Value() = delete;
 
   /// Copy and move.
@@ -148,7 +137,7 @@ class Value {
    *     assert(v.is<bool>());  // Same as the following
    *     assert(v.is<optional<bool>>());
    *
-   *     spanner::Value null_v = spanner::Value::MakeNull<bool>();
+   *     spanner::Value null_v = spanner::MakeNullValue<bool>();
    *     assert(v.is<bool>());  // Same as the following
    *     assert(v.is<optional<bool>>());
    */
@@ -169,7 +158,7 @@ class Value {
    *     assert(!v.is_null<bool>());  // Same as the following
    *     assert(!v.is_null<optional<bool>>());
    *
-   *     spanner::Value null_v = spanner::Value::MakeNull<bool>();
+   *     spanner::Value null_v = spanner::MakeNullValue<bool>();
    *     assert(v.is_null<bool>());  // Same as the following
    *     assert(v.is_null<optional<bool>>());
    *     assert(!v.is_null<std::int64_t>());  // Same as the following
@@ -197,7 +186,7 @@ class Value {
    *     }
    *
    *     // Now using a "null" std::int64_t
-   *     v = spanner::Value::MakeNull<std::int64_t>();
+   *     v = spanner::MakeNullValue<std::int64_t>();
    *     assert(v.is_null<std::int64_t>());
    *     StatusOr<std::int64_t> i = v.get<std::int64_t>();
    *     if (!i) {
@@ -232,7 +221,7 @@ class Value {
    *     spanner::Value v{true};
    *     bool b = static_cast<bool>(v);  // OK: b == true
    *
-   *     spanner::Value null_v = spanner::Value::MakeNull<std::int64_t>();
+   *     spanner::Value null_v = spanner::MakeNullValue<std::int64_t>();
    *     std::int64_t i = static_cast<std::int64_t>(null_v);  // UB! null
    *     bool bad = static_cast<bool>(null_v);  // UB! wrong type
    */
@@ -304,6 +293,18 @@ class Value {
   google::spanner::v1::Type type_;
   google::protobuf::Value value_;
 };
+
+/**
+ * Factory to construct a "null" Value of the specified type `T`.
+ *
+ * This is equivalent to passing to the constructor an `optional<T>` without a
+ * value, though this factory may be easier to invoke and result in clearer
+ * code at the call site.
+ */
+template <typename T>
+static Value MakeNullValue() {
+  return Value(optional<T>{});
+}
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -302,7 +302,7 @@ class Value {
  * code at the call site.
  */
 template <typename T>
-static Value MakeNullValue() {
+Value MakeNullValue() {
   return Value(optional<T>{});
 }
 

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -297,9 +297,9 @@ class Value {
 /**
  * Factory to construct a "null" Value of the specified type `T`.
  *
- * This is equivalent to passing to the constructor an `optional<T>` without a
- * value, though this factory may be easier to invoke and result in clearer
- * code at the call site.
+ * This is equivalent to passing an `optional<T>` without a value to the
+ * constructor, though this factory may be easier to invoke and result in
+ * clearer code at the call site.
  */
 template <typename T>
 Value MakeNullValue() {

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -40,7 +40,7 @@ void TestBasicSemantics(T init) {
   EXPECT_EQ(moved, v);
 
   // Tests a null Value of type `T`.
-  Value const null = Value::MakeNull<T>();
+  Value const null = MakeNullValue<T>();
 
   EXPECT_TRUE(null.is<T>());
   EXPECT_TRUE(null.is_null<T>());
@@ -125,7 +125,7 @@ TEST(Value, MixingTypes) {
   EXPECT_FALSE(a.is_null<B>());
   EXPECT_FALSE(a.get<B>().ok());
 
-  Value null_a = Value::MakeNull<A>();
+  Value null_a = MakeNullValue<A>();
   EXPECT_TRUE(null_a.is<A>());
   EXPECT_TRUE(null_a.is_null<A>());
   EXPECT_FALSE(null_a.get<A>().ok());
@@ -146,7 +146,7 @@ TEST(Value, MixingTypes) {
   EXPECT_NE(b, a);
   EXPECT_NE(b, null_a);
 
-  Value null_b = Value::MakeNull<B>();
+  Value null_b = MakeNullValue<B>();
   EXPECT_TRUE(null_b.is<B>());
   EXPECT_TRUE(null_b.is_null<B>());
   EXPECT_FALSE(null_b.get<B>().ok());
@@ -185,14 +185,14 @@ TEST(Value, SpannerArray) {
   EXPECT_TRUE(vd.get<ArrayDouble>().ok());
   EXPECT_EQ(ad, *vd.get<ArrayDouble>());
 
-  Value const null_vi = Value::MakeNull<ArrayInt64>();
+  Value const null_vi = MakeNullValue<ArrayInt64>();
   EXPECT_EQ(null_vi, null_vi);
   EXPECT_NE(null_vi, vi);
   EXPECT_NE(null_vi, vd);
   EXPECT_FALSE(null_vi.get<ArrayInt64>().ok());
   EXPECT_FALSE(null_vi.get<ArrayDouble>().ok());
 
-  Value const null_vd = Value::MakeNull<ArrayDouble>();
+  Value const null_vd = MakeNullValue<ArrayDouble>();
   EXPECT_EQ(null_vd, null_vd);
   EXPECT_NE(null_vd, null_vi);
   EXPECT_NE(null_vd, vd);


### PR DESCRIPTION
With this refactoring, the GetType() helper is now the only place that
maps C++ types to spanner type codes (e.g., std::int64_t ->
TypeCode::INT64). All the constructors now call GetType() to set the
type_ data member.

Now that "MakeNull" no longer needs to call a private constructor, a
MakeNullValue() factory is only a convenience function and does not need
any private or friend access to the value class. Therefore, it's nice to
make this a non-member function, which increases encapsulation since
fewer functions have access to Value's non-public members (this is a
pattern encouraged by many including Scott Meyers). Also,
spanner::MakeNullValue() is two fewer characters (removes an unneeded
"::").

	modified:   value.cc
	modified:   value.h
	modified:   value_test.cc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/76)
<!-- Reviewable:end -->
