### PR TITLE
Update google-cloud-cpp.

### DIFF
--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -31,11 +31,11 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_googleapis_google_cloud_cpp" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp",
-            strip_prefix = "google-cloud-cpp-7fc1586a855dfb728d3285b6c7392834e7234f67",
+            strip_prefix = "google-cloud-cpp-75b62d0bb931d475137342d2d3932e588161fe95",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp/archive/7fc1586a855dfb728d3285b6c7392834e7234f67.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp/archive/75b62d0bb931d475137342d2d3932e588161fe95.tar.gz",
             ],
-            sha256 = "d7bd8767291ffbd74a325e30ec33a77ba59330cfd350ad4c3f82a0153937b07a",
+            sha256 = "1c9e1448b44c20ac901430bc37cc04c443afed938a4ab85d283dd34f15b0b5c1",
         )
 
     # Load a newer version of google test than what gRPC does.

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -40,9 +40,9 @@ RUN ldconfig
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/ec767162045961e59504978abdea8629e9299b2f.tar.gz
-RUN tar -xf ec767162045961e59504978abdea8629e9299b2f.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-ec767162045961e59504978abdea8629e9299b2f
+RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/75b62d0bb931d475137342d2d3932e588161fe95.tar.gz
+RUN tar -xf 75b62d0bb931d475137342d2d3932e588161fe95.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-75b62d0bb931d475137342d2d3932e588161fe95
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/cmake/external/google-cloud-cpp.cmake
+++ b/cmake/external/google-cloud-cpp.cmake
@@ -25,10 +25,10 @@ if (NOT TARGET google-cloud-cpp-project)
     # downloaded from GitHub.
     set(
         GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp/archive/ec767162045961e59504978abdea8629e9299b2f.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp/archive/75b62d0bb931d475137342d2d3932e588161fe95.tar.gz"
         )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "2ad5c670d08d94beea1d5d81fff37caf6bd5f18c914c4f8bc9a8accfd4636e1e")
+        "1c9e1448b44c20ac901430bc37cc04c443afed938a4ab85d283dd34f15b0b5c1")
     set(
         GOOGLEAPIS_URL
         "https://github.com/google/googleapis/archive/a8ee1416f4c588f2ab92da72e7c1f588c784d3e6.zip"

--- a/google/cloud/spanner/spanner_version_test.cc
+++ b/google/cloud/spanner/spanner_version_test.cc
@@ -46,7 +46,7 @@ TEST(StorageVersionTest, NoBuildInfoInRelease) {
     return;
   }
   EXPECT_THAT(version_string(),
-              Not(HasSubstr("+" + google::cloud::internal::gitrev())));
+              Not(HasSubstr("+" + google::cloud::internal::build_metadata())));
 }
 
 /// @test Verify the version has the build info for development builds.
@@ -55,7 +55,7 @@ TEST(StorageVersionTest, HasBuildInfoInDevelopment) {
     return;
   }
   EXPECT_THAT(version_string(),
-              HasSubstr("+" + google::cloud::internal::gitrev()));
+              HasSubstr("+" + google::cloud::internal::build_metadata()));
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/version.cc
+++ b/google/cloud/spanner/version.cc
@@ -27,7 +27,7 @@ std::string version_string() {
     os << "v" << version_major() << "." << version_minor() << "."
        << version_patch();
     if (!google::cloud::internal::is_release()) {
-      os << "+" << google::cloud::internal::gitrev();
+      os << "+" << google::cloud::internal::build_metadata();
     }
     return os.str();
   }();


### PR DESCRIPTION
We need to pick up the fixes to `google::cloud::optional` to support
gcc-4.8.
