### PR TITLE
Adds ParseRow() function

### DIFF
--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -226,10 +226,10 @@ struct ExtractValue {
   template <typename T, typename It>
   void operator()(T& t, It& it) const {
     auto x = it++->template get<T>();
-    if (x) {
-      t = *std::move(x);
-    } else {
+    if (!x) {
       status = std::move(x).status();
+    } else {
+      t = *std::move(x);
     }
   }
 };
@@ -275,8 +275,8 @@ StatusOr<Row<internal::PromoteLiteral<Ts>...>> ParseRow(
   auto it = array.begin();
   Status status;
   internal::ForEach(row, internal::ExtractValue{status}, it);
-  if (status.ok()) return row;
-  return status;
+  if (!status.ok()) return status;
+  return row;
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -15,13 +15,13 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ROW_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_ROW_H_
 
+#include "google/cloud/spanner/internal/tuple_utils.h"
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/spanner/version.h"
-#include "google/cloud/spanner/internal/tuple_utils.h"
 #include "google/cloud/internal/disjunction.h"
 #include "google/cloud/status_or.h"
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -199,7 +199,7 @@ class Row {
   std::tuple<Types...> values_;
 };
 
-// Overload of a `get<I>(T)` function, which can be found via ADL. Allowing 
+// Overload of a `get<I>(T)` function, which can be found via ADL. Allowing
 template <std::size_t I, typename... Ts>
 auto get(Row<Ts...>& row) -> decltype(row.template get<I>()) {
   return row.template get<I>();

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/spanner/row.h"
 #include <gmock/gmock.h>
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include <string>
 #include <tuple>
 #include <type_traits>

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -175,7 +175,7 @@ TEST(Row, MakeRowCVQualifications) {
 }
 
 TEST(Row, ParseRowEmpty) {
-  std::array<Value, 0> const array;
+  std::array<Value, 0> const array = {};
   auto const row = ParseRow(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(), *row);

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -174,7 +174,32 @@ TEST(Row, MakeRowCVQualifications) {
                 "row holds a non-const string value");
 }
 
-TEST(Row, ParseRow) {
+TEST(Row, ParseRowEmpty) {
+  std::array<Value, 0> const array;
+  auto const row = ParseRow(array);
+  EXPECT_TRUE(row.ok());
+  EXPECT_EQ(MakeRow(), *row);
+}
+
+TEST(Row, ParseRowOneValue) {
+  std::array<Value, 1> const array = {Value(42)};
+  auto const row = ParseRow<std::int64_t>(array);
+  EXPECT_TRUE(row.ok());
+  EXPECT_EQ(MakeRow(42), *row);
+
+  // Tests parsing the Value with the wrong type.
+  auto const error_row = ParseRow<double>(array);
+  EXPECT_FALSE(row.ok());
+}
+
+TEST(Row, ParseRowThree) {
+  std::array<Value, 3> three = {Value(true), Value(42), Value("hello")};
+  auto row = ParseRow<bool, std::int64_t, std::string>(three);
+  EXPECT_TRUE(row.ok());
+  EXPECT_EQ(MakeRow(true, 42, "hello"), *row);
+}
+
+TEST(Row, ParseRowError) {
   std::array<Value, 3> array = {Value(true), Value(42), Value("hello")};
   auto row = ParseRow<bool, std::int64_t, std::string>(array);
   EXPECT_TRUE(row.ok());

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -188,7 +188,7 @@ TEST(Row, ParseRowOneValue) {
   EXPECT_EQ(MakeRow(42), *row);
   // Tests parsing the Value with the wrong type.
   auto const error_row = ParseRow<double>(array);
-  EXPECT_FALSE(row.ok());
+  EXPECT_FALSE(error_row.ok());
 }
 
 TEST(Row, ParseRowThree) {
@@ -198,7 +198,7 @@ TEST(Row, ParseRowThree) {
   EXPECT_EQ(MakeRow(true, 42, "hello"), *row);
   // Tests parsing the Value with the wrong type.
   auto const error_row = ParseRow<bool, double, std::string>(array);
-  EXPECT_FALSE(row.ok());
+  EXPECT_FALSE(error_row.ok());
 }
 
 }  // namespace

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/row.h"
 #include <gmock/gmock.h>
 #include <cstdint>
+#include <array>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -171,6 +172,13 @@ TEST(Row, MakeRowCVQualifications) {
   auto row = MakeRow(s);
   static_assert(std::is_same<Row<std::string>, decltype(row)>::value,
                 "row holds a non-const string value");
+}
+
+TEST(Row, ParseRow) {
+  std::array<Value, 3> array = {Value(true), Value(42), Value("hello")};
+  auto row = ParseRow<bool, std::int64_t, std::string>(array);
+  EXPECT_TRUE(row.ok());
+  EXPECT_EQ(MakeRow(true, 42, "hello"), *row);
 }
 
 }  // namespace

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -186,24 +186,19 @@ TEST(Row, ParseRowOneValue) {
   auto const row = ParseRow<std::int64_t>(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(42), *row);
-
   // Tests parsing the Value with the wrong type.
   auto const error_row = ParseRow<double>(array);
   EXPECT_FALSE(row.ok());
 }
 
 TEST(Row, ParseRowThree) {
-  std::array<Value, 3> three = {Value(true), Value(42), Value("hello")};
-  auto row = ParseRow<bool, std::int64_t, std::string>(three);
-  EXPECT_TRUE(row.ok());
-  EXPECT_EQ(MakeRow(true, 42, "hello"), *row);
-}
-
-TEST(Row, ParseRowError) {
   std::array<Value, 3> array = {Value(true), Value(42), Value("hello")};
   auto row = ParseRow<bool, std::int64_t, std::string>(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(true, 42, "hello"), *row);
+  // Tests parsing the Value with the wrong type.
+  auto const error_row = ParseRow<bool, double, std::string>(array);
+  EXPECT_FALSE(row.ok());
 }
 
 }  // namespace


### PR DESCRIPTION
Adds a `ParseRow()` function to row.h that knows how to extract C++ types form a `std::array` of `spanner::Value` objects. This function will be called from an upcoming "RowParser" class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/153)
<!-- Reviewable:end -->
