### PR TITLE
Makes Value::GetValue() return StatusOr<T>

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -220,8 +220,8 @@ google::protobuf::Value Value::MakeValueProto(char const* s) {
 
 StatusOr<bool> Value::GetValue(bool, google::protobuf::Value const& pv,
                                google::spanner::v1::Type const&) {
-  if (pv.kind_case() == google::protobuf::Value::kNullValue) {
-    return Status(StatusCode::kInvalidArgument, "value null");
+  if (pv.kind_case() != google::protobuf::Value::kBoolValue) {
+    return Status(StatusCode::kUnknown, "missing BOOL");
   }
   return pv.bool_value();
 }
@@ -229,8 +229,8 @@ StatusOr<bool> Value::GetValue(bool, google::protobuf::Value const& pv,
 StatusOr<std::int64_t> Value::GetValue(std::int64_t,
                                        google::protobuf::Value const& pv,
                                        google::spanner::v1::Type const&) {
-  if (pv.kind_case() == google::protobuf::Value::kNullValue) {
-    return Status(StatusCode::kInvalidArgument, "value null");
+  if (pv.kind_case() != google::protobuf::Value::kStringValue) {
+    return Status(StatusCode::kUnknown, "missing INT64");
   }
   auto const& s = pv.string_value();
   char* end = nullptr;
@@ -251,25 +251,25 @@ StatusOr<std::int64_t> Value::GetValue(std::int64_t,
 
 StatusOr<double> Value::GetValue(double, google::protobuf::Value const& pv,
                                  google::spanner::v1::Type const&) {
-  if (pv.kind_case() == google::protobuf::Value::kNullValue) {
-    return Status(StatusCode::kInvalidArgument, "value null");
+  if (pv.kind_case() == google::protobuf::Value::kNumberValue) {
+    return pv.number_value();
   }
-  if (pv.kind_case() == google::protobuf::Value::kStringValue) {
-    std::string const& s = pv.string_value();
-    auto const inf = std::numeric_limits<double>::infinity();
-    if (s == "-Infinity") return -inf;
-    if (s == "Infinity") return inf;
-    if (s == "NaN") return std::nan("");
-    return Status(StatusCode::kUnknown, "Bad FLOAT64 data: \"" + s + "\"");
+  if (pv.kind_case() != google::protobuf::Value::kStringValue) {
+    return Status(StatusCode::kUnknown, "missing FLOAT64");
   }
-  return pv.number_value();
+  std::string const& s = pv.string_value();
+  auto const inf = std::numeric_limits<double>::infinity();
+  if (s == "-Infinity") return -inf;
+  if (s == "Infinity") return inf;
+  if (s == "NaN") return std::nan("");
+  return Status(StatusCode::kUnknown, "bad FLOAT64 data: \"" + s + "\"");
 }
 
 StatusOr<std::string> Value::GetValue(std::string const&,
                                       google::protobuf::Value const& pv,
                                       google::spanner::v1::Type const&) {
-  if (pv.kind_case() == google::protobuf::Value::kNullValue) {
-    return Status(StatusCode::kInvalidArgument, "value null");
+  if (pv.kind_case() != google::protobuf::Value::kStringValue) {
+    return Status(StatusCode::kUnknown, "missing STRING");
   }
   return pv.string_value();
 }
@@ -277,16 +277,16 @@ StatusOr<std::string> Value::GetValue(std::string const&,
 StatusOr<std::chrono::system_clock::time_point> Value::GetValue(
     time_point, google::protobuf::Value const& pv,
     google::spanner::v1::Type const&) {
-  if (pv.kind_case() == google::protobuf::Value::kNullValue) {
-    return Status(StatusCode::kInvalidArgument, "value null");
+  if (pv.kind_case() != google::protobuf::Value::kStringValue) {
+    return Status(StatusCode::kUnknown, "missing TIMESTAMP");
   }
   return internal::TimestampFromString(pv.string_value());
 }
 
 StatusOr<Date> Value::GetValue(Date, google::protobuf::Value const& pv,
                                google::spanner::v1::Type const&) {
-  if (pv.kind_case() == google::protobuf::Value::kNullValue) {
-    return Status(StatusCode::kInvalidArgument, "value null");
+  if (pv.kind_case() != google::protobuf::Value::kStringValue) {
+    return Status(StatusCode::kUnknown, "missing DATE");
   }
   return internal::DateFromString(pv.string_value());
 }

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -499,7 +499,7 @@ class Value {
       return Status(StatusCode::kInvalidArgument, "missing STRUCT");
     }
     std::tuple<Ts...> tup;
-    Status status;
+    Status status;  // OK
     ExtractTupleValues f{status, 0, pv.list_value(), pt};
     internal::ForEach(tup, f);
     if (!status.ok()) return status;

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -287,10 +287,10 @@ class Value {
    */
   template <typename T>
   StatusOr<T> get() const {
-    if (!is<T>()) return Status(StatusCode::kInvalidArgument, "wrong type");
+    if (!is<T>()) return Status(StatusCode::kUnknown, "wrong type");
     if (value_.kind_case() == google::protobuf::Value::kNullValue) {
       if (is_optional<T>::value) return T{};
-      return Status(StatusCode::kInvalidArgument, "null value");
+      return Status(StatusCode::kUnknown, "null value");
     }
     return GetValue(T{}, value_, type_);
   }
@@ -496,7 +496,7 @@ class Value {
       std::tuple<Ts...> const&, google::protobuf::Value const& pv,
       google::spanner::v1::Type const& pt) {
     if (pv.kind_case() != google::protobuf::Value::kListValue) {
-      return Status(StatusCode::kInvalidArgument, "missing STRUCT");
+      return Status(StatusCode::kUnknown, "missing STRUCT");
     }
     std::tuple<Ts...> tup;
     Status status;  // OK

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -533,6 +533,179 @@ TEST(Value, ProtoConversionStruct) {
   EXPECT_EQ("42", p.second.list_value().values(1).string_value());
 }
 
+void SetProtoKind(Value& v, google::protobuf::NullValue x) {
+  auto p = internal::ToProto(v);
+  p.second.set_null_value(x);
+  v = internal::FromProto(p.first, p.second);
+}
+
+void SetProtoKind(Value& v, double x) {
+  auto p = internal::ToProto(v);
+  p.second.set_number_value(x);
+  v = internal::FromProto(p.first, p.second);
+}
+
+void SetProtoKind(Value& v, char const* x) {
+  auto p = internal::ToProto(v);
+  p.second.set_string_value(x);
+  v = internal::FromProto(p.first, p.second);
+}
+
+void SetProtoKind(Value& v, bool x) {
+  auto p = internal::ToProto(v);
+  p.second.set_bool_value(x);
+  v = internal::FromProto(p.first, p.second);
+}
+
+TEST(Value, GetBadBool) {
+  Value v(true);
+  SetProtoKind(v, google::protobuf::NULL_VALUE);
+  EXPECT_TRUE(v.is<bool>());
+  EXPECT_FALSE(v.get<bool>().ok());
+
+  SetProtoKind(v, 0.0);
+  EXPECT_TRUE(v.is<bool>());
+  EXPECT_FALSE(v.get<bool>().ok());
+
+  SetProtoKind(v, "hello");
+  EXPECT_TRUE(v.is<bool>());
+  EXPECT_FALSE(v.get<bool>().ok());
+}
+
+TEST(Value, GetBadDouble) {
+  Value v(0.0);
+  SetProtoKind(v, google::protobuf::NULL_VALUE);
+  EXPECT_TRUE(v.is<double>());
+  EXPECT_FALSE(v.get<double>().ok());
+
+  SetProtoKind(v, true);
+  EXPECT_TRUE(v.is<double>());
+  EXPECT_FALSE(v.get<double>().ok());
+
+  SetProtoKind(v, "bad string");
+  EXPECT_TRUE(v.is<double>());
+  EXPECT_FALSE(v.get<double>().ok());
+}
+
+TEST(Value, GetBadString) {
+  Value v("hello");
+  SetProtoKind(v, google::protobuf::NULL_VALUE);
+  EXPECT_TRUE(v.is<std::string>());
+  EXPECT_FALSE(v.get<std::string>().ok());
+
+  SetProtoKind(v, true);
+  EXPECT_TRUE(v.is<std::string>());
+  EXPECT_FALSE(v.get<std::string>().ok());
+
+  SetProtoKind(v, 0.0);
+  EXPECT_TRUE(v.is<std::string>());
+  EXPECT_FALSE(v.get<std::string>().ok());
+}
+
+TEST(Value, GetBadInt) {
+  Value v(42);
+  SetProtoKind(v, google::protobuf::NULL_VALUE);
+  EXPECT_TRUE(v.is<std::int64_t>());
+  EXPECT_FALSE(v.get<std::int64_t>().ok());
+
+  SetProtoKind(v, true);
+  EXPECT_TRUE(v.is<std::int64_t>());
+  EXPECT_FALSE(v.get<std::int64_t>().ok());
+
+  SetProtoKind(v, 0.0);
+  EXPECT_TRUE(v.is<std::int64_t>());
+  EXPECT_FALSE(v.get<std::int64_t>().ok());
+
+  SetProtoKind(v, "");
+  EXPECT_TRUE(v.is<std::int64_t>());
+  EXPECT_FALSE(v.get<std::int64_t>().ok());
+
+  SetProtoKind(v, "blah");
+  EXPECT_TRUE(v.is<std::int64_t>());
+  EXPECT_FALSE(v.get<std::int64_t>().ok());
+
+  SetProtoKind(v, "123blah");
+  EXPECT_TRUE(v.is<std::int64_t>());
+  EXPECT_FALSE(v.get<std::int64_t>().ok());
+}
+
+TEST(Value, GetBadTimestamp) {
+  using time_point = std::chrono::system_clock::time_point;
+  Value v(time_point{});
+  SetProtoKind(v, google::protobuf::NULL_VALUE);
+  EXPECT_TRUE(v.is<time_point>());
+  EXPECT_FALSE(v.get<time_point>().ok());
+
+  SetProtoKind(v, true);
+  EXPECT_TRUE(v.is<time_point>());
+  EXPECT_FALSE(v.get<time_point>().ok());
+
+  SetProtoKind(v, 0.0);
+  EXPECT_TRUE(v.is<time_point>());
+  EXPECT_FALSE(v.get<time_point>().ok());
+
+  SetProtoKind(v, "blah");
+  EXPECT_TRUE(v.is<time_point>());
+  EXPECT_FALSE(v.get<time_point>().ok());
+}
+
+TEST(Value, GetBadDate) {
+  Value v(Date{});
+  SetProtoKind(v, google::protobuf::NULL_VALUE);
+  EXPECT_TRUE(v.is<Date>());
+  EXPECT_FALSE(v.get<Date>().ok());
+
+  SetProtoKind(v, true);
+  EXPECT_TRUE(v.is<Date>());
+  EXPECT_FALSE(v.get<Date>().ok());
+
+  SetProtoKind(v, 0.0);
+  EXPECT_TRUE(v.is<Date>());
+  EXPECT_FALSE(v.get<Date>().ok());
+
+  SetProtoKind(v, "blah");
+  EXPECT_TRUE(v.is<Date>());
+  EXPECT_FALSE(v.get<Date>().ok());
+}
+
+TEST(Value, GetBadArray) {
+  Value v(std::vector<double>{});
+  SetProtoKind(v, google::protobuf::NULL_VALUE);
+  EXPECT_TRUE(v.is<std::vector<double>>());
+  EXPECT_FALSE(v.get<std::vector<double>>().ok());
+
+  SetProtoKind(v, true);
+  EXPECT_TRUE(v.is<std::vector<double>>());
+  EXPECT_FALSE(v.get<std::vector<double>>().ok());
+
+  SetProtoKind(v, 0.0);
+  EXPECT_TRUE(v.is<std::vector<double>>());
+  EXPECT_FALSE(v.get<std::vector<double>>().ok());
+
+  SetProtoKind(v, "blah");
+  EXPECT_TRUE(v.is<std::vector<double>>());
+  EXPECT_FALSE(v.get<std::vector<double>>().ok());
+}
+
+TEST(Value, GetBadStruct) {
+  Value v(std::tuple<bool>{});
+  SetProtoKind(v, google::protobuf::NULL_VALUE);
+  EXPECT_TRUE(v.is<std::tuple<bool>>());
+  EXPECT_FALSE(v.get<std::tuple<bool>>().ok());
+
+  SetProtoKind(v, true);
+  EXPECT_TRUE(v.is<std::tuple<bool>>());
+  EXPECT_FALSE(v.get<std::tuple<bool>>().ok());
+
+  SetProtoKind(v, 0.0);
+  EXPECT_TRUE(v.is<std::tuple<bool>>());
+  EXPECT_FALSE(v.get<std::tuple<bool>>().ok());
+
+  SetProtoKind(v, "blah");
+  EXPECT_TRUE(v.is<std::tuple<bool>>());
+  EXPECT_FALSE(v.get<std::tuple<bool>>().ok());
+}
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -557,8 +557,18 @@ void SetProtoKind(Value& v, bool x) {
   v = internal::FromProto(p.first, p.second);
 }
 
+void ClearProtoKind(Value& v) {
+  auto p = internal::ToProto(v);
+  p.second.clear_kind();
+  v = internal::FromProto(p.first, p.second);
+}
+
 TEST(Value, GetBadBool) {
   Value v(true);
+  ClearProtoKind(v);
+  EXPECT_TRUE(v.is<bool>());
+  EXPECT_FALSE(v.get<bool>().ok());
+
   SetProtoKind(v, google::protobuf::NULL_VALUE);
   EXPECT_TRUE(v.is<bool>());
   EXPECT_FALSE(v.get<bool>().ok());
@@ -574,6 +584,10 @@ TEST(Value, GetBadBool) {
 
 TEST(Value, GetBadDouble) {
   Value v(0.0);
+  ClearProtoKind(v);
+  EXPECT_TRUE(v.is<double>());
+  EXPECT_FALSE(v.get<double>().ok());
+
   SetProtoKind(v, google::protobuf::NULL_VALUE);
   EXPECT_TRUE(v.is<double>());
   EXPECT_FALSE(v.get<double>().ok());
@@ -589,6 +603,10 @@ TEST(Value, GetBadDouble) {
 
 TEST(Value, GetBadString) {
   Value v("hello");
+  ClearProtoKind(v);
+  EXPECT_TRUE(v.is<std::string>());
+  EXPECT_FALSE(v.get<std::string>().ok());
+
   SetProtoKind(v, google::protobuf::NULL_VALUE);
   EXPECT_TRUE(v.is<std::string>());
   EXPECT_FALSE(v.get<std::string>().ok());
@@ -604,6 +622,10 @@ TEST(Value, GetBadString) {
 
 TEST(Value, GetBadInt) {
   Value v(42);
+  ClearProtoKind(v);
+  EXPECT_TRUE(v.is<std::int64_t>());
+  EXPECT_FALSE(v.get<std::int64_t>().ok());
+
   SetProtoKind(v, google::protobuf::NULL_VALUE);
   EXPECT_TRUE(v.is<std::int64_t>());
   EXPECT_FALSE(v.get<std::int64_t>().ok());
@@ -632,6 +654,10 @@ TEST(Value, GetBadInt) {
 TEST(Value, GetBadTimestamp) {
   using time_point = std::chrono::system_clock::time_point;
   Value v(time_point{});
+  ClearProtoKind(v);
+  EXPECT_TRUE(v.is<time_point>());
+  EXPECT_FALSE(v.get<time_point>().ok());
+
   SetProtoKind(v, google::protobuf::NULL_VALUE);
   EXPECT_TRUE(v.is<time_point>());
   EXPECT_FALSE(v.get<time_point>().ok());
@@ -651,6 +677,10 @@ TEST(Value, GetBadTimestamp) {
 
 TEST(Value, GetBadDate) {
   Value v(Date{});
+  ClearProtoKind(v);
+  EXPECT_TRUE(v.is<Date>());
+  EXPECT_FALSE(v.get<Date>().ok());
+
   SetProtoKind(v, google::protobuf::NULL_VALUE);
   EXPECT_TRUE(v.is<Date>());
   EXPECT_FALSE(v.get<Date>().ok());
@@ -668,8 +698,27 @@ TEST(Value, GetBadDate) {
   EXPECT_FALSE(v.get<Date>().ok());
 }
 
+TEST(Value, GetBadOptional) {
+  Value v(optional<double>{});
+  ClearProtoKind(v);
+  EXPECT_TRUE(v.is<optional<double>>());
+  EXPECT_FALSE(v.get<optional<double>>().ok());
+
+  SetProtoKind(v, true);
+  EXPECT_TRUE(v.is<optional<double>>());
+  EXPECT_FALSE(v.get<optional<double>>().ok());
+
+  SetProtoKind(v, "blah");
+  EXPECT_TRUE(v.is<optional<double>>());
+  EXPECT_FALSE(v.get<optional<double>>().ok());
+}
+
 TEST(Value, GetBadArray) {
   Value v(std::vector<double>{});
+  ClearProtoKind(v);
+  EXPECT_TRUE(v.is<std::vector<double>>());
+  EXPECT_FALSE(v.get<std::vector<double>>().ok());
+
   SetProtoKind(v, google::protobuf::NULL_VALUE);
   EXPECT_TRUE(v.is<std::vector<double>>());
   EXPECT_FALSE(v.get<std::vector<double>>().ok());
@@ -689,6 +738,10 @@ TEST(Value, GetBadArray) {
 
 TEST(Value, GetBadStruct) {
   Value v(std::tuple<bool>{});
+  ClearProtoKind(v);
+  EXPECT_TRUE(v.is<std::tuple<bool>>());
+  EXPECT_FALSE(v.get<std::tuple<bool>>().ok());
+
   SetProtoKind(v, google::protobuf::NULL_VALUE);
   EXPECT_TRUE(v.is<std::tuple<bool>>());
   EXPECT_FALSE(v.get<std::tuple<bool>>().ok());


### PR DESCRIPTION
In order to be able to detect invalid protobufs, `Value::GetValue` needs to return `StatusOr<T>`. This PR adds that support, and some tests to verify its behavior. This is needed for the upcoming RowParser (#32)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/152)
<!-- Reviewable:end -->
