### PR TITLE
Remove dependency on bigtable_client.

### DIFF
--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -31,11 +31,11 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_googleapis_google_cloud_cpp" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp",
-            strip_prefix = "google-cloud-cpp-4772b916d66b2b1108294ec2812b9dd63bdba352",
+            strip_prefix = "google-cloud-cpp-1427c68c0ccf697ae514ff899a141b75bcacfb83",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp/archive/4772b916d66b2b1108294ec2812b9dd63bdba352.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp/archive/1427c68c0ccf697ae514ff899a141b75bcacfb83.tar.gz",
             ],
-            sha256 = "1e775dd56acbfe387333ad9e21f1a24ce8db4a28df72cdb56798e2a33469ca8b",
+            sha256 = "a888d0dd66bfab6c37d8544f29f5d983242e34074b39531a2d0146898caf6e83",
         )
 
     # Load a newer version of google test than what gRPC does.

--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -92,6 +92,17 @@ cc_library(
 # END SPANNER PROTOS
 ####################
 
+cc_library(
+    name = "grpc_utils_protos",
+    includes = [
+        ".",
+    ],
+    deps = [
+        "@com_github_grpc_grpc//:grpc++",
+        "//google/rpc:status_cc_proto"
+    ],
+)
+
 # TODO(googleapis/google-cloud-cpp#2807) - will not need these.
 cc_proto_library(
     name = "bigtableadmin_cc_proto",

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -54,9 +54,9 @@ RUN ldconfig
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/4772b916d66b2b1108294ec2812b9dd63bdba352.tar.gz
-RUN tar -xf 4772b916d66b2b1108294ec2812b9dd63bdba352.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-4772b916d66b2b1108294ec2812b9dd63bdba352
+RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/1427c68c0ccf697ae514ff899a141b75bcacfb83.tar.gz
+RUN tar -xf 1427c68c0ccf697ae514ff899a141b75bcacfb83.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-1427c68c0ccf697ae514ff899a141b75bcacfb83
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/cmake/external/google-cloud-cpp.cmake
+++ b/cmake/external/google-cloud-cpp.cmake
@@ -25,10 +25,10 @@ if (NOT TARGET google-cloud-cpp-project)
     # downloaded from GitHub.
     set(
         GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp/archive/4772b916d66b2b1108294ec2812b9dd63bdba352.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp/archive/1427c68c0ccf697ae514ff899a141b75bcacfb83.tar.gz"
         )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "1e775dd56acbfe387333ad9e21f1a24ce8db4a28df72cdb56798e2a33469ca8b")
+        "a888d0dd66bfab6c37d8544f29f5d983242e34074b39531a2d0146898caf6e83")
     set(
         GOOGLEAPIS_URL
         "https://github.com/google/googleapis/archive/a8ee1416f4c588f2ab92da72e7c1f588c784d3e6.zip"

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -38,7 +38,7 @@ load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
     deps = [
         ":spanner_client",
         "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_testing",
+        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",
     ],
 ) for test in spanner_client_unit_tests]

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -24,7 +24,7 @@ cc_library(
     hdrs = spanner_client_hdrs,
     deps = [
         "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/bigtable:bigtable_client",
+        "@com_github_googleapis_google_cloud_cpp//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
         "@com_google_googleapis//:bigtable_protos",
         "@com_google_googleapis//:spanner_protos",
     ],

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -15,7 +15,7 @@
 # ~~~
 
 find_package(google_cloud_cpp_common CONFIG REQUIRED)
-find_package(bigtable_client CONFIG REQUIRED)
+find_package(google_cloud_cpp_grpc_utils CONFIG REQUIRED)
 
 include(EnableClangTidy)
 include(EnableWerror)
@@ -55,7 +55,7 @@ target_include_directories(spanner_client
                                   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
                                   $<INSTALL_INTERFACE:include>)
 target_link_libraries(spanner_client
-                      PUBLIC bigtable_client google_cloud_cpp_common
+                      PUBLIC google_cloud_cpp_grpc_utils google_cloud_cpp_common
                              googleapis-c++::spanner_protos)
 set_target_properties(spanner_client
                       PROPERTIES VERSION

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/database_admin_client.h"
-#include "google/cloud/bigtable/internal/grpc_error_delegate.h"
+#include "google/cloud/grpc_utils/grpc_error_delegate.h"
 #include <algorithm>
 
 namespace google {

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -25,7 +25,7 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
     deps = [
         "//google/cloud/spanner:spanner_client",
         "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_testing",
+        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",
     ],
 ) for test in spanner_client_integration_tests]

--- a/google/cloud/spanner/internal/database_admin_stub.cc
+++ b/google/cloud/spanner/internal/database_admin_stub.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/database_admin_stub.h"
-#include "google/cloud/bigtable/internal/grpc_error_delegate.h"
+#include "google/cloud/grpc_utils/grpc_error_delegate.h"
 #include <google/longrunning/operations.grpc.pb.h>
 
 namespace google {
@@ -45,7 +45,7 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     grpc::Status status =
         database_admin_->CreateDatabase(&client_context, request, &response);
     if (!status.ok()) {
-      return google::cloud::bigtable::internal::MakeStatusFromRpcError(status);
+      return google::cloud::grpc_utils::MakeStatusFromRpcError(status);
     }
     return response;
   }
@@ -57,7 +57,7 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     grpc::Status status =
         database_admin_->DropDatabase(&client_context, request, &response);
     if (!status.ok()) {
-      return google::cloud::bigtable::internal::MakeStatusFromRpcError(status);
+      return google::cloud::grpc_utils::MakeStatusFromRpcError(status);
     }
     return google::cloud::Status();
   }
