### PR TITLE
Refactored c'tor bodies to MakeValueProto() function.

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -20,10 +20,6 @@
 #include <ios>
 #include <string>
 
-// Implementation note: See
-// https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/type.proto
-// for details about how Spanner types should be encoded.
-
 namespace google {
 namespace cloud {
 namespace spanner {
@@ -74,29 +70,23 @@ bool Equal(google::spanner::v1::Type const& pt1,
 }  // namespace
 
 Value::Value(bool v) {
-  type_ = GetType(bool{});
-  value_.set_bool_value(v);
+  type_ = MakeTypeProto(v);
+  value_ = MakeValueProto(v);
 }
 
 Value::Value(std::int64_t v) {
-  type_ = GetType(std::int64_t{});
-  value_.set_string_value(std::to_string(v));
+  type_ = MakeTypeProto(v);
+  value_ = MakeValueProto(v);
 }
 
-Value::Value(double v) {
-  type_ = GetType(double{});
-  if (std::isnan(v)) {
-    value_.set_string_value("NaN");
-  } else if (std::isinf(v)) {
-    value_.set_string_value(v < 0 ? "-Infinity" : "Infinity");
-  } else {
-    value_.set_number_value(v);
-  }
+Value::Value(double d) {
+  type_ = MakeTypeProto(d);
+  value_ = MakeValueProto(d);
 }
 
-Value::Value(std::string v) {
-  type_ = GetType(std::string{});
-  value_.set_string_value(std::move(v));
+Value::Value(std::string s) {
+  type_ = MakeTypeProto(s);
+  value_ = MakeValueProto(s);
 }
 
 bool operator==(Value const& a, Value const& b) {
@@ -113,31 +103,65 @@ bool Value::ProtoEqual(google::protobuf::Message const& m1,
 }
 
 //
-// Value::GetType
+// Value::MakeTypeProto
 //
 
-google::spanner::v1::Type Value::GetType(bool) {
+google::spanner::v1::Type Value::MakeTypeProto(bool) {
   google::spanner::v1::Type t;
   t.set_code(google::spanner::v1::TypeCode::BOOL);
   return t;
 }
 
-google::spanner::v1::Type Value::GetType(std::int64_t) {
+google::spanner::v1::Type Value::MakeTypeProto(std::int64_t) {
   google::spanner::v1::Type t;
   t.set_code(google::spanner::v1::TypeCode::INT64);
   return t;
 }
 
-google::spanner::v1::Type Value::GetType(double) {
+google::spanner::v1::Type Value::MakeTypeProto(double) {
   google::spanner::v1::Type t;
   t.set_code(google::spanner::v1::TypeCode::FLOAT64);
   return t;
 }
 
-google::spanner::v1::Type Value::GetType(std::string const&) {
+google::spanner::v1::Type Value::MakeTypeProto(std::string const&) {
   google::spanner::v1::Type t;
   t.set_code(google::spanner::v1::TypeCode::STRING);
   return t;
+}
+
+//
+// Value::MakeValueProto
+//
+
+google::protobuf::Value Value::MakeValueProto(bool b) {
+  google::protobuf::Value v;
+  v.set_bool_value(b);
+  return v;
+}
+
+google::protobuf::Value Value::MakeValueProto(std::int64_t i) {
+  google::protobuf::Value v;
+  v.set_string_value(std::to_string(i));
+  return v;
+}
+
+google::protobuf::Value Value::MakeValueProto(double d) {
+  google::protobuf::Value v;
+  if (std::isnan(d)) {
+    v.set_string_value("NaN");
+  } else if (std::isinf(d)) {
+    v.set_string_value(d < 0 ? "-Infinity" : "Infinity");
+  } else {
+    v.set_number_value(d);
+  }
+  return v;
+}
+
+google::protobuf::Value Value::MakeValueProto(std::string s) {
+  google::protobuf::Value v;
+  v.set_string_value(s);
+  return v;
 }
 
 //

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -79,14 +79,14 @@ Value::Value(std::int64_t v) {
   value_ = MakeValueProto(v);
 }
 
-Value::Value(double d) {
-  type_ = MakeTypeProto(d);
-  value_ = MakeValueProto(d);
+Value::Value(double v) {
+  type_ = MakeTypeProto(v);
+  value_ = MakeValueProto(v);
 }
 
-Value::Value(std::string s) {
-  type_ = MakeTypeProto(s);
-  value_ = MakeValueProto(s);
+Value::Value(std::string v) {
+  type_ = MakeTypeProto(v);
+  value_ = MakeValueProto(std::move(v));
 }
 
 bool operator==(Value const& a, Value const& b) {
@@ -160,7 +160,7 @@ google::protobuf::Value Value::MakeValueProto(double d) {
 
 google::protobuf::Value Value::MakeValueProto(std::string s) {
   google::protobuf::Value v;
-  v.set_string_value(s);
+  v.set_string_value(std::move(s));
   return v;
 }
 


### PR DESCRIPTION
This refactoring makes all constructor bodies look the same: 1 statment
setting the type_ member using `MakeTypeProto()`, and 1 statement
setting the value_ member using `MakeValueProto()`. This way we can
re-use the make-a-value-proto logic without having to invoke the
constructor then steal the value_ data member from it.

This refactoring was done in preparation for adding Spanner Struct
support, which I suspect will involve some form of std::typle, which
should work well with helper functions like this.

	modified:   value.cc
	modified:   value.h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/77)
<!-- Reviewable:end -->
