### PR TITLE
Use EXPECT_STATUS_OK in integration test

### DIFF
--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -31,11 +31,11 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_googleapis_google_cloud_cpp" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp",
-            strip_prefix = "google-cloud-cpp-1427c68c0ccf697ae514ff899a141b75bcacfb83",
+            strip_prefix = "google-cloud-cpp-21656366887eb2a3286d6be79d8e67fb3a4e004a",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp/archive/1427c68c0ccf697ae514ff899a141b75bcacfb83.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp/archive/da7749bcbf603431bc441c94d90e30cbc0d52c62.tar.gz",
             ],
-            sha256 = "a888d0dd66bfab6c37d8544f29f5d983242e34074b39531a2d0146898caf6e83",
+            sha256 = "e36feaa46dc858059cedf9c04d8be978f17d69ab42840adf64dcfd8fbef58205",
         )
 
     # Load a newer version of google test than what gRPC does.

--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -31,7 +31,7 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_googleapis_google_cloud_cpp" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp",
-            strip_prefix = "google-cloud-cpp-21656366887eb2a3286d6be79d8e67fb3a4e004a",
+            strip_prefix = "google-cloud-cpp-da7749bcbf603431bc441c94d90e30cbc0d52c62",
             urls = [
                 "https://github.com/googleapis/google-cloud-cpp/archive/da7749bcbf603431bc441c94d90e30cbc0d52c62.tar.gz",
             ],

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -61,7 +61,8 @@ WORKDIR /var/tmp/build/google-cloud-cpp-1427c68c0ccf697ae514ff899a141b75bcacfb83
 # libraries
 RUN cmake -H. -Bcmake-out \
     -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DBUILD_TESTING=OFF
+    -DBUILD_TESTING=OFF \
+    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
 RUN cmake --build cmake-out -- -j $(nproc)
 RUN cmake --build cmake-out --target install
 

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -52,20 +52,6 @@ RUN cmake \
 RUN cmake --build cmake-out/crc32c --target install -- -j $(nproc)
 RUN ldconfig
 
-# Download and compile google-cloud-cpp from source too:
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/1427c68c0ccf697ae514ff899a141b75bcacfb83.tar.gz
-RUN tar -xf 1427c68c0ccf697ae514ff899a141b75bcacfb83.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-1427c68c0ccf697ae514ff899a141b75bcacfb83
-# Compile without the tests because we are testing spanner, not the base
-# libraries
-RUN cmake -H. -Bcmake-out \
-    -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
-    -DBUILD_TESTING=OFF \
-    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
-RUN cmake --build cmake-out -- -j $(nproc)
-RUN cmake --build cmake-out --target install
-
 # Download and compile googletest, we need a recent version.
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/google/googletest/archive/b6cd405286ed8635ece71c72f118e659f4ade3fb.tar.gz
@@ -74,3 +60,17 @@ WORKDIR /var/tmp/build/googletest-b6cd405286ed8635ece71c72f118e659f4ade3fb
 RUN cmake \
         -H. -Bcmake-out/gtest
 RUN cmake --build cmake-out/gtest --target install -- -j $(nproc)
+
+# Download and compile google-cloud-cpp from source too:
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/da7749bcbf603431bc441c94d90e30cbc0d52c62.tar.gz
+RUN tar -xf da7749bcbf603431bc441c94d90e30cbc0d52c62.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-da7749bcbf603431bc441c94d90e30cbc0d52c62
+# Compile without the tests because we are testing spanner, not the base
+# libraries
+RUN cmake -H. -Bcmake-out \
+    -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package \
+    -DBUILD_TESTING=OFF \
+    -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
+RUN cmake --build cmake-out -- -j $(nproc)
+RUN cmake --build cmake-out --target install

--- a/cmake/external/google-cloud-cpp.cmake
+++ b/cmake/external/google-cloud-cpp.cmake
@@ -25,10 +25,10 @@ if (NOT TARGET google-cloud-cpp-project)
     # downloaded from GitHub.
     set(
         GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp/archive/1427c68c0ccf697ae514ff899a141b75bcacfb83.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp/archive/da7749bcbf603431bc441c94d90e30cbc0d52c62.tar.gz"
         )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "a888d0dd66bfab6c37d8544f29f5d983242e34074b39531a2d0146898caf6e83")
