### PR TITLE
Adds Spanner STRUCT support to Value

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -61,20 +61,19 @@ bool Equal(google::spanner::v1::Type const& pt1,
       return true;
     }
     case google::spanner::v1::TypeCode::STRUCT: {
-      std::cout << "# Equals STRUCT\n";
       auto const& fields1 = pt1.struct_type().fields();
       auto const& fields2 = pt2.struct_type().fields();
       if (fields1.size() != fields2.size()) return false;
-      /* auto const& v1 = pv1.list_value().values(); */
-      /* auto const& v2 = pv2.list_value().values(); */
-      /* if (v1.size() != v2.size()) return false; */
+      auto const& v1 = pv1.list_value().values();
+      auto const& v2 = pv2.list_value().values();
+      if (fields1.size() != v1.size() || v1.size() != v2.size()) return false;
       for (int i = 0; i < fields1.size(); ++i) {
-        auto const f1 = fields1.Get(i);
-        auto const f2 = fields2.Get(i);
+        auto const& f1 = fields1.Get(i);
+        auto const& f2 = fields2.Get(i);
         if (f1.name() != f2.name()) return false;
-        /* if (!Equal(f1.type(), v1.Get(i), f2.type(), v2.Get(i))) { */
-        /*   return false; */
-        /* } */
+        if (!Equal(f1.type(), v1.Get(i), f2.type(), v2.Get(i))) {
+          return false;
+        }
       }
       return true;
     }

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -60,6 +60,24 @@ bool Equal(google::spanner::v1::Type const& pt1,
       }
       return true;
     }
+    case google::spanner::v1::TypeCode::STRUCT: {
+      std::cout << "# Equals STRUCT\n";
+      auto const& fields1 = pt1.struct_type().fields();
+      auto const& fields2 = pt2.struct_type().fields();
+      if (fields1.size() != fields2.size()) return false;
+      /* auto const& v1 = pv1.list_value().values(); */
+      /* auto const& v2 = pv2.list_value().values(); */
+      /* if (v1.size() != v2.size()) return false; */
+      for (int i = 0; i < fields1.size(); ++i) {
+        auto const f1 = fields1.Get(i);
+        auto const f2 = fields2.Get(i);
+        if (f1.name() != f2.name()) return false;
+        /* if (!Equal(f1.type(), v1.Get(i), f2.type(), v2.Get(i))) { */
+        /*   return false; */
+        /* } */
+      }
+      return true;
+    }
     default:
       return true;
   }

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -14,8 +14,6 @@
 
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/log.h"
-#include <google/protobuf/util/field_comparator.h>
-#include <google/protobuf/util/message_differencer.h>
 #include <cmath>
 #include <ios>
 #include <string>
