### PR TITLE
Implement initial Stub for DatabaseAdmin.

### DIFF
--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -91,3 +91,54 @@ cc_library(
 ####################
 # END SPANNER PROTOS
 ####################
+
+# TODO(googleapis/google-cloud-cpp#2807) - will not need these.
+cc_proto_library(
+    name = "bigtableadmin_cc_proto",
+    deps = ["//google/bigtable/admin/v2:bigtableadmin_proto"],
+)
+
+cc_proto_library(
+    name = "bigtable_cc_proto",
+    deps = ["//google/bigtable/v2:bigtable_proto"],
+)
+
+cc_grpc_library(
+    name = "bigtableadmin_cc_grpc",
+    srcs = [
+        "//google/bigtable/admin/v2:bigtableadmin_proto",
+    ],
+    grpc_only = True,
+    use_external = True,
+    well_known_protos = True,
+    deps = [
+        ":bigtableadmin_cc_proto",
+        "//google/longrunning:longrunning_cc_grpc"
+    ],
+)
+
+cc_grpc_library(
+    name = "bigtable_cc_grpc",
+    srcs = ["//google/bigtable/v2:bigtable_proto"],
+    grpc_only = True,
+    use_external = True,
+    well_known_protos = True,
+    deps = [
+        ":bigtable_cc_proto",
+    ],
+)
+
+cc_library(
+    name = "bigtable_protos",
+    includes = [
+        ".",
+    ],
+    deps = [
+        "@com_github_grpc_grpc//:grpc++",
+        ":bigtable_cc_grpc",
+        ":bigtable_cc_proto",
+        ":bigtableadmin_cc_grpc",
+        ":bigtableadmin_cc_proto",
+        "//google/rpc:error_details_cc_proto"
+    ],
+)

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -46,6 +46,8 @@ cc_library(
     hdrs = spanner_client_hdrs + ["version_info.h"],
     deps = [
         "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp//google/cloud/bigtable:bigtable_client",
+        "@com_google_googleapis//:bigtable_protos",
         "@com_google_googleapis//:spanner_protos",
     ],
 )

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -28,6 +28,10 @@ include(EnableDoxygen)
 configure_file(version_info.h.in version_info.h)
 add_library(spanner_client
             ${CMAKE_BINARY_DIR}/google/cloud/spanner/version_info.h
+            client_options.cc
+            client_options.h
+            internal/database_admin_stub.cc
+            internal/database_admin_stub.h
             row.h
             sql_statement.cc
             sql_statement.h
@@ -80,6 +84,7 @@ function (spanner_client_define_tests)
     find_package(GTest CONFIG REQUIRED)
 
     set(spanner_client_unit_tests
+        client_options_test.cc
         row_test.cc
         spanner_version_test.cc
         sql_statement_test.cc

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -15,7 +15,7 @@
 # ~~~
 
 find_package(google_cloud_cpp_common CONFIG REQUIRED)
-find_package(googleapis CONFIG REQUIRED)
+find_package(bigtable_client CONFIG REQUIRED)
 
 include(EnableClangTidy)
 include(EnableWerror)
@@ -44,7 +44,8 @@ target_include_directories(spanner_client
                                   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
                                   $<INSTALL_INTERFACE:include>)
 target_link_libraries(spanner_client
-                      PUBLIC google_cloud_cpp_common
+                      PUBLIC bigtable_client
+                             google_cloud_cpp_common
                              googleapis-c++::spanner_protos)
 set_target_properties(spanner_client
                       PROPERTIES VERSION

--- a/google/cloud/spanner/client_options.cc
+++ b/google/cloud/spanner/client_options.cc
@@ -1,0 +1,32 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/client_options.h"
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+ClientOptions::ClientOptions(
+    std::shared_ptr<grpc::ChannelCredentials> credentials)
+    : credentials_(std::move(credentials)),
+      admin_endpoint_("spanner-admin.googleapis.com") {}
+
+ClientOptions::ClientOptions()
+    : ClientOptions(grpc::GoogleDefaultCredentials()) {}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/client_options.h
+++ b/google/cloud/spanner/client_options.h
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_CLIENT_OPTIONS_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_CLIENT_OPTIONS_H_
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/status_or.h"
+#include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
+#include <grpcpp/grpcpp.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+/**
+ * The configuration parameters for spanner clients.
+ */
+class ClientOptions {
+ public:
+  /// The default options, using `grpc::GoogleDefaultCredentials()`.
+  ClientOptions();
+
+  /// Default parameters, using an explicit credentials object.
+  explicit ClientOptions(std::shared_ptr<grpc::ChannelCredentials> c);
+
+  ClientOptions& set_credentials(std::shared_ptr<grpc::ChannelCredentials> v) {
+    credentials_ = std::move(v);
+    return *this;
+  }
+  std::shared_ptr<grpc::ChannelCredentials> credentials() const {
+    return credentials_;
+  }
+
+  ClientOptions& set_admin_endpoint(std::string v) {
+    admin_endpoint_ = std::move(v);
+    return *this;
+  }
+  std::string const& admin_endpoint() const { return admin_endpoint_; }
+
+ private:
+  std::shared_ptr<grpc::ChannelCredentials> credentials_;
+  std::string admin_endpoint_;
+};
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_CLIENT_OPTIONS_H_

--- a/google/cloud/spanner/client_options_test.cc
+++ b/google/cloud/spanner/client_options_test.cc
@@ -1,0 +1,42 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/client_options.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+TEST(ClientOptionsTest, Credentials) {
+  // In the CI environment grpc::GoogleDefaultCredentials() may assert. Use the
+  // insecure credentials to initialize the options in any unit test.
+  auto expected = grpc::InsecureChannelCredentials();
+  ClientOptions options(expected);
+  EXPECT_EQ(expected.get(), options.credentials().get());
+}
+
+TEST(ClientOptionsTest, AdminEndpoint) {
+  ClientOptions options(grpc::InsecureChannelCredentials());
+  EXPECT_EQ("spanner-admin.googleapis.com", options.admin_endpoint());
+  options.set_admin_endpoint("invalid-endpoint");
+  EXPECT_EQ("invalid-endpoint", options.admin_endpoint());
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/internal/database_admin_stub.cc
+++ b/google/cloud/spanner/internal/database_admin_stub.cc
@@ -1,0 +1,117 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/internal/database_admin_stub.h"
+#include "google/cloud/bigtable/internal/grpc_error_delegate.h"
+#include <google/longrunning/operations.grpc.pb.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+
+namespace gcsa = google::spanner::admin::database;
+
+DatabaseAdminStub::~DatabaseAdminStub() = default;
+
+StatusOr<google::longrunning::Operation> DatabaseAdminStub::CreateDatabase(
+    grpc::ClientContext&, gcsa::v1::CreateDatabaseRequest const&) {
+  return Status(StatusCode::kUnimplemented,
+                std::string("Unimplemented stub for ") + __func__);
+}
+
+Status DatabaseAdminStub::DropDatabase(grpc::ClientContext&,
+                                       gcsa::v1::DropDatabaseRequest const&) {
+  return Status(StatusCode::kUnimplemented,
+                std::string("Unimplemented stub for ") + __func__);
+}
+
+StatusOr<google::longrunning::Operation> DatabaseAdminStub::GetOperation(
+    grpc::ClientContext&, google::longrunning::GetOperationRequest const&) {
+  return Status(StatusCode::kUnimplemented,
+                std::string("Unimplemented stub for ") + __func__);
+}
+
+class DefaultDatabaseAdminStub : public DatabaseAdminStub {
+ public:
+  DefaultDatabaseAdminStub(
+      std::unique_ptr<gcsa::v1::DatabaseAdmin::Stub> database_admin,
+      std::unique_ptr<google::longrunning::Operations::Stub> operations)
+      : database_admin_(std::move(database_admin)),
+        operations_(std::move(operations)) {}
+
+  ~DefaultDatabaseAdminStub() override = default;
+
+  /// Start the long-running operation to create a new Cloud Spanner
+  /// database.
+  StatusOr<google::longrunning::Operation> CreateDatabase(
+      grpc::ClientContext& client_context,
+      gcsa::v1::CreateDatabaseRequest const& request) override {
+    google::longrunning::Operation response;
+    grpc::Status status =
+        database_admin_->CreateDatabase(&client_context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::bigtable::internal::MakeStatusFromRpcError(status);
+    }
+    return response;
+  }
+
+  /// Drop an existing Cloud Spanner database.
+  Status DropDatabase(grpc::ClientContext& client_context,
+                      gcsa::v1::DropDatabaseRequest const& request) override {
+    google::protobuf::Empty response;
+    grpc::Status status =
+        database_admin_->DropDatabase(&client_context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::bigtable::internal::MakeStatusFromRpcError(status);
+    }
+    return google::cloud::Status();
+  }
+
+  /// Poll a long-running operation.
+  StatusOr<google::longrunning::Operation> GetOperation(
+      grpc::ClientContext& client_context,
+      google::longrunning::GetOperationRequest const& request) override {
+    google::longrunning::Operation response;
+    grpc::Status status =
+        operations_->GetOperation(&client_context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::bigtable::internal::MakeStatusFromRpcError(status);
+    }
+    return response;
+  }
+
+ private:
+  std::unique_ptr<gcsa::v1::DatabaseAdmin::Stub> database_admin_;
+  std::unique_ptr<google::longrunning::Operations::Stub> operations_;
+};
+
+std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
+    ClientOptions const& options) {
+  auto channel =
+      grpc::CreateChannel(options.admin_endpoint(), options.credentials());
+  auto spanner_grpc_stub = gcsa::v1::DatabaseAdmin::NewStub(channel);
+  auto longrunning_grpc_stub =
+      google::longrunning::Operations::NewStub(channel);
+
+  return std::make_shared<DefaultDatabaseAdminStub>(
+      std::move(spanner_grpc_stub), std::move(longrunning_grpc_stub));
+}
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/internal/database_admin_stub.h
+++ b/google/cloud/spanner/internal/database_admin_stub.h
@@ -1,0 +1,65 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_STUB_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_STUB_H_
+
+#include "google/cloud/spanner/client_options.h"
+#include "google/cloud/status_or.h"
+#include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+/**
+ * Defines the low-level interface for database administration RPCs.
+ */
+class DatabaseAdminStub {
+ public:
+  virtual ~DatabaseAdminStub() = 0;
+
+  /// Start the long-running operation to create a new Cloud Spanner database.
+  virtual StatusOr<google::longrunning::Operation> CreateDatabase(
+      grpc::ClientContext& client_context,
+      google::spanner::admin::database::v1::CreateDatabaseRequest const&
+          request);
+
+  /// Drop an existing Cloud Spanner database.
+  virtual Status DropDatabase(
+      grpc::ClientContext& client_context,
+      google::spanner::admin::database::v1::DropDatabaseRequest const& request);
+
+  /// Poll a long-running operation.
+  virtual StatusOr<google::longrunning::Operation> GetOperation(
+      grpc::ClientContext& client_context,
+      google::longrunning::GetOperationRequest const& request);
+};
+
+/**
+ * Constructs a simple `DatabaseAdminStub`,
+ *
+ * This stub does not create a channel pool, or retry operations.
+ */
+std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
+    ClientOptions const& options);
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_STUB_H_

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -17,6 +17,8 @@
 """Automatically generated source lists for spanner_client - DO NOT EDIT."""
 
 spanner_client_hdrs = [
+    "client_options.h",
+    "internal/database_admin_stub.h",
     "row.h",
     "sql_statement.h",
     "value.h",
@@ -24,6 +26,8 @@ spanner_client_hdrs = [
 ]
 
 spanner_client_srcs = [
+    "client_options.cc",
+    "internal/database_admin_stub.cc",
     "sql_statement.cc",
     "value.cc",
     "version.cc",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 spanner_client_unit_tests = [
+    "client_options_test.cc",
     "row_test.cc",
     "spanner_version_test.cc",
     "sql_statement_test.cc",

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/format_time_point.h"
+#include "google/cloud/spanner/internal/database_admin_stub.h"
 #include "google/cloud/status.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
@@ -25,6 +26,8 @@
 #include <thread>
 
 namespace {
+
+namespace cs = google::cloud::spanner;
 
 int ListDatabases(std::vector<std::string> args) {
   if (args.size() != 2U) {
@@ -88,6 +91,32 @@ int WaitForOperation(std::shared_ptr<grpc::Channel> channel,
   return 0;
 }
 
+int WaitForOperation(
+    std::shared_ptr<cs::internal::DatabaseAdminStub> const& stub,
+    google::longrunning::Operation operation) {
+  std::cout << "Waiting for operation " << operation.name() << " "
+            << std::flush;
+  while (!operation.done()) {
+    // Spanner operations can take minutes, but in small experiments like these
+    // they typically take a few seconds.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::cout << '.' << std::flush;
+    grpc::ClientContext context;
+    google::longrunning::GetOperationRequest request;
+    request.set_name(operation.name());
+    auto update = stub->GetOperation(context, request);
+    if (!update) {
+      std::cerr << __func__ << " Error in GetOperation: " << update.status()
+                << "\n";
+      return 1;
+    }
+    using std::swap;
+    swap(*update, operation);
+  }
+  std::cout << " DONE\n" << operation.DebugString() << "\n";
+  return 0;
+}
+
 int CreateDatabase(std::vector<std::string> args) {
   if (args.size() != 3U) {
     std::cerr << "create-database <project> <instance> <database>\n";
@@ -99,30 +128,24 @@ int CreateDatabase(std::vector<std::string> args) {
 
   namespace spanner = google::spanner::admin::database::v1;
 
-  std::shared_ptr<grpc::ChannelCredentials> cred =
-      grpc::GoogleDefaultCredentials();
-  std::shared_ptr<grpc::Channel> channel =
-      grpc::CreateChannel("spanner.googleapis.com", cred);
-  auto stub = spanner::DatabaseAdmin::NewStub(channel);
+  std::shared_ptr<cs::internal::DatabaseAdminStub> stub =
+      cs::internal::CreateDefaultDatabaseAdminStub(cs::ClientOptions());
 
   spanner::CreateDatabaseRequest request;
-  google::longrunning::Operation operation;
   request.set_parent("projects/" + project + "/instances/" + instance);
   request.set_create_statement("CREATE DATABASE `" + database + "`");
 
   grpc::ClientContext context;
-  grpc::Status status = stub->CreateDatabase(&context, request, &operation);
-
-  if (!status.ok()) {
-    std::cerr << "FAILED: " << status.error_code() << ": "
-              << status.error_message() << "\n";
+  auto operation = stub->CreateDatabase(context, request);
+  if (!operation) {
+    std::cerr << "Error in CreateDatabase: " << operation.status() << "\n";
     return 1;
   }
 
   std::cout << "Response:\n";
-  std::cout << operation.DebugString() << "\n";
+  std::cout << operation->DebugString() << "\n";
 
-  return WaitForOperation(std::move(channel), std::move(operation));
+  return WaitForOperation(stub, *std::move(operation));
 }
 
 int DropDatabase(std::vector<std::string> args) {
@@ -136,23 +159,18 @@ int DropDatabase(std::vector<std::string> args) {
 
   namespace spanner = google::spanner::admin::database::v1;
 
-  std::shared_ptr<grpc::ChannelCredentials> cred =
-      grpc::GoogleDefaultCredentials();
-  std::shared_ptr<grpc::Channel> channel =
-      grpc::CreateChannel("spanner.googleapis.com", cred);
-  auto stub = spanner::DatabaseAdmin::NewStub(channel);
+  auto stub = cs::internal::CreateDefaultDatabaseAdminStub(
+      cs::ClientOptions());
 
   spanner::DropDatabaseRequest request;
-  google::protobuf::Empty response;
   request.set_database("projects/" + project + "/instances/" + instance +
                        "/databases/" + database);
 
   grpc::ClientContext context;
-  grpc::Status status = stub->DropDatabase(&context, request, &response);
+  google::cloud::Status status = stub->DropDatabase(context, request);
 
   if (!status.ok()) {
-    std::cerr << "FAILED: " << status.error_code() << ": "
-              << status.error_message() << "\n";
+    std::cerr << "Error in DropDatabase: " << status << "\n";
     return 1;
   }
 


### PR DESCRIPTION
This creates a Stub class for the database admin operations. In this PR I just
introduced the `CreateDatabase()`, `DropDatabase()` and, because
`CreateDatabase()` returns a long running operation, `GetOperation()`.
I refactored the code in `spanner_tool` to use this new class. An independent
integration test will come in a future PR.

Note that this Stub does not retry, does not set timeouts, does not log operations,
does not load-balance across a connection pool. Those will be implemented as
decorators on this class.
