### PR TITLE
cleanup: Make .clang-tidy consistent.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,7 @@
 # Configure clang-tidy for this project.
 
 # Disabled:
-#  -google-readability-namespace-comments the BIGTABLE_CLIENT_NS is a macro, and
+#  -google-readability-namespace-comments the *_CLIENT_NS is a macro, and
 #   clang-tidy fails to match it against the initial value.
 Checks: >-
   bugprone-*,
@@ -38,11 +38,13 @@ CheckOptions:
   - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
   - { key: readability-identifier-naming.ProtectedMemberSuffix,  value: _          }
   - { key: readability-identifier-naming.MacroDefinitionCase,    value: UPPER_CASE }
-  - { key: readability-identifier-naming.EnumConstantCase,       value: CamelCase }
-  - { key: readability-identifier-naming.EnumConstantPrefix,     value: k }
-  - { key: readability-identifier-naming.ConstexprVariableCase,  value: CamelCase }
-  - { key: readability-identifier-naming.ConstexprVariablePrefix, value: k }
-  - { key: readability-identifier-naming.GlobalConstantCase,     value: CamelCase }
-  - { key: readability-identifier-naming.GlobalConstantPrefix,   value: k }
-  - { key: readability-identifier-naming.MemberConstantCase,     value: CamelCase }
-  - { key: readability-identifier-naming.MemberConstantPrefix,   value: k }
+  - { key: readability-identifier-naming.EnumConstantCase,         value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantPrefix,       value: k         }
+  - { key: readability-identifier-naming.ConstexprVariableCase,    value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix,  value: k         }
+  - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.MemberConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }

--- a/google/cloud/spanner/version.cc
+++ b/google/cloud/spanner/version.cc
@@ -22,7 +22,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 // NOLINTNEXTLINE(readability-identifier-naming)
 std::string version_string() {
-  static std::string const version = [] {
+  static std::string const kVersion = [] {
     std::ostringstream os;
     os << "v" << version_major() << "." << version_minor() << "."
        << version_patch();
@@ -31,7 +31,7 @@ std::string version_string() {
     }
     return os.str();
   }();
-  return version;
+  return kVersion;
 }
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner


### PR DESCRIPTION
I would like us to share these files, but that sounds hard, we should
keep them consistent in any case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/154)
<!-- Reviewable:end -->
