### PR TITLE
cleanup: Make clang-format put the spanner headers first.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,6 +9,8 @@ PointerAlignment: Left
 
 IncludeBlocks: Merge
 IncludeCategories:
+- Regex: '^\"google/cloud/spanner'
+  Priority: 500
 - Regex: '^\"google/cloud/'
   Priority: 1500
 - Regex: '^\"'

--- a/google/cloud/spanner/spanner_version_test.cc
+++ b/google/cloud/spanner/spanner_version_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/internal/build_info.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/internal/build_info.h"
 #include <gmock/gmock.h>
 
 namespace google {

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H_
 
+#include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/optional.h"
-#include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
 #include <google/protobuf/struct.pb.h>
 #include <google/protobuf/util/message_differencer.h>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/117)
<!-- Reviewable:end -->
