### PR TITLE
Disables forwarding c'tor if T == Row.

### DIFF
--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ROW_H_
 
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/internal/disjunction.h"
 #include <cstdint>
 #include <string>
 #include <tuple>
@@ -68,7 +69,7 @@ class Row {
   Row() {}
   Row(Row const&) = default;
   Row& operator=(Row const&) = default;
-  Row(Row&) = default;
+  Row(Row&&) = default;
   Row& operator=(Row&&) = default;
 
   /**
@@ -76,8 +77,15 @@ class Row {
    *
    * See also the `MakeRow()` helper function template for a convenient way to
    * make rows without having to also specify the value's types.
+   *
+   * This constructor is disabled if any of the specified types is `Row`, which
+   * prevents this constructor from taking over copy construction.
    */
-  template <typename... Ts>
+  template <typename... Ts,
+            typename std::enable_if<
+                !google::cloud::internal::disjunction<
+                    std::is_same<typename std::decay<Ts>::type, Row>...>::value,
+                int>::type = 0>
   explicit Row(Ts&&... ts) : values_(std::forward<Ts>(ts)...) {}
 
   /// Returns the number of columns in this row.

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -29,15 +29,18 @@ void VerifyRegularType(Ts&&... ts) {
   auto const row = MakeRow(std::forward<Ts>(ts)...);
   EXPECT_EQ(row, row);
 
-  auto copy = row;
-  EXPECT_EQ(copy, row);
+  auto copy_implicit = row;
+  EXPECT_EQ(copy_implicit, row);
+
+  auto copy_explicit(copy_implicit);
+  EXPECT_EQ(copy_explicit, copy_implicit);
 
   using RowType = typename std::decay<decltype(row)>::type;
   RowType assign;  // Default construction.
-  assign = copy;
-  EXPECT_EQ(assign, copy);
+  assign = row;
+  EXPECT_EQ(assign, row);
 
-  auto const moved = std::move(copy);
+  auto const moved = std::move(assign);
   EXPECT_EQ(moved, row);
 }
 


### PR DESCRIPTION
When constructing a `Row` from a T that is the same as `Row<Ts...>`,
that should be handled by the copy constructor, not the
perfect-forwarding constructor. To do this, we need to disable the
perfect-forwarding c'tor if any of its given `Ts` is Row.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/136)
<!-- Reviewable:end -->
