### PR TITLE
Some cleanup from post-merge comments from PR #88

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/log.h"
+#include <google/protobuf/util/field_comparator.h>
+#include <google/protobuf/util/message_differencer.h>
 #include <cmath>
 #include <ios>
 #include <string>
@@ -210,6 +212,14 @@ std::string Value::GetValue(std::string const&,
                             google::protobuf::Value const& pv,
                             google::spanner::v1::Type const&) {
   return pv.string_value();
+}
+
+bool Value::EqualTypeProtoIgnoringNames(google::spanner::v1::Type const& a,
+                                        google::spanner::v1::Type const& b) {
+  google::protobuf::util::MessageDifferencer diff;
+  auto const* field = google::spanner::v1::StructType::Field::descriptor();
+  diff.IgnoreField(field->FindFieldByName("name"));
+  return diff.Compare(a, b);
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -103,9 +103,9 @@ inline namespace SPANNER_CLIENT_NS {
  * Spanner structs are represented in C++ as instances of `std::tuple` holding
  * zero or more of the allowed Spanner types, such as `bool`, `std::int64_t`,
  * `std::vector`, and even other `std::tuple` objects. Each tuple element
- * corresponds to a single field in a Spanner Struct.
+ * corresponds to a single field in a Spanner STRUCT.
  *
- * Spanner struct fields may optionally contain a string indicating the field's
+ * Spanner STRUCT fields may optionally contain a string indicating the field's
  * name. Fields names may be empty, unique, or repeated. A named field may be
  * specified as a tuple element of type `std::pair<std::string, T>`, where the
  * pair's `.first` member indicate's the field's name, and the `.second` member
@@ -118,7 +118,7 @@ inline namespace SPANNER_CLIENT_NS {
  *     assert(s == *v.get<Struct>());
  *
  * NOTE: While a struct's (optional) field names are not part of its C++ type,
- * they are part of its Spanner struct type. Array's (i.e., `std::vector`)
+ * they are part of its Spanner STRUCT type. Array's (i.e., `std::vector`)
  * must contain a single element type, therefore it is an error to construct
  * a `std::vector` of `std::tuple` objects with differently named fields.
  */
@@ -158,7 +158,7 @@ class Value {
    * NOTE: If `T` is a `std::tuple` with field names (i.e., at least one of its
    * element types is a `std::pair<std::string, T>`) then, all of the vector's
    * elements must have exactly the same field names. Any mismatch in in field
-   * names results in undefined bhavior.
+   * names results in undefined behavior.
    */
   template <typename T>  // TODO(#59): add an enabler to disallow T==vector
   explicit Value(std::vector<T> const& v) {

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -116,7 +116,7 @@ inline namespace SPANNER_CLIENT_NS {
  *     assert(v.is<Struct>());
  *     assert(s == *v.get<Struct>());
  *
- * NOTE: While a struct's (optional) field names are not part of its C++ type,
+ * NOTE: While a STRUCT's (optional) field names are not part of its C++ type,
  * they are part of its Spanner STRUCT type. Array's (i.e., `std::vector`)
  * must contain a single element type, therefore it is an error to construct
  * a `std::vector` of `std::tuple` objects with differently named fields.
@@ -169,7 +169,7 @@ class Value {
    * Constructs an instance from a Spanner STRUCT with a type and values
    * matching the given `std::tuple`.
    *
-   * Any struct field may optionally have a name, which is specified as
+   * Any STRUCT field may optionally have a name, which is specified as
    * `std::pair<std::string, T>`.
    */
   template <typename... Ts>

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -20,7 +20,6 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
 #include <google/protobuf/struct.pb.h>
-#include <google/protobuf/util/field_comparator.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <google/spanner/v1/type.pb.h>
 #include <ostream>
@@ -200,11 +199,8 @@ class Value {
    */
   template <typename T>
   bool is() const {
-    google::protobuf::util::MessageDifferencer diff;
-    auto const* field = google::spanner::v1::StructType::Field::descriptor();
     // Ignores the name field because it is never set on the incoming `T`.
-    diff.IgnoreField(field->FindFieldByName("name"));
-    return diff.Compare(type_, MakeTypeProto(T{}));
+    return EqualTypeProtoIgnoringNames(type_, MakeTypeProto(T{}));
   }
 
   /**
@@ -474,6 +470,9 @@ class Value {
   static typename std::enable_if<
       I == std::tuple_size<typename std::decay<Tup>::type>::value, void>::type
   IterateTuple(Tup&&, F&&, Args&&...) {}
+
+  static bool EqualTypeProtoIgnoringNames(google::spanner::v1::Type const& a,
+                                          google::spanner::v1::Type const& b);
 
   google::spanner::v1::Type type_;
   google::protobuf::Value value_;


### PR DESCRIPTION
1. Standardized on STRUCT when specifically referring to the Spanner
type. Use struct when referring to a generic struct or C++ struct.

2. Fixed tyop.

3. Factored out function for `EqualTypeProtosIgnoringNames`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/94)
<!-- Reviewable:end -->
