### PR TITLE
fixed argument name mismatch

### DIFF
--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -88,10 +88,10 @@ class Value {
   Value& operator=(Value&&) = default;
 
   /// Constructs a non-null instance with the specified type and value.
-  explicit Value(bool v);
-  explicit Value(std::int64_t v);
-  explicit Value(double v);
-  explicit Value(std::string v);
+  explicit Value(bool b);
+  explicit Value(std::int64_t i);
+  explicit Value(double d);
+  explicit Value(std::string s);
 
   /**
    * Constructs a non-null instance if `opt` has a value, otherwise constructs


### PR DESCRIPTION
I broke the clang-tidy build in #77 

Fixing now. If the build is green, please feel free to merge this PR yourself to fix the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/78)
<!-- Reviewable:end -->
