### PR TITLE
Static assert that vector of vector is not allowed.

### DIFF
--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -159,8 +159,10 @@ class Value {
    * elements must have exactly the same field names. Any mismatch in in field
    * names results in undefined behavior.
    */
-  template <typename T>  // TODO(#59): add an enabler to disallow T==vector
+  template <typename T>
   explicit Value(std::vector<T> const& v) {
+    static_assert(!is_vector<typename std::decay<T>::type>::value,
+                  "vector of vector not allowed. See value.h documentation.");
     type_ = MakeTypeProto(v);
     value_ = MakeValueProto(v);
   }
@@ -302,6 +304,12 @@ class Value {
   struct is_optional : std::false_type {};
   template <typename T>
   struct is_optional<optional<T>> : std::true_type {};
+
+  // Metafunction that returns true if `T` is a std::vector<U>
+  template <typename T>
+  struct is_vector : std::false_type {};
+  template <typename... Ts>
+  struct is_vector<std::vector<Ts...>> : std::true_type {};
 
   // Tag-dispatch overloads to convert a C++ type to a `Type` protobuf. The
   // argument type is the tag, the argument value is ignored.


### PR DESCRIPTION
Fixes #59

This PR adds an `is_vector` metafunction and `static_assert`s in the
constructor's body to disallow vector of vector. I choose to use a
static_assert in the body here instead of an enabler in the template
parameter list for several reasons:

1. Using `std::enable_if` in the template parameter list requires that
the metafunction be defined first, so it would have to live above the
constructors in the Value class, instead of being "hidden" at the bottom
of the class in the private section.

2. The static_assert() produces a slightly clearer error message in this
case.

3. Enablers are most useful when the goal is to disable an overload so
that *some other overload* can be used instead. That's not the goal
here. In this case, we're just detecting an error case. There's no
alterative better constructor to use instead, so an enabler isn't really
useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/92)
<!-- Reviewable:end -->
