### PR TITLE
Removes need for tuple-like types to overload ADL `get<I>(T)`.

### DIFF
--- a/google/cloud/spanner/internal/tuple_utils.h
+++ b/google/cloud/spanner/internal/tuple_utils.h
@@ -44,6 +44,15 @@ std::size_t const NumElementsImpl<T<Ts...>>::value;  // Declares storage
 template <typename T>
 using NumElements = NumElementsImpl<typename std::decay<T>::type>;
 
+// Similar to `std::get<I>(std::tuple)`, except that this function is an
+// extension point for `ForEach` (below) that callers can define in their own
+// namespace for their own types to add support for `ForEach`. This overload
+// simply forwards to `std::get`.
+template <std::size_t I, typename Tup>
+auto GetElement(Tup&& tup) -> decltype(std::get<I>(std::forward<Tup>(tup))) {
+  return std::get<I>(std::forward<Tup>(tup));
+}
+
 // Base case of `ForEach` that is called at the end of iterating a tuple.
 // See the docs for the next overload to see how to use `ForEach`.
 template <std::size_t I = 0, typename T, typename F, typename... Args>
@@ -52,13 +61,13 @@ typename std::enable_if<I == NumElements<T>::value, void>::type ForEach(
 
 // This function template iterates the elements of a tuple-like type, calling
 // the given functor with each element of the container as well as any
-// additional arguments that were provided. A tuple-like container is any
-// heterogeneous type that contains a variadic number of types, and has a
-// `get<I>(T)` function that can be found via ADL. The given functor should be
-// able to accept each type in the container. All arguments are
-// perfect-forwarded to the functor, so the functor may choose to accept the
-// tuple arguments by value, const-ref, or even non-const reference, in which
-// case the elements inside the tuple may be modified.
+// additional arguments that were provided. A tuple-like type is any fixed-size
+// heterogeneous container that has a `GetElement<I>(T)` function that can be
+// found via ADL. The given functor should be able to accept each type in the
+// container. All arguments are perfect-forwarded to the functor, so the
+// functor may choose to accept the tuple arguments by value, const-ref, or
+// even non-const reference, in which case the elements inside the tuple may be
+// modified.
 //
 // Example:
 //
@@ -76,8 +85,7 @@ typename std::enable_if<I == NumElements<T>::value, void>::type ForEach(
 template <std::size_t I = 0, typename T, typename F, typename... Args>
 typename std::enable_if<(I < NumElements<T>::value), void>::type ForEach(
     T&& t, F&& f, Args&&... args) {
-  using std::get;
-  auto&& e = get<I>(std::forward<T>(t));
+  auto&& e = GetElement<I>(std::forward<T>(t));
   std::forward<F>(f)(std::forward<decltype(e)>(e), std::forward<Args>(args)...);
   ForEach<I + 1>(std::forward<T>(t), std::forward<F>(f),
                  std::forward<Args>(args)...);

--- a/google/cloud/spanner/internal/tuple_utils.h
+++ b/google/cloud/spanner/internal/tuple_utils.h
@@ -50,7 +50,8 @@ using NumElements = NumElementsImpl<typename std::decay<T>::type>;
 // simply forwards to `std::get`.
 template <std::size_t I, typename Tup>
 auto GetElement(Tup&& tup) -> decltype(std::get<I>(std::forward<Tup>(tup))) {
-  return std::get<I>(std::forward<Tup>(tup));
+  using std::get;
+  return get<I>(std::forward<Tup>(tup));
 }
 
 // Base case of `ForEach` that is called at the end of iterating a tuple.

--- a/google/cloud/spanner/internal/tuple_utils_test.cc
+++ b/google/cloud/spanner/internal/tuple_utils_test.cc
@@ -61,10 +61,10 @@ template <typename... Ts>
 struct NotATuple {
   std::tuple<Ts...> data;
 };
-// Overload of a `get<I>(T)` function, which can be found via ADL.
+
+// Required ADL extension point to make `NotATuple` iterable like a tuple.
 template <std::size_t I, typename... Ts>
-typename std::tuple_element<I, std::tuple<Ts...>>::type& get(  // NOLINT
-    NotATuple<Ts...>& nat) {
+auto GetElement(NotATuple<Ts...>& nat) -> decltype(std::get<I>(nat.data)) {
   return std::get<I>(nat.data);
 }
 }  // namespace ns


### PR DESCRIPTION
For a type to work with `internal::ForEach`, that type must now provide
a non-member function named `GetElement<I>(T)` that can be found via
ADL. It should do the equivalent of what `std::get<I>(T)` does, but this
differently named function makes it so we don't need to step on
`std::get`'s toes. It also avoids our need to implement a
namespace-scope function named "get", which violates a
clang-tidy-enforced readability rule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/151)
<!-- Reviewable:end -->