@@ -95,11 +93,6 @@ bool operator==(Value const& a, Value const& b) {
 
 void PrintTo(Value const& v, std::ostream* os) {
   *os << v.type_.ShortDebugString() << "; " << v.value_.ShortDebugString();
-}
-
-bool Value::ProtoEqual(google::protobuf::Message const& m1,
-                       google::protobuf::Message const& m2) {
-  return google::protobuf::util::MessageDifferencer::Equals(m1, m2);
 }
 
 //

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -178,11 +178,13 @@ google::protobuf::Value Value::MakeValueProto(std::string s) {
 // Value::GetValue
 //
 
-bool Value::GetValue(bool, google::protobuf::Value const& pv) {
+bool Value::GetValue(bool, google::protobuf::Value const& pv,
+                     google::spanner::v1::Type const&) {
   return pv.bool_value();
 }
 
-std::int64_t Value::GetValue(std::int64_t, google::protobuf::Value const& pv) {
+std::int64_t Value::GetValue(std::int64_t, google::protobuf::Value const& pv,
+                             google::spanner::v1::Type const&) {
   auto const& s = pv.string_value();
   std::size_t processed = 0;
   long long x = std::stoll(s, &processed, 10);
@@ -192,7 +194,8 @@ std::int64_t Value::GetValue(std::int64_t, google::protobuf::Value const& pv) {
   return x;
 }
 
-double Value::GetValue(double, google::protobuf::Value const& pv) {
+double Value::GetValue(double, google::protobuf::Value const& pv,
+                       google::spanner::v1::Type const&) {
   if (pv.kind_case() == google::protobuf::Value::kStringValue) {
     std::string const& s = pv.string_value();
     auto const inf = std::numeric_limits<double>::infinity();
@@ -204,7 +207,8 @@ double Value::GetValue(double, google::protobuf::Value const& pv) {
 }
 
 std::string Value::GetValue(std::string const&,
-                            google::protobuf::Value const& pv) {
+                            google::protobuf::Value const& pv,
+                            google::spanner::v1::Type const&) {
   return pv.string_value();
 }
 

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -149,7 +149,7 @@ class Value {
   bool is() const {
     google::protobuf::util::MessageDifferencer diff;
     auto const* field = google::spanner::v1::StructType::Field::descriptor();
-    // Ignores the name field when checking if `type_` == the proto for `T`.
+    // Ignores the name field because it is never set on the incoming `T`.
     diff.IgnoreField(field->FindFieldByName("name"));
     return diff.Compare(type_, MakeTypeProto(T{}));
   }

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -50,7 +50,7 @@ inline namespace SPANNER_CLIENT_NS {
  * FLOAT64      | `double`
  * STRING       | `std::string`
  * ARRAY        | `std::vector<T>`  // [1]
- * STRUCT       | `std::tuple<Ts...>
+ * STRUCT       | `std::tuple<Ts...>`
  *
  * [1] The type `T` may be any of the other supported types, except for
  *     ARRAY/`std::vector`.
@@ -87,7 +87,7 @@ inline namespace SPANNER_CLIENT_NS {
  *
  * Spanner arrays are represented in C++ as a `std::vector<T>`, where the type
  * `T` may be any of the other allowed Spanner types, such as `bool`,
- * `std::int64_t`, etc. The only exception is that a arrays may not directly
+ * `std::int64_t`, etc. The only exception is that arrays may not directly
  * contain another array; to achieve a similar result you could create an array
  * of a 1-element struct holding an array. The following examples show usage of
  * arrays.
@@ -336,8 +336,7 @@ class Value {
   static google::spanner::v1::Type MakeTypeProto(std::tuple<Ts...> const& tup) {
     google::spanner::v1::Type t;
     t.set_code(google::spanner::v1::TypeCode::STRUCT);
-    AddStructTypes f;
-    IterateTuple(tup, f, *t.mutable_struct_type());
+    IterateTuple(tup, AddStructTypes{}, *t.mutable_struct_type());
     return t;
   }
 
@@ -383,8 +382,7 @@ class Value {
   template <typename... Ts>
   static google::protobuf::Value MakeValueProto(std::tuple<Ts...> const& tup) {
     google::protobuf::Value v;
-    AddStructValues f;
-    IterateTuple(tup, f, *v.mutable_list_value());
+    IterateTuple(tup, AddStructValues{}, *v.mutable_list_value());
     return v;
   }
 

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -322,7 +322,6 @@ class Value {
     google::spanner::v1::Type t;
     t.set_code(google::spanner::v1::TypeCode::ARRAY);
     *t.mutable_array_element_type() = MakeTypeProto(v.empty() ? T{} : v[0]);
-#ifndef NDEBUG
     // Checks that vector elements have exactly the same proto Type, which
     // includes field names. This is documented UB.
     for (auto const& e : v) {
@@ -331,7 +330,6 @@ class Value {
         internal::ThrowInvalidArgument("Mismatched types");
       }
     }
-#endif
     return t;
   }
   template <typename... Ts>

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -171,10 +171,10 @@ TEST(Value, SpannerArray) {
   EXPECT_TRUE(ve.is<ArrayInt64>());
   EXPECT_FALSE(ve.is_null<ArrayInt64>());
   EXPECT_FALSE(ve.is<ArrayDouble>());
-  EXPECT_EQ(empty, static_cast<ArrayInt64>(ve));
   EXPECT_TRUE(ve.get<ArrayInt64>().ok());
   EXPECT_FALSE(ve.get<ArrayDouble>().ok());
   EXPECT_EQ(empty, *ve.get<ArrayInt64>());
+  EXPECT_EQ(empty, static_cast<ArrayInt64>(ve));
 
   ArrayInt64 const ai = {1, 2, 3};
   Value const vi(ai);
@@ -182,10 +182,10 @@ TEST(Value, SpannerArray) {
   EXPECT_TRUE(vi.is<ArrayInt64>());
   EXPECT_FALSE(vi.is_null<ArrayInt64>());
   EXPECT_FALSE(vi.is<ArrayDouble>());
-  EXPECT_EQ(ai, static_cast<ArrayInt64>(vi));
   EXPECT_TRUE(vi.get<ArrayInt64>().ok());
   EXPECT_FALSE(vi.get<ArrayDouble>().ok());
   EXPECT_EQ(ai, *vi.get<ArrayInt64>());
+  EXPECT_EQ(ai, static_cast<ArrayInt64>(vi));
 
   ArrayDouble const ad = {1.0, 2.0, 3.0};
   Value const vd(ad);
@@ -194,9 +194,9 @@ TEST(Value, SpannerArray) {
   EXPECT_TRUE(vd.is<ArrayDouble>());
   EXPECT_FALSE(vd.is_null<ArrayDouble>());
   EXPECT_FALSE(vd.is<ArrayInt64>());
-  EXPECT_EQ(ad, static_cast<ArrayDouble>(vd));
   EXPECT_TRUE(vd.get<ArrayDouble>().ok());
   EXPECT_EQ(ad, *vd.get<ArrayDouble>());
+  EXPECT_EQ(ad, static_cast<ArrayDouble>(vd));
 
   Value const null_vi = MakeNullValue<ArrayInt64>();
   EXPECT_EQ(null_vi, null_vi);
@@ -215,7 +215,7 @@ TEST(Value, SpannerArray) {
 }
 
 TEST(Value, SpannerStruct) {
-  // Using declarations to shorten the tests making them more readable.
+  // Using declarations to shorten the tests, making them more readable.
   using std::int64_t;
   using std::make_pair;
   using std::make_tuple;
@@ -282,9 +282,9 @@ TEST(Value, SpannerStruct) {
   EXPECT_NE(v2, v_null);
 
   auto array_struct = std::vector<T3>{
-      {false, {"age", 1}},
-      {true, {"age", 2}},
-      {false, {"age", 3}},
+      T3{false, {"age", 1}},
+      T3{true, {"age", 2}},
+      T3{false, {"age", 3}},
   };
   using T4 = decltype(array_struct);
   Value v4(array_struct);

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -19,6 +19,7 @@
 #include <limits>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 namespace google {
@@ -164,6 +165,17 @@ TEST(Value, SpannerArray) {
   using ArrayInt64 = std::vector<std::int64_t>;
   using ArrayDouble = std::vector<double>;
 
+  ArrayInt64 const empty = {};
+  Value const ve(empty);
+  EXPECT_EQ(ve, ve);
+  EXPECT_TRUE(ve.is<ArrayInt64>());
+  EXPECT_FALSE(ve.is_null<ArrayInt64>());
+  EXPECT_FALSE(ve.is<ArrayDouble>());
+  EXPECT_EQ(empty, static_cast<ArrayInt64>(ve));
+  EXPECT_TRUE(ve.get<ArrayInt64>().ok());
+  EXPECT_FALSE(ve.get<ArrayDouble>().ok());
+  EXPECT_EQ(empty, *ve.get<ArrayInt64>());
+
   ArrayInt64 const ai = {1, 2, 3};
   Value const vi(ai);
   EXPECT_EQ(vi, vi);
@@ -203,25 +215,111 @@ TEST(Value, SpannerArray) {
 }
 
 TEST(Value, SpannerStruct) {
-  using StructType = std::tuple<bool, std::pair<std::string, std::int64_t>>;
-  StructType tup = std::make_tuple(
-      false, std::make_pair(std::string("foo"), std::int64_t{123}));
-  StructType tup2 = std::make_tuple(
-      false, std::make_pair(std::string("foo"), std::int64_t{124}));
-  Value v1(tup);
-  Value v2(tup2);
-  /* EXPECT_EQ(Value(false), v); */
-  EXPECT_TRUE(v1.is<StructType>());
-  EXPECT_TRUE((v1.is<std::tuple<bool, std::int64_t>>()));
-  EXPECT_TRUE(v2.is<StructType>());
-  EXPECT_TRUE((v2.is<std::tuple<bool, std::int64_t>>()));
-  EXPECT_NE(v1, v2);
+  // Using declarations to shorten the tests making them more readable.
+  using std::int64_t;
+  using std::make_pair;
+  using std::make_tuple;
+  using std::pair;
+  using std::string;
+  using std::tuple;
 
-  auto sor = v1.get<StructType>();
-  EXPECT_TRUE(sor.ok());
-  EXPECT_EQ(tup, *sor);
-  /* EXPECT_EQ(tup, *v.get<StructType>()); */
-  /* EXPECT_NE(tup2, *v.get<StructType>()); */
+  auto tup1 = make_tuple(false, int64_t{123});
+  using T1 = decltype(tup1);
+  Value v1(tup1);
+  EXPECT_TRUE(v1.is<T1>());
+  EXPECT_FALSE(v1.is_null<T1>());
+  EXPECT_TRUE(v1.get<T1>().ok());
+  EXPECT_EQ(tup1, *v1.get<T1>());
+  EXPECT_EQ(v1, v1);
+
+  // Verify that wrapping an element in a pair doesn't affect its C++ type.
+  EXPECT_TRUE((v1.is<tuple<bool, int64_t>>()));
+  EXPECT_TRUE((v1.is<tuple<pair<string, bool>, int64_t>>()));
+  EXPECT_TRUE((v1.is<tuple<bool, pair<string, int64_t>>>()));
+  EXPECT_TRUE((v1.is<tuple<pair<string, bool>, pair<string, int64_t>>>()));
+
+  auto tup2 = make_tuple(false, make_pair(string("f2"), int64_t{123}));
+  using T2 = decltype(tup2);
+  Value v2(tup2);
+  EXPECT_TRUE(v2.is<T2>());
+  EXPECT_FALSE(v2.is_null<T2>());
+  EXPECT_TRUE(v2.get<T2>().ok());
+  EXPECT_EQ(tup2, *v2.get<T2>());
+  EXPECT_EQ(v2, v2);
+  EXPECT_NE(v2, v1);
+
+  // T1 is lacking field names, but otherwise the same as T2.
+  EXPECT_EQ(tup1, *v2.get<T1>());
+  EXPECT_NE(tup2, *v1.get<T2>());
+
+  auto tup3 = make_tuple(false, make_pair(string("Other"), int64_t{123}));
+  using T3 = decltype(tup3);
+  Value v3(tup3);
+  EXPECT_TRUE(v3.is<T3>());
+  EXPECT_FALSE(v3.is_null<T3>());
+  EXPECT_TRUE(v3.get<T3>().ok());
+  EXPECT_EQ(tup3, *v3.get<T3>());
+  EXPECT_EQ(v3, v3);
+  EXPECT_NE(v3, v2);
+  EXPECT_NE(v3, v1);
+
+  static_assert(std::is_same<T2, T3>::value, "Only diff is field name");
+
+  // v1 != v2, yet T2 works with v1 and vice versa
+  EXPECT_NE(v1, v2);
+  EXPECT_TRUE(v1.is<T2>());
+  EXPECT_FALSE(v1.is_null<T2>());
+  EXPECT_TRUE(v2.is<T1>());
+  EXPECT_FALSE(v2.is_null<T1>());
+
+  Value v_null(optional<T1>{});
+  EXPECT_TRUE(v_null.is<T1>());
+  EXPECT_TRUE(v_null.is<T2>());
+  EXPECT_TRUE(v_null.is_null<T1>());
+  EXPECT_TRUE(v_null.is_null<T2>());
+
+  EXPECT_NE(v1, v_null);
+  EXPECT_NE(v2, v_null);
+
+  auto array_struct = std::vector<T3>{
+      {false, {"age", 1}},
+      {true, {"age", 2}},
+      {false, {"age", 3}},
+  };
+  using T4 = decltype(array_struct);
+  Value v4(array_struct);
+  EXPECT_TRUE(v4.is<T4>());
+  EXPECT_FALSE(v4.is<T3>());
+  EXPECT_FALSE(v4.is<T2>());
+  EXPECT_FALSE(v4.is<T1>());
+
+  EXPECT_FALSE(v4.is_null<T4>());
+  EXPECT_TRUE(v4.get<T4>().ok());
+  EXPECT_EQ(array_struct, *v4.get<T4>());
+
+  auto empty = tuple<>{};
+  using T5 = decltype(empty);
+  Value v5(empty);
+  EXPECT_TRUE(v5.is<T5>());
+  EXPECT_FALSE(v5.is<T4>());
+  EXPECT_EQ(v5, v5);
+  EXPECT_NE(v5, v4);
+
+  EXPECT_FALSE(v5.is_null<T5>());
+  EXPECT_TRUE(v5.get<T5>().ok());
+  EXPECT_EQ(empty, *v5.get<T5>());
+
+  auto crazy = tuple<tuple<std::vector<optional<bool>>>>{};
+  using T6 = decltype(crazy);
+  Value v6(crazy);
+  EXPECT_TRUE(v6.is<T6>());
+  EXPECT_FALSE(v6.is<T5>());
+  EXPECT_EQ(v6, v6);
+  EXPECT_NE(v6, v5);
+
+  EXPECT_FALSE(v6.is_null<T6>());
+  EXPECT_TRUE(v6.get<T6>().ok());
+  EXPECT_EQ(crazy, *v6.get<T6>());
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -208,10 +208,14 @@ TEST(Value, SpannerStruct) {
       false, std::make_pair(std::string("foo"), std::int64_t{123}));
   StructType tup2 = std::make_tuple(
       false, std::make_pair(std::string("bar"), std::int64_t{123}));
-  Value v(tup);
+  Value v1(tup);
+  Value v2(tup2);
   /* EXPECT_EQ(Value(false), v); */
-  EXPECT_TRUE(v.is<StructType>());
-  EXPECT_TRUE((v.is<std::tuple<bool, std::int64_t>>()));
+  EXPECT_TRUE(v1.is<StructType>());
+  EXPECT_TRUE((v1.is<std::tuple<bool, std::int64_t>>()));
+  EXPECT_TRUE(v2.is<StructType>());
+  EXPECT_TRUE((v2.is<std::tuple<bool, std::int64_t>>()));
+  EXPECT_NE(v1, v2);
   /* EXPECT_EQ(tup, *v.get<StructType>()); */
   /* EXPECT_NE(tup2, *v.get<StructType>()); */
 }

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -216,6 +216,10 @@ TEST(Value, SpannerStruct) {
   EXPECT_TRUE(v2.is<StructType>());
   EXPECT_TRUE((v2.is<std::tuple<bool, std::int64_t>>()));
   EXPECT_NE(v1, v2);
+
+  auto sor = v1.get<StructType>();
+  EXPECT_TRUE(sor.ok());
+  EXPECT_EQ(tup, *sor);
   /* EXPECT_EQ(tup, *v.get<StructType>()); */
   /* EXPECT_NE(tup2, *v.get<StructType>()); */
 }

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -207,7 +207,7 @@ TEST(Value, SpannerStruct) {
   StructType tup = std::make_tuple(
       false, std::make_pair(std::string("foo"), std::int64_t{123}));
   StructType tup2 = std::make_tuple(
-      false, std::make_pair(std::string("bar"), std::int64_t{123}));
+      false, std::make_pair(std::string("foo"), std::int64_t{124}));
   Value v1(tup);
   Value v2(tup2);
   /* EXPECT_EQ(Value(false), v); */

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <limits>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace google {
@@ -199,6 +200,20 @@ TEST(Value, SpannerArray) {
   EXPECT_NE(null_vd, vi);
   EXPECT_FALSE(null_vd.get<ArrayDouble>().ok());
   EXPECT_FALSE(null_vd.get<ArrayInt64>().ok());
+}
+
+TEST(Value, SpannerStruct) {
+  using StructType = std::tuple<bool, std::pair<std::string, std::int64_t>>;
+  StructType tup = std::make_tuple(
+      false, std::make_pair(std::string("foo"), std::int64_t{123}));
+  StructType tup2 = std::make_tuple(
+      false, std::make_pair(std::string("bar"), std::int64_t{123}));
+  Value v(tup);
+  /* EXPECT_EQ(Value(false), v); */
+  EXPECT_TRUE(v.is<StructType>());
+  EXPECT_TRUE((v.is<std::tuple<bool, std::int64_t>>()));
+  /* EXPECT_EQ(tup, *v.get<StructType>()); */
+  /* EXPECT_NE(tup2, *v.get<StructType>()); */
 }
 
 }  // namespace SPANNER_CLIENT_NS


### PR DESCRIPTION
Fixes #54 

Adds support for Spanner STRUCT. This is represented in C++ as `std::tuple<Ts...>`, where each `T` is any valid Spanner type, including another `std::tuple`. Each field may optionally contain a name, which is specified as a tuple element of type `std::pair<std::string, T>`.

@devbww this is a larger PR than I wanted. Feel free to ping me on chat or otherwise if you'd like to ask about or discuss parts of this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/88)
<!-- Reviewable:end -->