@@ -70,7 +70,7 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     grpc::Status status =
         operations_->GetOperation(&client_context, request, &response);
     if (!status.ok()) {
-      return google::cloud::bigtable::internal::MakeStatusFromRpcError(status);
+      return google::cloud::grpc_utils::MakeStatusFromRpcError(status);
     }
     return response;
   }

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
+#include "google/cloud/grpc_utils/grpc_error_delegate.h"
 #include <google/spanner/v1/spanner.grpc.pb.h>
 
 namespace google {
@@ -82,13 +83,6 @@ class DefaultSpannerStub : public SpannerStub {
   std::unique_ptr<spanner_proto::Spanner::StubInterface> grpc_stub_;
 };
 
-// TODO(googleapis/google-cloud-cpp#2807) update this to use the generic
-// common method when available.
-Status GRPCStatusToStatus(grpc::Status const& grpc_status) {
-  return Status(static_cast<StatusCode>(grpc_status.error_code()),
-                grpc_status.error_message());
-}
-
 StatusOr<spanner_proto::Session> DefaultSpannerStub::CreateSession(
     grpc::ClientContext& client_context,
     spanner_proto::CreateSessionRequest const& request) {
@@ -96,7 +90,7 @@ StatusOr<spanner_proto::Session> DefaultSpannerStub::CreateSession(
   grpc::Status grpc_status =
       grpc_stub_->CreateSession(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }
@@ -108,7 +102,7 @@ StatusOr<spanner_proto::Session> DefaultSpannerStub::GetSession(
   grpc::Status grpc_status =
       grpc_stub_->GetSession(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }
@@ -120,7 +114,7 @@ StatusOr<spanner_proto::ListSessionsResponse> DefaultSpannerStub::ListSessions(
   grpc::Status grpc_status =
       grpc_stub_->ListSessions(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }
@@ -131,7 +125,7 @@ Status DefaultSpannerStub::DeleteSession(
   google::protobuf::Empty response;
   grpc::Status grpc_status =
       grpc_stub_->DeleteSession(&client_context, request, &response);
-  return GRPCStatusToStatus(grpc_status);
+  return grpc_utils::MakeStatusFromRpcError(grpc_status);
 }
 
 StatusOr<spanner_proto::ResultSet> DefaultSpannerStub::ExecuteSql(
@@ -141,7 +135,7 @@ StatusOr<spanner_proto::ResultSet> DefaultSpannerStub::ExecuteSql(
   grpc::Status grpc_status =
       grpc_stub_->ExecuteSql(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }
@@ -161,7 +155,7 @@ DefaultSpannerStub::ExecuteBatchDml(
   grpc::Status grpc_status =
       grpc_stub_->ExecuteBatchDml(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }
@@ -173,7 +167,7 @@ StatusOr<spanner_proto::ResultSet> DefaultSpannerStub::Read(
   grpc::Status grpc_status =
       grpc_stub_->Read(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }
@@ -191,7 +185,7 @@ StatusOr<spanner_proto::Transaction> DefaultSpannerStub::BeginTransaction(
   grpc::Status grpc_status =
       grpc_stub_->BeginTransaction(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }
@@ -203,7 +197,7 @@ StatusOr<spanner_proto::CommitResponse> DefaultSpannerStub::Commit(
   grpc::Status grpc_status =
       grpc_stub_->Commit(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }
@@ -214,7 +208,7 @@ Status DefaultSpannerStub::Rollback(
   google::protobuf::Empty response;
   grpc::Status grpc_status =
       grpc_stub_->Rollback(&client_context, request, &response);
-  return GRPCStatusToStatus(grpc_status);
+  return grpc_utils::MakeStatusFromRpcError(grpc_status);
 }
 
 StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionQuery(
@@ -224,7 +218,7 @@ StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionQuery(
   grpc::Status grpc_status =
       grpc_stub_->PartitionQuery(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }
@@ -236,7 +230,7 @@ StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionRead(
   grpc::Status grpc_status =
       grpc_stub_->PartitionRead(&client_context, request, &response);
   if (!grpc_status.ok()) {
-    return GRPCStatusToStatus(grpc_status);
+    return grpc_utils::MakeStatusFromRpcError(grpc_status);
   }
   return response;
 }


### PR DESCRIPTION
Fixes #129 

This updates the `google-cloud-cpp` dep and changes any appropriate references to `grpc_utils`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/165)
<!-- Reviewable:end -->
