### PR TITLE
Added ToProto/FromProto support for Value

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -86,6 +86,18 @@ bool Equal(google::spanner::v1::Type const& pt1,
 
 }  // namespace
 
+namespace internal {
+
+Value FromProto(google::spanner::v1::Type t, google::protobuf::Value v) {
+  return Value(std::move(t), std::move(v));
+}
+
+std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v) {
+  return std::make_pair(std::move(v.type_), std::move(v.value_));
+}
+
+}  // namespace internal
+
 bool operator==(Value const& a, Value const& b) {
   return Equal(a.type_, a.value_, b.type_, b.value_);
 }

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -32,6 +32,13 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+class Value;  // Defined later in this file.
+// Internal implementation details that callers should not use.
+namespace internal {
+Value FromProto(google::spanner::v1::Type t, google::protobuf::Value v);
+std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v);
+}  // namespace internal
+
 /**
  * The Value class represents a type-safe, nullable Spanner value.
  *
@@ -514,6 +521,14 @@ class Value {
   explicit Value(PrivateConstructor, T&& t)
       : type_(MakeTypeProto(std::forward<T>(t))),
         value_(MakeValueProto(std::forward<T>(t))) {}
+
+  explicit Value(google::spanner::v1::Type t, google::protobuf::Value v)
+      : type_(std::move(t)), value_(std::move(v)) {}
+
+  friend Value internal::FromProto(google::spanner::v1::Type,
+                                   google::protobuf::Value);
+  friend std::pair<google::spanner::v1::Type, google::protobuf::Value>
+      internal::ToProto(Value);
 
   google::spanner::v1::Type type_;
   google::protobuf::Value value_;


### PR DESCRIPTION
Adds support for getting the raw protos from a `spanner::Value` and constructing a `spanner::Value` from raw protos. This is needed for converting the raw request/response protos to/from `spanner::Value` objects.

Note: In a later PR, we'll add support for checking for invalid protos. See #122

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/131)
<!-- Reviewable:end -->
