### PR TITLE
bug: Do not run integration tests in super-build.

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -30,6 +30,7 @@ additional_commands = {
             "EXCLUDE_FROM_ALL": 1,
             "INSTALL_COMMAND": "+",
             "INSTALL_DIR": 1,
+            "TEST_COMMAND": "+",
             "LOG_BUILD": 1,
             "LOG_CONFIGURE": 1,
             "LOG_DOWNLOAD": 1,

--- a/ci/super/CMakeLists.txt
+++ b/ci/super/CMakeLists.txt
@@ -45,13 +45,12 @@ ExternalProject_Add(
                -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
                -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-    BUILD_COMMAND ${CMAKE_COMMAND}
-                  --build
-                  <BINARY_DIR>
-                  TEST_COMMAND
-                  ${CMAKE_CTEST_COMMAND}
-                  --output-on-failure
-                  # TODO(#23) - Use this when install is implemented.
+    BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>
+    TEST_COMMAND ${CMAKE_CTEST_COMMAND}
+                 --output-on-failure
+                 -LE
+                 integration-tests
+                 # TODO(#23) - Use this when install is implemented.
     INSTALL_COMMAND ""
     LOG_DOWNLOAD OFF
     LOG_CONFIGURE OFF


### PR DESCRIPTION
The integration tests require a custom config. This shows that we have
not enabled the super build, I will fix that in a separate CR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/167)
<!-- Reviewable:end -->
