### PR TITLE
feat: Implement spanner::Value support for TIMESTAMP and DATE

### DIFF
--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_VALUE_H_
 
+#include "google/cloud/spanner/date.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/optional.h"
@@ -22,6 +23,7 @@
 #include <google/protobuf/struct.pb.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <google/spanner/v1/type.pb.h>
+#include <chrono>
 #include <ostream>
 #include <string>
 #include <tuple>
@@ -56,6 +58,8 @@ std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v);
  * INT64        | `std::int64_t`
  * FLOAT64      | `double`
  * STRING       | `std::string`
+ * TIMESTAMP    | `std::chrono::system_clock::time_point`
+ * DATE         | `google::cloud::spanner::Date`
  * ARRAY        | `std::vector<T>`  // [1]
  * STRUCT       | `std::tuple<Ts...>`
  *
@@ -144,6 +148,9 @@ class Value {
   explicit Value(std::int64_t v) : Value(PrivateConstructor{}, v) {}
   explicit Value(double v) : Value(PrivateConstructor{}, v) {}
   explicit Value(std::string v) : Value(PrivateConstructor{}, std::move(v)) {}
+  explicit Value(std::chrono::system_clock::time_point v)
+      : Value(PrivateConstructor{}, std::move(v)) {}
+  explicit Value(Date v) : Value(PrivateConstructor{}, std::move(v)) {}
 
   /**
    * Constructs a non-null instance from common C++ literal types that closely,
@@ -320,6 +327,8 @@ class Value {
   friend void PrintTo(Value const& v, std::ostream* os);
 
  private:
+  using time_point = std::chrono::system_clock::time_point;
+
   // Metafunction that returns true if `T` is an optional<U>
   template <typename T>
   struct is_optional : std::false_type {};
@@ -338,6 +347,8 @@ class Value {
   static google::spanner::v1::Type MakeTypeProto(std::int64_t);
   static google::spanner::v1::Type MakeTypeProto(double);
   static google::spanner::v1::Type MakeTypeProto(std::string const&);
+  static google::spanner::v1::Type MakeTypeProto(time_point);
+  static google::spanner::v1::Type MakeTypeProto(Date);
   static google::spanner::v1::Type MakeTypeProto(int);
   static google::spanner::v1::Type MakeTypeProto(char const*);
   template <typename T>
@@ -393,6 +404,8 @@ class Value {
   static google::protobuf::Value MakeValueProto(std::int64_t i);
   static google::protobuf::Value MakeValueProto(double d);
   static google::protobuf::Value MakeValueProto(std::string s);
+  static google::protobuf::Value MakeValueProto(time_point ts);
+  static google::protobuf::Value MakeValueProto(Date d);
   static google::protobuf::Value MakeValueProto(int i);
   static google::protobuf::Value MakeValueProto(char const* s);
   template <typename T>
@@ -444,6 +457,10 @@ class Value {
   static std::string GetValue(std::string const&,
                               google::protobuf::Value const&,
                               google::spanner::v1::Type const&);
+  static time_point GetValue(time_point, google::protobuf::Value const&,
+                             google::spanner::v1::Type const&);
+  static Date GetValue(Date, google::protobuf::Value const&,
+                       google::spanner::v1::Type const&);
   template <typename T>
   static optional<T> GetValue(optional<T> const&,
                               google::protobuf::Value const& pv,

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/value.h"
+#include "google/cloud/spanner/internal/date.h"
+#include "google/cloud/spanner/internal/time.h"
 #include "google/cloud/optional.h"
 #include <gmock/gmock.h>
 #include <cmath>
@@ -102,6 +104,48 @@ TEST(Value, BasicSemantics) {
     TestBasicSemantics(x);
     TestBasicSemantics(std::vector<std::string>(5, x));
     std::vector<optional<std::string>> v(5, x);
+    v.resize(10);
+    TestBasicSemantics(v);
+  }
+
+  for (time_t t : {
+           -9223372035L,  // near the limit of 64-bit/ns system_clock
+           -2147483649L,  // below min 32-bit int
+           -2147483648L,  // min 32-bit int
+           -1L, 0L, 1L,   // around the unix epoch
+           1561147549L,   // contemporary
+           2147483647L,   // max 32-bit int
+           2147483648L,   // above max 32-bit int
+           9223372036L    // near the limit of 64-bit/ns system_clock
+       }) {
+    auto tp = std::chrono::system_clock::from_time_t(t);
+    for (auto micros : {-1, 0, 1}) {
+      auto ts = tp + std::chrono::microseconds(micros);
+      SCOPED_TRACE("Testing: std::chrono::system_clock::time_point " +
+                   internal::TimestampToString(ts));
+      TestBasicSemantics(ts);
+      std::vector<std::chrono::system_clock::time_point> v(5, ts);
+      TestBasicSemantics(v);
+      std::vector<optional<std::chrono::system_clock::time_point>> ov(5, ts);
+      ov.resize(10);
+      TestBasicSemantics(ov);
+    }
+  }
+
+  for (auto x : {
+           Date(1582, 10, 15),  // start of Gregorian calendar
+           Date(1677, 9, 21),   // before system_clock limit
+           Date(1901, 12, 13),  // around min 32-bit seconds limit
+           Date(1970, 1, 1),    // the unix epoch
+           Date(2019, 6, 21),   // contemporary
+           Date(2038, 1, 19),   // around max 32-bit seconds limit
+           Date(2262, 4, 12)    // after system_clock limit
+       }) {
+    SCOPED_TRACE("Testing: google::cloud::spanner::Date " +
+                 internal::DateToString(x));
+    TestBasicSemantics(x);
+    TestBasicSemantics(std::vector<Date>(5, x));
+    std::vector<optional<Date>> v(5, x);
     v.resize(10);
     TestBasicSemantics(v);
   }
@@ -414,6 +458,47 @@ TEST(Value, ProtoConversionString) {
     EXPECT_EQ(v, internal::FromProto(p.first, p.second));
     EXPECT_EQ(google::spanner::v1::TypeCode::STRING, p.first.code());
     EXPECT_EQ(x, p.second.string_value());
+  }
+}
+
+TEST(Value, ProtoConversionTimestamp) {
+  for (time_t t : {
+           -9223372035L,  // near the limit of 64-bit/ns system_clock
+           -2147483649L,  // below min 32-bit int
+           -2147483648L,  // min 32-bit int
+           -1L, 0L, 1L,   // around the unix epoch
+           1561147549L,   // contemporary
+           2147483647L,   // max 32-bit int
+           2147483648L,   // above max 32-bit int
+           9223372036L    // near the limit of 64-bit/ns system_clock
+       }) {
+    auto tp = std::chrono::system_clock::from_time_t(t);
+    for (auto micros : {-1, 0, 1}) {
+      auto ts = tp + std::chrono::microseconds(micros);
+      Value const v(ts);
+      auto const p = internal::ToProto(v);
+      EXPECT_EQ(v, internal::FromProto(p.first, p.second));
+      EXPECT_EQ(google::spanner::v1::TypeCode::TIMESTAMP, p.first.code());
+      EXPECT_EQ(internal::TimestampToString(ts), p.second.string_value());
+    }
+  }
+}
+
+TEST(Value, ProtoConversionDate) {
+  for (auto x : {
+           Date(1582, 10, 15),  // start of Gregorian calendar
+           Date(1677, 9, 21),   // before system_clock limit
+           Date(1901, 12, 13),  // around min 32-bit seconds limit
+           Date(1970, 1, 1),    // the unix epoch
+           Date(2019, 6, 21),   // contemporary
+           Date(2038, 1, 19),   // around max 32-bit seconds limit
+           Date(2262, 4, 12)    // after system_clock limit
+       }) {
+    Value const v(x);
+    auto const p = internal::ToProto(v);
+    EXPECT_EQ(v, internal::FromProto(p.first, p.second));
+    EXPECT_EQ(google::spanner::v1::TypeCode::DATE, p.first.code());
+    EXPECT_EQ(internal::DateToString(x), p.second.string_value());
   }
 }
 


### PR DESCRIPTION
TIMESTAMP is represented by `std::chrono::system_clock::time_point`
(although see #138), and DATE by a new, simple "YMD" type,
`google::cloud::spanner::Date`.

Fixes #50 and #51.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/149)
<!-- Reviewable:end -->
