### PR TITLE
Support building with gcc-4.8.

### DIFF
--- a/ci/kokoro/Dockerfile.centos
+++ b/ci/kokoro/Dockerfile.centos
@@ -1,0 +1,28 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DISTRO_VERSION=7
+FROM centos:${DISTRO_VERSION}
+
+RUN yum makecache && yum install -y \
+    gcc \
+    gcc-c++ \
+    git \
+    unzip \
+    wget \
+    which
+
+WORKDIR /var/tmp/ci
+COPY install-bazel.sh /var/tmp/ci
+RUN /var/tmp/ci/install-bazel.sh

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -70,6 +70,13 @@ elif [[ "${BUILD_NAME}" = "cmake" ]]; then
 elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
   export CMAKE_SOURCE_DIR="ci/super"
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
+elif [[ "${BUILD_NAME}" = "gcc-4.8" ]]; then
+  # The oldest version of GCC we support is 4.8, this build checks the code
+  # against that version. The use of CentOS 7 for that build is not a
+  # coincidence: the reason we support GCC 4.8 is to support this distribution
+  # (and its commercial cousin: RHEL 7).
+  export DISTRO=centos
+  export DISTRO_VERSION=7
 else
   echo "Unknown BUILD_NAME (${BUILD_NAME}). Fix the Kokoro .cfg file."
   exit 1

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -22,6 +22,15 @@
 
 namespace google {
 namespace cloud {
+
+void PrintTo(optional<bool> const& v, std::ostream* os) {
+  if (!v.has_value()) {
+    *os << "optional<bool>{}";
+    return;
+  }
+  *os << "optional<bool>{" << (v.value() ? "true" : "false") << "}";
+}
+
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 template <typename T>
@@ -60,7 +69,9 @@ TEST(Value, BasicSemantics) {
   for (auto x : {false, true}) {
     SCOPED_TRACE("Testing: bool " + std::to_string(x));
     TestBasicSemantics(x);
+    SCOPED_TRACE("Testing: vector<bool> " + std::to_string(x));
     TestBasicSemantics(std::vector<bool>(5, x));
+    SCOPED_TRACE("Testing: vector<optional<bool>> " + std::to_string(x));
     std::vector<optional<bool>> v(5, x);
     v.resize(10, x);
     TestBasicSemantics(v);

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -22,15 +22,6 @@
 
 namespace google {
 namespace cloud {
-
-void PrintTo(optional<bool> const& v, std::ostream* os) {
-  if (!v.has_value()) {
-    *os << "optional<bool>{}";
-    return;
-  }
-  *os << "optional<bool>{" << (v.value() ? "true" : "false") << "}";
-}
-
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 template <typename T>
@@ -69,9 +60,7 @@ TEST(Value, BasicSemantics) {
   for (auto x : {false, true}) {
     SCOPED_TRACE("Testing: bool " + std::to_string(x));
     TestBasicSemantics(x);
-    SCOPED_TRACE("Testing: vector<bool> " + std::to_string(x));
     TestBasicSemantics(std::vector<bool>(5, x));
-    SCOPED_TRACE("Testing: vector<optional<bool>> " + std::to_string(x));
     std::vector<optional<bool>> v(5, x);
     v.resize(10, x);
     TestBasicSemantics(v);


### PR DESCRIPTION
Create configuration files to build with gcc-4.8, the oldest compiler we are planning to support. A separate internal CL will enable this build.

