### PR TITLE
feat: Add a default c'tor for Value

### DIFF
--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -68,7 +68,7 @@ std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v);
  *     ARRAY/`std::vector`.
  *
  * Value is a regular C++ value type with support for copy, move, equality,
- * etc, but there is no default constructor because there is no default type.
+ * etc. A default-constructed Value represents an empty value with no type.
  * Callers may create instances by passing any of the supported values (shown
  * in the table above) to the constructor. "Null" values are created using the
  * `MakeNullValue<T>()` factory function or by passing an empty `optional<T>`
@@ -136,7 +136,13 @@ std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v);
  */
 class Value {
  public:
-  Value() = delete;
+  /**
+   * Constructs a non-null `Value` that holds nothing.
+   *
+   * All calls to `is<T>()`, `is_null<T>()`, and `get<T>()` will return false
+   * or an error as appropriate.
+   */
+  Value() = default;
 
   /// Copy and move.
   Value(Value const&) = default;

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -69,6 +69,7 @@ std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v);
  *
  * Value is a regular C++ value type with support for copy, move, equality,
  * etc. A default-constructed Value represents an empty value with no type.
+ *
  * Callers may create instances by passing any of the supported values (shown
  * in the table above) to the constructor. "Null" values are created using the
  * `MakeNullValue<T>()` factory function or by passing an empty `optional<T>`

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -31,6 +31,11 @@ inline namespace SPANNER_CLIENT_NS {
 
 template <typename T>
 void TestBasicSemantics(T init) {
+  Value const default_ctor{};
+  EXPECT_FALSE(default_ctor.is<T>());
+  EXPECT_FALSE(default_ctor.is_null<T>());
+  EXPECT_FALSE(default_ctor.get<T>().ok());
+
   Value const v{init};
 
   EXPECT_TRUE(v.is<T>());


### PR DESCRIPTION
A default-constructed Value represents no value with no type. This is
needed in order to create a `std::array` of Value objects.

	modified:   value.h
	modified:   value_test.cc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/156)
<!-- Reviewable:end -->