+        "e36feaa46dc858059cedf9c04d8be978f17d69ab42840adf64dcfd8fbef58205")
     set(
         GOOGLEAPIS_URL
         "https://github.com/google/googleapis/archive/a8ee1416f4c588f2ab92da72e7c1f588c784d3e6.zip"
@@ -51,6 +51,7 @@ if (NOT TARGET google-cloud-cpp-project)
                    -DGOOGLE_CLOUD_CPP_DEPENDENCY_PROVIDER=package
                    -DGOOGLE_CLOUD_CPP_GOOGLEAPIS_URL=${GOOGLEAPIS_URL}
                    -DGOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256=${GOOGLEAPIS_SHA256}
+                   -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON
                    -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -88,6 +88,8 @@ function (spanner_client_define_tests)
     # the GTest::gmock target, and the target names are also weird.
     find_package(GTest CONFIG REQUIRED)
 
+    find_package(google_cloud_cpp_testing CONFIG REQUIRED)
+
     set(spanner_client_unit_tests
         client_options_test.cc
         database_admin_client_test.cc
@@ -124,6 +126,7 @@ function (spanner_client_define_tests)
         add_executable(${target} ${fname})
         target_link_libraries(${target}
                               PRIVATE googleapis-c++::spanner_client
+                                      google_cloud_cpp_testing
                                       GTest::gmock_main
                                       GTest::gmock
                                       GTest::gtest)

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -24,6 +24,8 @@ function (spanner_client_define_integration_tests)
     # the GTest::gmock target, and the target names are also weird.
     find_package(GTest CONFIG REQUIRED)
 
+    find_package(google_cloud_cpp_testing CONFIG REQUIRED)
+
     set(spanner_client_integration_tests database_admin_integration_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
@@ -47,6 +49,7 @@ function (spanner_client_define_integration_tests)
         add_executable(${target} ${fname})
         target_link_libraries(${target}
                               PRIVATE googleapis-c++::spanner_client
+                                      google_cloud_cpp_testing
                                       GTest::gmock_main
                                       GTest::gmock
                                       GTest::gtest)

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -55,12 +55,12 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
   auto database_future =
       client.CreateDatabase(project_id, instance_id, database_id);
   auto database = database_future.get();
-  EXPECT_STATUS_OK(database.status());
+  EXPECT_STATUS_OK(database);
 
   EXPECT_THAT(database->name(), ::testing::EndsWith(database_id));
 
   auto drop_status = client.DropDatabase(project_id, instance_id, database_id);
-  EXPECT_STATUS_OK(database.status());
+  EXPECT_STATUS_OK(drop_status);
 }
 
 }  // namespace

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -54,14 +55,12 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
   auto database_future =
       client.CreateDatabase(project_id, instance_id, database_id);
   auto database = database_future.get();
-  // TODO(#googleapis/google-cloud-cpp#2810) - use EXPECT_STATUS_OK(...)
-  EXPECT_TRUE(database) << "status=" << database.status();
+  EXPECT_STATUS_OK(database.status());
 
   EXPECT_THAT(database->name(), ::testing::EndsWith(database_id));
 
   auto drop_status = client.DropDatabase(project_id, instance_id, database_id);
-  // TODO(googleapis/google-cloud-cpp#2810) - use EXPECT_STATUS_OK(...)
-  EXPECT_TRUE(drop_status.ok()) << "status=" << drop_status;
+  EXPECT_STATUS_OK(database.status());
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/retry_loop_test.cc
+++ b/google/cloud/spanner/internal/retry_loop_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/retry_loop.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -43,7 +44,7 @@ TEST(RetryLoopTest, Success) {
         return StatusOr<int>(2 * request);
       },
       context, 42, "error message");
-  EXPECT_TRUE(actual) << "status=" << actual.status();
+  EXPECT_STATUS_OK(actual);
   EXPECT_EQ(84, *actual);
 }
 
@@ -59,7 +60,7 @@ TEST(RetryLoopTest, TransientThenSuccess) {
         return StatusOr<int>(2 * request);
       },
       context, 42, "error message");
-  EXPECT_TRUE(actual) << "status=" << actual.status();
+  EXPECT_STATUS_OK(actual);
   EXPECT_EQ(84, *actual);
 }
 
@@ -75,7 +76,7 @@ TEST(RetryLoopTest, ReturnJustStatus) {
         return Status();
       },
       context, 42, "error message");
-  EXPECT_TRUE(actual.ok()) << "status=" << actual;
+  EXPECT_STATUS_OK(actual);
 }
 
 // gmock makes clang-tidy very angry, disable a few warnings that we have no
@@ -117,7 +118,7 @@ TEST(RetryLoopTest, UsesBackoffPolicy) {
       },
       context, 42, "error message",
       [&sleep_for](ms p) { sleep_for.push_back(p); });
-  EXPECT_TRUE(actual) << "status=" << actual.status();
+  EXPECT_STATUS_OK(actual);
   EXPECT_EQ(84, *actual);
   EXPECT_THAT(sleep_for, ::testing::ElementsAre(
                              ms(10), std::chrono::milliseconds(20), ms(30)));


### PR DESCRIPTION
This updates google-cloud-cpp to pull in the `testing_util` changes and changes the test to use `EXPECT_STATUS_OK`. Note that I moved building google-cloud-cpp after googletest because I originally got an error; it should be faster this way too since googletest will probably not change as often as google-cloud-cpp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/168)
<!-- Reviewable:end -->
