### PR TITLE
Add the package for "shellcheck"

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -46,10 +46,10 @@ replace_original_if_changed() {
   local original="$1"
   local reformatted="$2"
 
-  chmod --reference="${original}" "${reformatted}"
   if cmp -s "${original}" "${reformatted}"; then
     rm -f "${reformatted}"
   else
+    chmod --reference="${original}" "${reformatted}"
     mv -f "${reformatted}" "${original}"
   fi
 }

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -21,8 +21,8 @@ FROM fedora:${DISTRO_VERSION}
 RUN dnf makecache && \
     dnf install -y clang clang-tools-extra cmake doxygen findutils gcc-c++ git \
         grpc-devel grpc-plugins libcxx-devel libcxxabi-devel libcurl-devel \
-        make openssl-devel pkgconfig protobuf-compiler python-pip tar wget \
-        zlib-devel
+        make openssl-devel pkgconfig protobuf-compiler python-pip ShellCheck \
+        tar wget zlib-devel
 
 # Install the the buildifier tool, which does not compile with the default
 # golang compiler for Ubuntu 16.04 and Ubuntu 18.04.

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -58,8 +58,8 @@ if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
   echo "================================================================"
   # It is Okay to skip the tests in this case because the super build
   # automatically runs them.
-  env -C "${BINARY_DIR}" ctest --output-on-failure -j "$(nproc)"
   echo "Running the unit tests $(date)"
+  env -C "${BINARY_DIR}" ctest --output-on-failure -j "$(nproc)"
   echo "================================================================"
 fi
 


### PR DESCRIPTION
Install the ShellCheck package needed for check-style.sh.  Also move
the "chmod" in replace_original_if_changed to a more logical location.

Emit the "Running the unit tests" message in build-in-docker-cmake.sh
before actually running the tests.