### PR TITLE
Allows Value construct from int and string literals.

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -106,6 +106,16 @@ Value::Value(std::string v) {
   value_ = MakeValueProto(std::move(v));
 }
 
+Value::Value(int v) {
+  type_ = MakeTypeProto(v);
+  value_ = MakeValueProto(v);
+}
+
+Value::Value(char const* v) {
+  type_ = MakeTypeProto(v);
+  value_ = MakeValueProto(v);
+}
+
 bool operator==(Value const& a, Value const& b) {
   return Equal(a.type_, a.value_, b.type_, b.value_);
 }
@@ -142,6 +152,14 @@ google::spanner::v1::Type Value::MakeTypeProto(std::string const&) {
   return t;
 }
 
+google::spanner::v1::Type Value::MakeTypeProto(int) {
+  return MakeTypeProto(std::int64_t{});
+}
+
+google::spanner::v1::Type Value::MakeTypeProto(char const*) {
+  return MakeTypeProto(std::string{});
+}
+
 //
 // Value::MakeValueProto
 //
@@ -174,6 +192,14 @@ google::protobuf::Value Value::MakeValueProto(std::string s) {
   google::protobuf::Value v;
   v.set_string_value(std::move(s));
   return v;
+}
+
+google::protobuf::Value Value::MakeValueProto(int i) {
+  return MakeValueProto(std::int64_t{i});
+}
+
+google::protobuf::Value Value::MakeValueProto(char const* s) {
+  return MakeValueProto(std::string(s));
 }
 
 //

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -142,7 +142,7 @@ class Value {
    * though not exactly, match supported Spanner types.
    *
    * An integer literal in C++ is of type `int`, which is not exactly an
-   * allowed Spanner type. This will be allowed but it will be implcitly up
+   * allowed Spanner type. This will be allowed but it will be implicitly up
    * converted to a `std::int64_t`. Similarly, a C++ string literal will be
    * implicitly converted to a `std::string`. For example:
    *
@@ -153,6 +153,7 @@ class Value {
    *     assert(v2.is<std::string>());
    */
   explicit Value(int v);
+  /// @copydoc Value(int)
   explicit Value(char const* v);
 
   /**
@@ -373,8 +374,10 @@ class Value {
       auto* field = struct_type.add_fields();
       *field->mutable_type() = MakeTypeProto(t);
     }
-    template <typename T>
-    void operator()(std::pair<std::string, T> const& p,
+    template <typename S, typename T,
+              typename std::enable_if<
+                  std::is_convertible<S, std::string>::value, int>::type = 0>
+    void operator()(std::pair<S, T> const& p,
                     google::spanner::v1::StructType& struct_type) const {
       auto* field = struct_type.add_fields();
       field->set_name(p.first);
@@ -419,8 +422,10 @@ class Value {
     void operator()(T const& t, google::protobuf::ListValue& list_value) const {
       *list_value.add_values() = MakeValueProto(t);
     }
-    template <typename T>
-    void operator()(std::pair<std::string, T> const& p,
+    template <typename S, typename T,
+              typename std::enable_if<
+                  std::is_convertible<S, std::string>::value, int>::type = 0>
+    void operator()(std::pair<S, T> const& p,
                     google::protobuf::ListValue& list_value) const {
       *list_value.add_values() = MakeValueProto(p.second);
     }

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -138,6 +138,24 @@ class Value {
   explicit Value(std::string v);
 
   /**
+   * Constructs a non-null instance from common C++ literal types that closely,
+   * though not exactly, match supported Spanner types.
+   *
+   * An integer literal in C++ is of type `int`, which is not exactly an
+   * allowed Spanner type. This will be allowed but it will be implcitly up
+   * converted to a `std::int64_t`. Similarly, a C++ string literal will be
+   * implicitly converted to a `std::string`. For example:
+   *
+   *     spanner::Value v1(42);
+   *     assert(v1.is<std::int64_t>());
+   *
+   *     spanner::Value v2("hello");
+   *     assert(v2.is<std::string>());
+   */
+  explicit Value(int v);
+  explicit Value(char const* v);
+
+  /**
    * Constructs a non-null instance if `opt` has a value, otherwise constructs
    * a null instance.
    */
@@ -317,6 +335,8 @@ class Value {
   static google::spanner::v1::Type MakeTypeProto(std::int64_t);
   static google::spanner::v1::Type MakeTypeProto(double);
   static google::spanner::v1::Type MakeTypeProto(std::string const&);
+  static google::spanner::v1::Type MakeTypeProto(int);
+  static google::spanner::v1::Type MakeTypeProto(char const*);
   template <typename T>
   static google::spanner::v1::Type MakeTypeProto(optional<T> const&) {
     return MakeTypeProto(T{});
@@ -368,6 +388,8 @@ class Value {
   static google::protobuf::Value MakeValueProto(std::int64_t i);
   static google::protobuf::Value MakeValueProto(double d);
   static google::protobuf::Value MakeValueProto(std::string s);
+  static google::protobuf::Value MakeValueProto(int i);
+  static google::protobuf::Value MakeValueProto(char const* s);
   template <typename T>
   static google::protobuf::Value MakeValueProto(optional<T> const& opt) {
     if (opt.has_value()) return MakeValueProto(*opt);

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -131,6 +131,12 @@ TEST(Value, ConstructionFromLiterals) {
   std::tuple<char const*, char const*> tup = std::make_tuple("foo", "bar");
   Value v_tup(tup);
   EXPECT_TRUE((v_tup.is<std::tuple<std::string, std::string>>()));
+
+  auto named_field = std::make_tuple(false, std::make_pair("f1", 42));
+  Value v_named_field(named_field);
+  EXPECT_TRUE(
+      (v_named_field
+           .is<std::tuple<bool, std::pair<std::string, std::int64_t>>>()));
 }
 
 TEST(Value, MixingTypes) {

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -115,6 +115,24 @@ TEST(Value, DoubleNaN) {
   EXPECT_NE(v, v);
 }
 
+TEST(Value, ConstructionFromLiterals) {
+  Value v_int64(42);
+  EXPECT_TRUE(v_int64.is<std::int64_t>());
+  EXPECT_EQ(42, *v_int64.get<std::int64_t>());
+
+  Value v_string("hello");
+  EXPECT_TRUE(v_string.is<std::string>());
+  EXPECT_EQ("hello", *v_string.get<std::string>());
+
+  std::vector<char const*> vec = {"foo", "bar"};
+  Value v_vec(vec);
+  EXPECT_TRUE(v_vec.is<std::vector<std::string>>());
+
+  std::tuple<char const*, char const*> tup = std::make_tuple("foo", "bar");
+  Value v_tup(tup);
+  EXPECT_TRUE((v_tup.is<std::tuple<std::string, std::string>>()));
+}
+
 TEST(Value, MixingTypes) {
   using A = bool;
   using B = std::int64_t;


### PR DESCRIPTION
Since integer literals are of type int and string literals are of type
char const* (actually arrays, but they decay to pointers), it would be
nice to allow constructing a Value directly from these commonly used
literal types. These types don't directly map to supported Spanner
types, so we'll up convert both of them to std::int64_t and std::string
respectively.

Fixes #93

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/95)
<!-- Reviewable:end -->
