### PR TITLE
bug: Add options to spanner tool

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -66,6 +66,8 @@ add_executable(spanner_tool spanner_tool.cc)
 target_link_libraries(spanner_tool
                       PRIVATE googleapis-c++::spanner_client
                               google_cloud_cpp_common)
+google_cloud_cpp_add_clang_tidy(spanner_tool)
+google_cloud_cpp_add_common_options(spanner_tool)
 
 # Define the tests in a function so we have a new scope for variable names.
 function (spanner_client_define_tests)

--- a/google/cloud/spanner/spanner_tool.cc
+++ b/google/cloud/spanner/spanner_tool.cc
@@ -42,7 +42,7 @@ int ListDatabases(std::vector<std::string> args) {
   std::shared_ptr<grpc::ChannelCredentials> cred =
       grpc::GoogleDefaultCredentials();
   std::shared_ptr<grpc::Channel> channel =
-      grpc::CreateChannel("spanner.googleapis.com", std::move(cred));
+      grpc::CreateChannel("spanner.googleapis.com", cred);
   std::unique_ptr<spanner::DatabaseAdmin::Stub> stub(
       spanner::DatabaseAdmin::NewStub(std::move(channel)));
 


### PR DESCRIPTION
The `spanner_tool` program was not getting clang-tidy nor code coverage
options.
