### PR TITLE
fix: Value::GetValue(optional<T>, ...) must check for nullness

### DIFF
--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -32,6 +32,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+
 class Value;  // Defined later in this file.
 // Internal implementation details that callers should not use.
 namespace internal {
@@ -447,6 +448,9 @@ class Value {
   static optional<T> GetValue(optional<T> const&,
                               google::protobuf::Value const& pv,
                               google::spanner::v1::Type const& pt) {
+    if (pv.kind_case() == google::protobuf::Value::kNullValue) {
+      return optional<T>{};
+    }
     return GetValue(T{}, pv, pt);
   }
   template <typename T>
@@ -519,8 +523,7 @@ class Value {
   struct PrivateConstructor {};
   template <typename T>
   explicit Value(PrivateConstructor, T&& t)
-      : type_(MakeTypeProto(std::forward<T>(t))),
-        value_(MakeValueProto(std::forward<T>(t))) {}
+      : type_(MakeTypeProto(t)), value_(MakeValueProto(std::forward<T>(t))) {}
 
   explicit Value(google::spanner::v1::Type t, google::protobuf::Value v)
       : type_(std::move(t)), value_(std::move(v)) {}

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -448,9 +448,7 @@ class Value {
   static optional<T> GetValue(optional<T> const&,
                               google::protobuf::Value const& pv,
                               google::spanner::v1::Type const& pt) {
-    if (pv.kind_case() == google::protobuf::Value::kNullValue) {
-      return optional<T>{};
-    }
+    if (pv.kind_case() == google::protobuf::Value::kNullValue) return {};
     return GetValue(T{}, pv, pt);
   }
   template <typename T>

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -26,6 +26,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+
 template <typename T>
 void TestBasicSemantics(T init) {
   Value const v{init};
@@ -68,7 +69,7 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<bool>(5, x));
     std::vector<optional<bool>> v(5, x);
-    v.resize(10, x);
+    v.resize(10);
     TestBasicSemantics(v);
   }
 
@@ -79,7 +80,7 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<std::int64_t>(5, x));
     std::vector<optional<std::int64_t>> v(5, x);
-    v.resize(10, x);
+    v.resize(10);
     TestBasicSemantics(v);
   }
 
@@ -91,7 +92,7 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<double>(5, x));
     std::vector<optional<double>> v(5, x);
-    v.resize(10, x);
+    v.resize(10);
     TestBasicSemantics(v);
   }
 
@@ -101,7 +102,7 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<std::string>(5, x));
     std::vector<optional<std::string>> v(5, x);
-    v.resize(10, x);
+    v.resize(10);
     TestBasicSemantics(v);
   }
 }


### PR DESCRIPTION
`Value::GetValue(optional<T>, ...)` must check the `google::protobuf::Value`
for nullness if it is ever going to produce an `optional<T>{}`.

Change `Value.BasicSemantics` to correctly produce `vector<optional<T>>`
values that have some elements present and some missing.

Don't forward the `Value` private ctor argument to `MakeTypeProto()`.
`MakeTypeProto()` is responsible for taking its argument by value or
`const&`, and the ctor argument is only forwarded to `MakeValueProto()`.

Also use a non-throwing string->integer conversion function in
`Value::GetValue(std::int64_t, ...)`. This will help with #122.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/137)
<!-- Reviewable:end -->
