### PR TITLE
Simplifies the Value constructor implementations.

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -86,36 +86,6 @@ bool Equal(google::spanner::v1::Type const& pt1,
 
 }  // namespace
 
-Value::Value(bool v) {
-  type_ = MakeTypeProto(v);
-  value_ = MakeValueProto(v);
-}
-
-Value::Value(std::int64_t v) {
-  type_ = MakeTypeProto(v);
-  value_ = MakeValueProto(v);
-}
-
-Value::Value(double v) {
-  type_ = MakeTypeProto(v);
-  value_ = MakeValueProto(v);
-}
-
-Value::Value(std::string v) {
-  type_ = MakeTypeProto(v);
-  value_ = MakeValueProto(std::move(v));
-}
-
-Value::Value(int v) {
-  type_ = MakeTypeProto(v);
-  value_ = MakeValueProto(v);
-}
-
-Value::Value(char const* v) {
-  type_ = MakeTypeProto(v);
-  value_ = MakeValueProto(v);
-}
-
 bool operator==(Value const& a, Value const& b) {
   return Equal(a.type_, a.value_, b.type_, b.value_);
 }


### PR DESCRIPTION
All public constructors now call one private templated constructor that
sets the type_ and value_ members.

@coryan you previously referred to a simpler constructor /implementation/. I'm not sure if this is what you were referring to (maybe?), but I think I like this better than the repeated c'tor bodies that this code previously had.

Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/96)
<!-- Reviewable:end -->
