### PR TITLE
Iterate tuple

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(spanner_client
             internal/time.h
             internal/time_format.cc
             internal/time_format.h
+            internal/tuple_utils.h
             row.h
             sql_statement.cc
             sql_statement.h
@@ -89,6 +90,7 @@ function (spanner_client_define_tests)
         internal/spanner_stub_test.cc
         internal/time_format_test.cc
         internal/time_test.cc
+        internal/tuple_utils_test.cc
         row_test.cc
         spanner_version_test.cc
         sql_statement_test.cc

--- a/google/cloud/spanner/internal/tuple_utils.h
+++ b/google/cloud/spanner/internal/tuple_utils.h
@@ -1,0 +1,72 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_TUPLE_UTILS_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_TUPLE_UTILS_H_
+
+#include "google/cloud/spanner/version.h"
+#include <tuple>
+#include <type_traits>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+
+// Base case of `ForEach` that is called at the end of iterating a tuple.
+// See the docs for the next overload to see how to use `ForEach`.
+template <std::size_t I = 0, typename Tup, typename F, typename... Args>
+typename std::enable_if<
+    I == std::tuple_size<typename std::decay<Tup>::type>::value, void>::type
+ForEach(Tup&&, F&&, Args&&...) {}
+
+// This function template iterates the elements of a std::tuple, calling the
+// given functor with each element of the tuple as well as any additional
+// arguments that were provided. Since tuples are heterogeneous containers, the
+// given functor should be able to accept each type in the tuple. All arguments
+// are perfect-forwarded to the functor, so the functor may choose to accept
+// the tuple arguments by value, const-ref, or even non-const reference, in
+// which case the elements inside the tuple may be modified.
+//
+// Example:
+//
+//     struct Stringify {
+//       template <typename T>
+//       void operator()(T& t, std::vector<std::string>& out) const {
+//         out.push_back(std::to_string(t));
+//       }
+//     };
+//     auto tup = std::make_tuple(true, 42);
+//     std::vector<std::string> v;
+//     internal::ForEach(tup, Stringify{}, v);
+//     EXPECT_THAT(v, testing::ElementsAre("1", "42"));
+//
+template <std::size_t I = 0, typename Tup, typename F, typename... Args>
+typename std::enable_if<
+    (I < std::tuple_size<typename std::decay<Tup>::type>::value), void>::type
+ForEach(Tup&& tup, F&& f, Args&&... args) {
+  auto&& e = std::get<I>(std::forward<Tup>(tup));
+  std::forward<F>(f)(std::forward<decltype(e)>(e), std::forward<Args>(args)...);
+  ForEach<I + 1>(std::forward<Tup>(tup), std::forward<F>(f),
+                      std::forward<Args>(args)...);
+}
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_TUPLE_UTILS_H_

--- a/google/cloud/spanner/internal/tuple_utils.h
+++ b/google/cloud/spanner/internal/tuple_utils.h
@@ -25,20 +25,40 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
+// A metafunction that returns the number of elements in any class template
+// that takes a variable number of arguments.
+//
+// Example:
+//
+//     using Type = std::tuple<int, char, bool>;
+//     assert(NumElements<Type>::value == 3);
+//
+template <typename T>
+struct NumElementsImpl;
+template <template <typename...> class T, typename... Ts>
+struct NumElementsImpl<T<Ts...>> {
+  static const std::size_t value = sizeof...(Ts);
+};
+template <template <typename...> class T, typename... Ts>
+std::size_t const NumElementsImpl<T<Ts...>>::value;  // Declares storage
+template <typename T>
+using NumElements = NumElementsImpl<typename std::decay<T>::type>;
+
 // Base case of `ForEach` that is called at the end of iterating a tuple.
 // See the docs for the next overload to see how to use `ForEach`.
-template <std::size_t I = 0, typename Tup, typename F, typename... Args>
-typename std::enable_if<
-    I == std::tuple_size<typename std::decay<Tup>::type>::value, void>::type
-ForEach(Tup&&, F&&, Args&&...) {}
+template <std::size_t I = 0, typename T, typename F, typename... Args>
+typename std::enable_if<I == NumElements<T>::value, void>::type ForEach(
+    T&&, F&&, Args&&...) {}
 
-// This function template iterates the elements of a std::tuple, calling the
-// given functor with each element of the tuple as well as any additional
-// arguments that were provided. Since tuples are heterogeneous containers, the
-// given functor should be able to accept each type in the tuple. All arguments
-// are perfect-forwarded to the functor, so the functor may choose to accept
-// the tuple arguments by value, const-ref, or even non-const reference, in
-// which case the elements inside the tuple may be modified.
+// This function template iterates the elements of a tuple-like type, calling
+// the given functor with each element of the container as well as any
+// additional arguments that were provided. A tuple-like container is any
+// heterogeneous type that contains a variadic number of types, and has a
+// `get<I>(T)` function that can be found via ADL. The given functor should be
+// able to accept each type in the container. All arguments are
+// perfect-forwarded to the functor, so the functor may choose to accept the
+// tuple arguments by value, const-ref, or even non-const reference, in which
+// case the elements inside the tuple may be modified.
 //
 // Example:
 //
@@ -53,14 +73,14 @@ ForEach(Tup&&, F&&, Args&&...) {}
 //     internal::ForEach(tup, Stringify{}, v);
 //     EXPECT_THAT(v, testing::ElementsAre("1", "42"));
 //
-template <std::size_t I = 0, typename Tup, typename F, typename... Args>
-typename std::enable_if<
-    (I < std::tuple_size<typename std::decay<Tup>::type>::value), void>::type
-ForEach(Tup&& tup, F&& f, Args&&... args) {
-  auto&& e = std::get<I>(std::forward<Tup>(tup));
+template <std::size_t I = 0, typename T, typename F, typename... Args>
+typename std::enable_if<(I < NumElements<T>::value), void>::type ForEach(
+    T&& t, F&& f, Args&&... args) {
+  using std::get;
+  auto&& e = get<I>(std::forward<T>(t));
   std::forward<F>(f)(std::forward<decltype(e)>(e), std::forward<Args>(args)...);
-  ForEach<I + 1>(std::forward<Tup>(tup), std::forward<F>(f),
-                      std::forward<Args>(args)...);
+  ForEach<I + 1>(std::forward<T>(t), std::forward<F>(f),
+                 std::forward<Args>(args)...);
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/tuple_utils_test.cc
+++ b/google/cloud/spanner/internal/tuple_utils_test.cc
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/internal/tuple_utils.h"
+#include <gmock/gmock.h>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+struct Stringify {
+  template <typename T>
+  void operator()(T& t, std::vector<std::string>& out) const {
+    out.push_back(std::to_string(t));
+  }
+};
+
+TEST(TupleUtils, ForEach) {
+  auto tup = std::make_tuple(true, 42);
+  std::vector<std::string> v;
+  internal::ForEach(tup, Stringify{}, v);
+  EXPECT_THAT(v, testing::ElementsAre("1", "42"));
+}
+
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/internal/tuple_utils_test.cc
+++ b/google/cloud/spanner/internal/tuple_utils_test.cc
@@ -22,20 +22,59 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
+TEST(TupleUtils, NumElements) {
+  EXPECT_EQ(internal::NumElements<std::vector<int>>::value, 2);
+  EXPECT_EQ(internal::NumElements<std::tuple<>>::value, 0);
+  EXPECT_EQ(internal::NumElements<std::tuple<int>>::value, 1);
+  EXPECT_EQ((internal::NumElements<std::tuple<int, int>>::value), 2);
+}
+
+// Helper functor used to test the `ForEach` function. Uses a templated
+// `operator()`.
 struct Stringify {
   template <typename T>
-  void operator()(T& t, std::vector<std::string>& out) const {
+  void operator()(T const& t, std::vector<std::string>& out) const {
     out.push_back(std::to_string(t));
   }
 };
 
-TEST(TupleUtils, ForEach) {
+TEST(TupleUtils, ForEachMultipleTypes) {
   auto tup = std::make_tuple(true, 42);
   std::vector<std::string> v;
   internal::ForEach(tup, Stringify{}, v);
   EXPECT_THAT(v, testing::ElementsAre("1", "42"));
 }
 
+TEST(TupleUtils, ForEachMutate) {
+  auto add_one = [](int& x) { x += 1; };
+  auto tup = std::make_tuple(1, 2, 3);
+  internal::ForEach(tup, add_one);
+  EXPECT_EQ(tup, std::make_tuple(2, 3, 4));
+}
+
+namespace ns {
+// A type that looks like a tuple (i.e., a heterogeneous container), but is not
+// a tuple. This will verify that `ForEach` works with tuple-like types. In a
+// separate namespace to make sure that `ForEach` works with types in another
+// namespace.
+template <typename... Ts>
+struct NotATuple {
+  std::tuple<Ts...> data;
+};
+// Overload of a `get<I>(T)` function, which can be found via ADL.
+template <std::size_t I, typename... Ts>
+typename std::tuple_element<I, std::tuple<Ts...>>::type& get(  // NOLINT
+    NotATuple<Ts...>& nat) {
+  return std::get<I>(nat.data);
+}
+}  // namespace ns
+
+TEST(TupleUtils, ForEachStruct) {
+  auto not_a_tuple = ns::NotATuple<bool, int>{std::make_tuple(true, 42)};
+  std::vector<std::string> v;
+  internal::ForEach(not_a_tuple, Stringify{}, v);
+  EXPECT_THAT(v, testing::ElementsAre("1", "42"));
+}
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -25,6 +25,7 @@ spanner_client_hdrs = [
     "internal/spanner_stub.h",
     "internal/time.h",
     "internal/time_format.h",
+    "internal/tuple_utils.h",
     "row.h",
     "sql_statement.h",
     "value.h",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -24,6 +24,7 @@ spanner_client_unit_tests = [
     "internal/spanner_stub_test.cc",
     "internal/time_format_test.cc",
     "internal/time_test.cc",
+    "internal/tuple_utils_test.cc",
     "row_test.cc",
     "spanner_version_test.cc",
     "sql_statement_test.cc",


### PR DESCRIPTION
Refactors the `IterateTuple` function from the private section of `Value` into `internal/tuple_utils.h` so that it can be used from other places (I'll need this from an upcoming "RowParser" class). The function is renamed to `internal::ForEach`.

This PR also makes the implementation a bit more generic so that it will work with not just `std::tuple`, but also any class that looks like a tuple, that is any class template that takes a variable number of template parameters. This will make `ForEach` work with the `Row<Ts...>` class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/146)
<!-- Reviewable:end -->
