### PR TITLE
Introduce google::cloud::spanner::Date to represent a Spanner DATE

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(spanner_client
             client_options.h
             database_admin_client.cc
             database_admin_client.h
+            date.h
             internal/database_admin_stub.cc
             internal/database_admin_stub.h
             internal/spanner_stub.cc
@@ -79,6 +80,7 @@ function (spanner_client_define_tests)
     set(spanner_client_unit_tests
         client_options_test.cc
         database_admin_client_test.cc
+        date_test.cc
         internal/spanner_stub_test.cc
         internal/time_format_test.cc
         row_test.cc

--- a/google/cloud/spanner/date.h
+++ b/google/cloud/spanner/date.h
@@ -1,0 +1,61 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_DATE_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_DATE_H_
+
+#include "google/cloud/spanner/version.h"
+#include <cstdint>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+/**
+ * Represents a date in the proleptic Gregorian calendar as a triple of
+ * year, month (1-12), and day (1-31).
+ *
+ * Standard C++11 lacks a good "date" abstraction, so we supply a simple
+ * implementation of a YMD triple. There is no range checking or field
+ * normalization, and no operations. You get what you give.
+ */
+class Date {
+ public:
+  Date() : Date(0, 0, 0) {}  // Note: bad month/day
+  Date(std::int64_t year, int month, int day)
+      : year_(year), month_(month), day_(day) {}
+
+  std::int64_t year() const { return year_; }
+  int month() const { return month_; }
+  int day() const { return day_; }
+
+ private:
+  std::int64_t year_;
+  int month_;
+  int day_;
+};
+
+inline bool operator==(Date const& a, Date const& b) {
+  return a.year() == b.year() && a.month() == b.month() && a.day() == b.day();
+}
+
+inline bool operator!=(Date const& a, Date const& b) { return !(a == b); }
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_DATE_H_

--- a/google/cloud/spanner/date_test.cc
+++ b/google/cloud/spanner/date_test.cc
@@ -1,0 +1,41 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/date.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+
+TEST(Date, Basics) {
+  Date d(2019, 6, 21);
+  EXPECT_EQ(2019, d.year());
+  EXPECT_EQ(6, d.month());
+  EXPECT_EQ(21, d.day());
+
+  Date copy = d;
+  EXPECT_EQ(copy, d);
+
+  Date d2(2019, 6, 22);
+  EXPECT_NE(d2, d);
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -19,6 +19,7 @@
 spanner_client_hdrs = [
     "client_options.h",
     "database_admin_client.h",
+    "date.h",
     "internal/database_admin_stub.h",
     "internal/spanner_stub.h",
     "internal/time_format.h",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -19,6 +19,7 @@
 spanner_client_unit_tests = [
     "client_options_test.cc",
     "database_admin_client_test.cc",
+    "date_test.cc",
     "internal/spanner_stub_test.cc",
     "internal/time_format_test.cc",
     "row_test.cc",


### PR DESCRIPTION
Standard C++11 lacks a good "date" abstraction, so we supply a simple
implementation of a YMD triple. There is no range checking or field
normalization, and no operations.  Just enough to use it as a Value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/143)
<!-- Reviewable:end -->
