### PR TITLE
feat: Made Row::size() member static.

### DIFF
--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -69,6 +69,9 @@ class Row {
   using ColumnType = typename std::tuple_element<I, std::tuple<Types...>>::type;
 
  public:
+  /// Returns the number of columns in this row.
+  static constexpr std::size_t size() { return sizeof...(Types); }
+
   /// Regular value type, supporting copy, assign, move, etc.
   Row() {}
   Row(Row const&) = default;
@@ -91,9 +94,6 @@ class Row {
                     std::is_same<typename std::decay<Ts>::type, Row>...>::value,
                 int>::type = 0>
   explicit Row(Ts&&... ts) : values_(std::forward<Ts>(ts)...) {}
-
-  /// Returns the number of columns in this row.
-  constexpr std::size_t size() const { return sizeof...(Types); }
 
   /**
    *  Returns a reference to the value at position `I`.

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -43,6 +43,10 @@ void VerifyRegularType(Ts&&... ts) {
 
   auto const moved = std::move(assign);
   EXPECT_EQ(moved, row);
+
+  EXPECT_EQ(RowType::size(), row.size());
+  static_assert(RowType::size() == sizeof...(Ts),
+                "This method must be constexpr");
 }
 
 TEST(Row, RegularType) {


### PR DESCRIPTION
This is useful when callers need to know how many columns the row
contains but they don't have an instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/159)
<!-- Reviewable:end -->
