### PR TITLE
Support builds with the MemorySanitizer.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,14 +41,16 @@ build:ubsan --linkopt=-fsanitize=undefined
 build:ubsan --linkopt=-lubsan
 build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 
-# TODO(#41): this does not work unless libc++ (or libstdc++) are also compiled
-# with -fsanitize=memory.
-# --config tsan: Memory Sanitizer
-# build:msan --strip=never
-# build:msan --copt=-fsanitize=memory
-# build:msan --copt=-O0
-# build:msan --copt=-fno-omit-frame-pointer
-# build:msan --copt=-fsanitize-memory-track-origins
-# build:msan --copt=-fsanitize-memory-use-after-dtor
-# build:msan --linkopt=-fsanitize=memory
-# build:msan --action_env=MSAN_OPTIONS=poison_in_dtor=1
+# --config msan: Memory Sanitizer
+build:msan --strip=never
+build:msan --copt=-fsanitize=memory
+build:msan --copt=-O0
+build:msan --copt=-fno-omit-frame-pointer
+build:msan --copt=-fsanitize-memory-track-origins
+build:msan --copt=-fsanitize-memory-use-after-dtor
+build:msan --linkopt=-fsanitize=memory
+build:msan --action_env=MSAN_OPTIONS=poison_in_dtor=1
+build:msan --cxxopt=-stdlib=libc++
+build:msan --linkopt=-stdlib=libc++
+build:msan --linkopt=-lc++
+build:msan --linkopt=-lc++abi

--- a/ci/kokoro/Dockerfile.fedora-libcxx-msan
+++ b/ci/kokoro/Dockerfile.fedora-libcxx-msan
@@ -1,0 +1,65 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=30
+FROM fedora:${DISTRO_VERSION}
+
+# Install the minimal packages needed to compile libcxx, install Bazel, and
+# then compile our code.
+RUN dnf makecache && \
+    dnf install -y clang clang-tools-extra cmake gcc-c++ git llvm-devel \
+        make ninja-build python3-lit tar unzip which wget xz
+
+WORKDIR /var/tmp/build
+RUN wget -q http://releases.llvm.org/8.0.0/libcxx-8.0.0.src.tar.xz
+RUN tar -xf libcxx-8.0.0.src.tar.xz
+RUN wget -q http://releases.llvm.org/8.0.0/libcxxabi-8.0.0.src.tar.xz
+RUN tar -xf libcxxabi-8.0.0.src.tar.xz
+
+# To build libc++abi we need to bootstrap libc++ without libc++abi first:
+RUN cmake -Hlibcxx-8.0.0.src -B.boot-libcxx -GNinja -Wno-dev \
+    -DLLVM_USE_SANITIZER=Memory -DLLVM_EXTERNAL_LIT=/usr/bin/lit \
+    -DLLVM_CONFIG_PATH=/usr/bin/llvm-config \
+    -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release  \
+    -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+RUN cmake --build .boot-libcxx --target cxx
+RUN cmake --build .boot-libcxx --target install-cxx
+
+# Compile libc++abi using the bootstrap version
+RUN cmake -Hlibcxxabi-8.0.0.src -B.build-libcxxabi -GNinja -Wno-dev \
+    -DLIBCXXABI_LIBCXX_PATH=/var/tmp/build/libcxx-8.0.0.src \
+    -DLLVM_USE_SANITIZER=Memory -DLLVM_EXTERNAL_LIT=/usr/bin/lit \
+    -DLLVM_CONFIG_PATH=/usr/bin/llvm-config \
+    -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release  \
+    -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+RUN cmake --build .build-libcxxabi --target check-cxxabi
+RUN cmake --build .build-libcxxabi --target install-cxxabi
+
+# After libc++abi is installed, compile test and install the libc++ library
+# again.
+RUN cmake -Hlibcxx-8.0.0.src -B.build-libcxx -GNinja -Wno-dev \
+    -DLIBCXX_CXX_ABI=libcxxabi \
+    -DLIBCXX_CXX_ABI_INCLUDE_PATHS=/var/tmp/build/libcxxabi-8.0.0.src/include \
+    -DLLVM_USE_SANITIZER=Memory -DLLVM_EXTERNAL_LIT=/usr/bin/lit \
+    -DLLVM_CONFIG_PATH=/usr/bin/llvm-config \
+    -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release  \
+    -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+# The tests for libcxx do not pass, mostly around the filesystem library, which
+# we do not care about.
+RUN cmake --build .build-libcxx --target cxx
+RUN cmake --build .build-libcxx --target install-cxx
+
+WORKDIR /var/tmp/ci
+COPY install-bazel.sh /var/tmp/ci
+RUN /var/tmp/ci/install-bazel.sh

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -54,6 +54,15 @@ elif [[ "${BUILD_NAME}" = "tsan" ]]; then
   export BAZEL_CONFIG=tsan
   export CC=clang
   export CXX=clang++
+elif [[ "${BUILD_NAME}" = "msan" ]]; then
+  # We use Fedora for this build because (1) I was able to find instructions on
+  # how to build libc++ with msan for that distribution, (2) Fedora has a
+  # relatively recent version of Clang (8.0 as I write this).
+  export DISTRO=fedora-libcxx-msan
+  export DISTRO_VERSION=30
+  export BAZEL_CONFIG=msan
+  export CC=clang
+  export CXX=clang++
 elif [[ "${BUILD_NAME}" = "cmake" ]]; then
   export DISTRO=fedora-install
   export DISTRO_VERSION=30

--- a/ci/kokoro/docker/msan-presubmit.cfg
+++ b/ci/kokoro/docker/msan-presubmit.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "msan"
+}

--- a/ci/kokoro/docker/msan.cfg
+++ b/ci/kokoro/docker/msan.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+build_file: "google-cloud-cpp-spanner/ci/kokoro/docker/build.sh"
+timeout_mins: 120
+
+env_vars {
+  key: "BUILD_NAME"
+  value: "msan"
+}


### PR DESCRIPTION
The MemorySanitizer will help us detect unitialized reads. This is the
one sanitizer that must be turned on for all the code, including the C++
library (presumably the C library too, but the C++ library seems to be
enough). In this PR we introduce support for the MemorySanitizer,
enabling the build would require a internal CL in Google.

This fixes #41. Incidentally, we get a CI build using libc++ on Linux too.
