### PR TITLE
fix: Fully qualify the namespace for ThrowInvalidArgument()

### DIFF
--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -346,7 +346,7 @@ class Value {
     for (auto const& e : v) {
       if (!google::protobuf::util::MessageDifferencer::Equals(
               MakeTypeProto(e), t.array_element_type())) {
-        internal::ThrowInvalidArgument("Mismatched types");
+        google::cloud::internal::ThrowInvalidArgument("Mismatched types");
       }
     }
     return t;


### PR DESCRIPTION
When `google::cloud::spanner` grows an internal namespace, this
reference to `internal::ThrowInvalidArgument()` will start meaning
something else.  So spell out that `google::cloud::internal` is
the namespace we are really looking for.