### PR TITLE
feat: Use a fixed type for TIMESTAMP

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(spanner_client
             row.h
             sql_statement.cc
             sql_statement.h
+            timestamp.h
             value.cc
             value.h
             version.cc

--- a/google/cloud/spanner/internal/time.cc
+++ b/google/cloud/spanner/internal/time.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/spanner/internal/time.h"
 #include "google/cloud/spanner/internal/time_format.h"
 #include <chrono>
-#include <cstdint>
 #include <cstring>
 #include <ctime>
 #include <iomanip>
@@ -29,156 +28,161 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-// All the civil-time code assumes the proleptic Gregorian calendar, and
-// 24-hour days divided into 60-minute hours and 60-second minutes.
-
-using nanoseconds = std::chrono::nanoseconds;
-using seconds = std::chrono::seconds;
-using system_clock = std::chrono::system_clock;
-using time_point = system_clock::time_point;
-
 //
 // Duration
 //
 
-google::protobuf::Duration ToProto(nanoseconds ns) {
-  auto nanos = ns.count();
+google::protobuf::Duration ToProto(std::chrono::nanoseconds ns) {
+  auto s = std::chrono::duration_cast<std::chrono::seconds>(ns);
+  ns -= std::chrono::duration_cast<std::chrono::nanoseconds>(s);
   google::protobuf::Duration proto;
-  proto.set_seconds(nanos / nanoseconds::period::den);  // rounds toward zero
-  proto.set_nanos(nanos % nanoseconds::period::den);    // (a/b)*b + a%b == a
+  proto.set_seconds(s.count());
+  proto.set_nanos(ns.count());
   return proto;
 }
 
-nanoseconds FromProto(google::protobuf::Duration const& proto) {
-  nanoseconds ns(proto.nanos());
-  ns += seconds(proto.seconds());
-  return ns;
+std::chrono::nanoseconds FromProto(google::protobuf::Duration const& proto) {
+  return std::chrono::seconds(proto.seconds()) +
+         std::chrono::nanoseconds(proto.nanos());
 }
 
 //
 // Timestamp
 //
 
-google::protobuf::Timestamp ToProto(time_point tp) {
-  std::time_t t = system_clock::to_time_t(tp);
-  time_point ttp = system_clock::from_time_t(t);
-  auto ss = std::chrono::duration_cast<nanoseconds>(tp - ttp);
-  if (ss.count() < 0) {
-    t -= 1;
-    ss += seconds(1);
-  }
-  google::protobuf::Timestamp proto;
-  proto.set_seconds(t);
-  proto.set_nanos(ss.count());
-  return proto;
-}
-
-time_point FromProto(google::protobuf::Timestamp const& proto) {
-  nanoseconds ss(proto.nanos());
-  auto sub = std::chrono::duration_cast<system_clock::duration>(ss);
-  return system_clock::from_time_t(proto.seconds()) + sub;
-}
-
 namespace {
 
-// A duration capable of holding subsecond values at high precision.
-using femtoseconds = std::chrono::duration<std::int64_t, std::femto>;
+// RFC3339 "date-time" prefix (no "time-secfrac" or "time-offset").
+constexpr auto kTimeFormat = "%Y-%m-%dT%H:%M:%S";
 
-// Convert a std::time_t into a Zulu std::tm.
+// Split a Timestamp into a seconds-since-epoch and a (>=0) subsecond.
+std::pair<std::chrono::seconds, Timestamp::duration> SplitTime(Timestamp ts) {
+  auto e = std::chrono::system_clock::from_time_t(0);
+  auto d = ts - std::chrono::time_point_cast<Timestamp::duration>(e);
+  auto s = std::chrono::duration_cast<std::chrono::seconds>(d);
+  auto ss = d - std::chrono::duration_cast<Timestamp::duration>(s);
+  if (ss < Timestamp::duration(0)) {
+    s -= std::chrono::seconds(1);
+    ss += std::chrono::seconds(1);
+  }
+  return {s, ss};
+}
+
+// Combine a seconds-since-epoch and a subsecond into a Timestamp.
+Timestamp CombineTime(std::chrono::seconds s, Timestamp::duration ss) {
+  auto e = std::chrono::system_clock::from_time_t(0);
+  return std::chrono::time_point_cast<Timestamp::duration>(e) + (s + ss);
+}
+
+// Convert a seconds-since-epoch into a Zulu std::tm.
 //
 // See http://howardhinnant.github.io/date_algorithms.html for an explanation
 // of the calendrical arithmetic in ZTime() and TimeZ().  For quick reference,
 // March 1st is used as the first day of the year (so that any leap day occurs
 // at year's end), there are 719468 days between 0000-03-01 and 1970-01-01,
 // and there are 146097 days in the 400-year Gregorian cycle (an era).
-std::tm ZTime(std::time_t const t) {
-  std::time_t sec = t % (24 * 60 * 60);
-  std::time_t day = t / (24 * 60 * 60);
-  if (sec < 0) {
-    sec += 24 * 60 * 60;
-    day -= 1;
-  }
+//
+// All the civil-time code assumes the proleptic Gregorian calendar, with
+// 24-hour days divided into 60-minute hours and 60-second minutes.
+std::tm ZTime(std::chrono::seconds s) {
+  using rep = std::chrono::seconds::rep;
+  constexpr auto secs_per_day = std::chrono::hours::period::num * 24;
+  using days = std::chrono::duration<rep, std::ratio<secs_per_day>>;  // C++20
 
-  day += 719468;
-  std::time_t const era = (day >= 0 ? day : day - 146096) / 146097;
-  std::time_t const doe = day - era * 146097;
-  std::time_t const yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-  std::time_t const y = yoe + era * 400;
-  std::time_t const doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-  std::time_t const mp = (5 * doy + 2) / 153;
-  std::time_t const d = doy - (153 * mp + 2) / 5 + 1;
-  std::time_t const m = mp + (mp < 10 ? 3 : -9);
+  auto day = std::chrono::duration_cast<days>(s);
+  auto sec = s - std::chrono::duration_cast<std::chrono::seconds>(day);
+  if (sec < std::chrono::seconds(0)) {
+    sec += days(1);
+    day -= days(1);
+  }
+  auto hour = std::chrono::duration_cast<std::chrono::hours>(sec);
+  sec -= std::chrono::duration_cast<std::chrono::seconds>(hour);
+  auto min = std::chrono::duration_cast<std::chrono::minutes>(sec);
+  sec -= std::chrono::duration_cast<std::chrono::seconds>(min);
+
+  rep const aday = day.count() + 719468;
+  rep const era = (aday >= 0 ? aday : aday - 146096) / 146097;
+  rep const doe = aday - era * 146097;
+  rep const yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+  rep const y = yoe + era * 400;
+  rep const doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+  rep const mp = (5 * doy + 2) / 153;
+  rep const d = doy - (153 * mp + 2) / 5 + 1;
+  rep const m = mp + (mp < 10 ? 3 : -9);
 
   std::tm tm;
-  tm.tm_year = static_cast<int>(y + (m <= 2 ? 1 : 0) - 1900);
+  tm.tm_year = static_cast<int>(y + (m <= 2 ? 1 : 0) - 1900);  // narrowing
   tm.tm_mon = static_cast<int>(m - 1);
   tm.tm_mday = static_cast<int>(d);
-  tm.tm_hour = static_cast<int>(sec / (60 * 60));
-  tm.tm_min = static_cast<int>((sec / 60) % 60);
-  tm.tm_sec = static_cast<int>(sec % 60);
+  tm.tm_hour = static_cast<int>(hour.count());
+  tm.tm_min = static_cast<int>(min.count());
+  tm.tm_sec = static_cast<int>(sec.count());
   return tm;
 }
 
-// Convert a Zulu std::tm into a std::time_t.
-std::time_t TimeZ(std::tm const& tm) {
-  std::time_t const y = tm.tm_year + 1900L;
-  std::time_t const m = tm.tm_mon + 1;
-  std::time_t const d = tm.tm_mday;
+// Convert a Zulu std::tm into a seconds-since-epoch.
+std::chrono::seconds TimeZ(std::tm const& tm) {
+  using rep = std::chrono::seconds::rep;
+  rep const y = tm.tm_year + static_cast<rep>(1900);
+  rep const m = tm.tm_mon + 1;
+  rep const d = tm.tm_mday;
 
-  std::time_t const eyear = (m <= 2) ? y - 1 : y;
-  std::time_t const era = (eyear >= 0 ? eyear : eyear - 399) / 400;
-  std::time_t const yoe = eyear - era * 400;
-  std::time_t const doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
-  std::time_t const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-  std::time_t const day = era * 146097 + doe - 719468;
+  rep const eyear = (m <= 2) ? y - 1 : y;
+  rep const era = (eyear >= 0 ? eyear : eyear - 399) / 400;
+  rep const yoe = eyear - era * 400;
+  rep const doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+  rep const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+  rep const aday = era * 146097 + doe - 719468;
 
-  return (((day * 24) + tm.tm_hour) * 60 + tm.tm_min) * 60 + tm.tm_sec;
+  return std::chrono::hours(aday * 24) + std::chrono::hours(tm.tm_hour) +
+         std::chrono::minutes(tm.tm_min) + std::chrono::seconds(tm.tm_sec);
 }
-
-// Split a time_point into a Zulu std::tm and a (>=0) femto subsecond.
-std::pair<std::tm, femtoseconds> SplitTime(time_point tp) {
-  std::time_t t = system_clock::to_time_t(tp);
-  time_point ttp = system_clock::from_time_t(t);
-  auto ss = std::chrono::duration_cast<femtoseconds>(tp - ttp);
-  if (ss.count() < 0) {
-    t -= 1;
-    ss += seconds(1);
-  }
-  return {ZTime(t), ss};
-}
-
-// Combine a Zulu std::tm and a femto subsecond into a time_point.
-time_point CombineTime(std::tm const& tm, femtoseconds ss) {
-  auto sub = std::chrono::duration_cast<system_clock::duration>(ss);
-  return system_clock::from_time_t(TimeZ(tm)) + sub;
-}
-
-// RFC3339 "date-time" prefix (no "time-secfrac" or "time-offset").
-constexpr auto kTimeFormat = "%Y-%m-%dT%H:%M:%S";
 
 }  // namespace
 
+google::protobuf::Timestamp ToProto(Timestamp ts) {
+  auto p = SplitTime(ts);
+  auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(p.second);
+  google::protobuf::Timestamp proto;
+  proto.set_seconds(p.first.count());
+  proto.set_nanos(ns.count());
+  return proto;
+}
+
+Timestamp FromProto(google::protobuf::Timestamp const& proto) {
+  auto ns = std::chrono::nanoseconds(proto.nanos());
+  return CombineTime(std::chrono::seconds(proto.seconds()),
+                     std::chrono::duration_cast<Timestamp::duration>(ns));
+}
+
 // TODO(#145): Reconcile this implementation with FormatRfc3339() in
 // google/cloud/internal/format_time_point.h in google-cloud-cpp.
-std::string TimestampToString(time_point tp) {
+std::string TimestampToString(Timestamp ts) {
   std::ostringstream output;
-  auto bd = SplitTime(tp);
-  output << FormatTime(kTimeFormat, bd.first);
-  if (auto ss = bd.second.count()) {  // femtoseconds
-    int width = 15;                   // log10(std::femto::den)
+  auto p = SplitTime(ts);
+  output << FormatTime(kTimeFormat, ZTime(p.first));
+
+  if (auto ss = p.second.count()) {
+    int width = 0;
+    auto scale = Timestamp::duration::period::den;
+    while (scale != 1) {
+      scale /= 10;
+      width += 1;
+    }
     while (ss % 10 == 0) {
       ss /= 10;
       width -= 1;
     }
     output << '.' << std::setfill('0') << std::setw(width) << ss;
   }
+
   output << 'Z';
   return output.str();
 }
 
 // TODO(#145): Reconcile this implementation with ParseRfc3339() in
 // google/cloud/internal/parse_rfc3339.h in google-cloud-cpp.
-StatusOr<time_point> TimestampFromString(std::string const& s) {
+StatusOr<Timestamp> TimestampFromString(std::string const& s) {
   std::tm tm;
   auto const len = s.size();
   auto pos = ParseTime(kTimeFormat, s, &tm);
@@ -187,10 +191,10 @@ StatusOr<time_point> TimestampFromString(std::string const& s) {
                   s + ": Failed to match RFC3339 date-time");
   }
 
-  femtoseconds ss(0);
+  Timestamp::duration ss(0);
   if (s[pos] == '.') {
-    femtoseconds::rep v = 0;
-    auto scale = std::femto::den;
+    Timestamp::duration::rep v = 0;
+    auto scale = Timestamp::duration::period::den;
     auto fpos = pos + 1;  // start of fractional part
     while (++pos != len) {
       static constexpr auto kDigits = "0123456789";
@@ -205,7 +209,7 @@ StatusOr<time_point> TimestampFromString(std::string const& s) {
       return Status(StatusCode::kInvalidArgument,
                     s + ": RFC3339 time-secfrac must include a digit");
     }
-    ss = femtoseconds(v * scale);
+    ss = Timestamp::duration(v * scale);
   }
 
   if (pos == len || s[pos] != 'Z') {
@@ -217,7 +221,7 @@ StatusOr<time_point> TimestampFromString(std::string const& s) {
                   s + ": Extra data after RFC3339 date-time");
   }
 
-  return CombineTime(tm, ss);
+  return CombineTime(TimeZ(tm), ss);
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/time.cc
+++ b/google/cloud/spanner/internal/time.cc
@@ -87,7 +87,7 @@ Timestamp CombineTime(std::chrono::seconds s, Timestamp::duration ss) {
 std::tm ZTime(std::chrono::seconds s) {
   using rep = std::chrono::seconds::rep;
   constexpr auto kSecsPerDay = std::chrono::hours::period::num * 24;
-  using days = std::chrono::duration<rep, std::ratio<kSecsPerDay>>;  // C++20
+  using days = std::chrono::duration<rep, std::ratio<kSecsPerDay>>;
 
   auto day = std::chrono::duration_cast<days>(s);
   auto sec = s - std::chrono::duration_cast<std::chrono::seconds>(day);

--- a/google/cloud/spanner/internal/time.cc
+++ b/google/cloud/spanner/internal/time.cc
@@ -86,8 +86,8 @@ Timestamp CombineTime(std::chrono::seconds s, Timestamp::duration ss) {
 // 24-hour days divided into 60-minute hours and 60-second minutes.
 std::tm ZTime(std::chrono::seconds s) {
   using rep = std::chrono::seconds::rep;
-  constexpr auto secs_per_day = std::chrono::hours::period::num * 24;
-  using days = std::chrono::duration<rep, std::ratio<secs_per_day>>;  // C++20
+  constexpr auto kSecsPerDay = std::chrono::hours::period::num * 24;
+  using days = std::chrono::duration<rep, std::ratio<kSecsPerDay>>;  // C++20
 
   auto day = std::chrono::duration_cast<days>(s);
   auto sec = s - std::chrono::duration_cast<std::chrono::seconds>(day);

--- a/google/cloud/spanner/internal/time.h
+++ b/google/cloud/spanner/internal/time.h
@@ -15,12 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_TIME_H_
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_TIME_H_
 
+#include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
 #include <google/protobuf/duration.pb.h>
 #include <google/protobuf/timestamp.pb.h>
 #include <chrono>
-#include <cstdint>
 #include <string>
 
 namespace google {
@@ -42,26 +42,24 @@ std::chrono::nanoseconds FromProto(google::protobuf::Duration const& proto);
 /**
  * Convert a system_clock::time_point to a google::protobuf::Timestamp.
  */
-google::protobuf::Timestamp ToProto(std::chrono::system_clock::time_point tp);
+google::protobuf::Timestamp ToProto(Timestamp ts);
 
 /**
  * Convert a google::protobuf::Timestamp to a system_clock::time_point.
  */
-std::chrono::system_clock::time_point FromProto(
-    google::protobuf::Timestamp const& proto);
+Timestamp FromProto(google::protobuf::Timestamp const& proto);
 
 /**
  * Convert a system_clock::time_point to an RFC3339 "date-time".
  */
-std::string TimestampToString(std::chrono::system_clock::time_point tp);
+std::string TimestampToString(Timestamp ts);
 
 /**
  * Convert an RFC3339 "date-time" to a system_clock::time_point.
  *
  * Returns a a non-OK Status if the input cannot be parsed.
  */
-StatusOr<std::chrono::system_clock::time_point> TimestampFromString(
-    std::string const& s);
+StatusOr<Timestamp> TimestampFromString(std::string const& s);
 
 }  // namespace internal
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/time.h
+++ b/google/cloud/spanner/internal/time.h
@@ -40,22 +40,22 @@ google::protobuf::Duration ToProto(std::chrono::nanoseconds ns);
 std::chrono::nanoseconds FromProto(google::protobuf::Duration const& proto);
 
 /**
- * Convert a system_clock::time_point to a google::protobuf::Timestamp.
+ * Convert a google::cloud::spanner::Timestamp to a google::protobuf::Timestamp.
  */
 google::protobuf::Timestamp ToProto(Timestamp ts);
 
 /**
- * Convert a google::protobuf::Timestamp to a system_clock::time_point.
+ * Convert a google::protobuf::Timestamp to a google::cloud::spanner::Timestamp.
  */
 Timestamp FromProto(google::protobuf::Timestamp const& proto);
 
 /**
- * Convert a system_clock::time_point to an RFC3339 "date-time".
+ * Convert a google::cloud::spanner::Timestamp to an RFC3339 "date-time".
  */
 std::string TimestampToString(Timestamp ts);
 
 /**
- * Convert an RFC3339 "date-time" to a system_clock::time_point.
+ * Convert an RFC3339 "date-time" to a google::cloud::spanner::Timestamp.
  *
  * Returns a a non-OK Status if the input cannot be parsed.
  */

--- a/google/cloud/spanner/internal/time_test.cc
+++ b/google/cloud/spanner/internal/time_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/internal/time.h"
 #include <gmock/gmock.h>
 #include <chrono>
+#include <ctime>
 
 namespace google {
 namespace cloud {
@@ -23,270 +24,291 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
-using Duration = google::protobuf::Duration;
-using Timestamp = google::protobuf::Timestamp;
-using microseconds = std::chrono::microseconds;
-using nanoseconds = std::chrono::nanoseconds;
-using system_clock = std::chrono::system_clock;
-using time_point = system_clock::time_point;
+Timestamp FromTimeT(std::time_t t) {
+  return std::chrono::time_point_cast<Timestamp::duration>(
+      std::chrono::system_clock::from_time_t(t));
+}
 
 TEST(Duration, ToProto) {
-  Duration d;
+  google::protobuf::Duration d;
 
-  d = ToProto(nanoseconds(-1234567890));
+  d = ToProto(std::chrono::nanoseconds(-1234567890));
   EXPECT_EQ(-1, d.seconds());
   EXPECT_EQ(-234567890, d.nanos());
 
-  d = ToProto(nanoseconds(-1000000001));
+  d = ToProto(std::chrono::nanoseconds(-1000000001));
   EXPECT_EQ(-1, d.seconds());
   EXPECT_EQ(-1, d.nanos());
 
-  d = ToProto(nanoseconds(-1000000000));
+  d = ToProto(std::chrono::nanoseconds(-1000000000));
   EXPECT_EQ(-1, d.seconds());
   EXPECT_EQ(0, d.nanos());
 
-  d = ToProto(nanoseconds(-999999999));
+  d = ToProto(std::chrono::nanoseconds(-999999999));
   EXPECT_EQ(0, d.seconds());
   EXPECT_EQ(-999999999, d.nanos());
 
-  d = ToProto(nanoseconds(-1));
+  d = ToProto(std::chrono::nanoseconds(-1));
   EXPECT_EQ(0, d.seconds());
   EXPECT_EQ(-1, d.nanos());
 
-  d = ToProto(nanoseconds(0));
+  d = ToProto(std::chrono::nanoseconds(0));
   EXPECT_EQ(0, d.seconds());
   EXPECT_EQ(0, d.nanos());
 
-  d = ToProto(nanoseconds(1));
+  d = ToProto(std::chrono::nanoseconds(1));
   EXPECT_EQ(0, d.seconds());
   EXPECT_EQ(1, d.nanos());
 
-  d = ToProto(nanoseconds(999999999));
+  d = ToProto(std::chrono::nanoseconds(999999999));
   EXPECT_EQ(0, d.seconds());
   EXPECT_EQ(999999999, d.nanos());
 
-  d = ToProto(nanoseconds(1000000000));
+  d = ToProto(std::chrono::nanoseconds(1000000000));
   EXPECT_EQ(1, d.seconds());
   EXPECT_EQ(0, d.nanos());
 
-  d = ToProto(nanoseconds(1000000001));
+  d = ToProto(std::chrono::nanoseconds(1000000001));
   EXPECT_EQ(1, d.seconds());
   EXPECT_EQ(1, d.nanos());
 
-  d = ToProto(nanoseconds(1234567890));
+  d = ToProto(std::chrono::nanoseconds(1234567890));
   EXPECT_EQ(1, d.seconds());
   EXPECT_EQ(234567890, d.nanos());
 }
 
 TEST(Duration, FromProto) {
-  Duration d;
+  google::protobuf::Duration d;
 
   d.set_seconds(-1);
   d.set_nanos(-234567890);
-  EXPECT_EQ(nanoseconds(-1234567890), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(-1234567890), FromProto(d));
 
   d.set_seconds(-1);
   d.set_nanos(-1);
-  EXPECT_EQ(nanoseconds(-1000000001), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(-1000000001), FromProto(d));
 
   d.set_seconds(-1);
   d.set_nanos(0);
-  EXPECT_EQ(nanoseconds(-1000000000), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(-1000000000), FromProto(d));
 
   d.set_seconds(0);
   d.set_nanos(-999999999);
-  EXPECT_EQ(nanoseconds(-999999999), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(-999999999), FromProto(d));
 
   d.set_seconds(0);
   d.set_nanos(-1);
-  EXPECT_EQ(nanoseconds(-1), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(-1), FromProto(d));
 
   d.set_seconds(0);
   d.set_nanos(0);
-  EXPECT_EQ(nanoseconds(0), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(0), FromProto(d));
 
   d.set_seconds(0);
   d.set_nanos(1);
-  EXPECT_EQ(nanoseconds(1), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(1), FromProto(d));
 
   d.set_seconds(0);
   d.set_nanos(999999999);
-  EXPECT_EQ(nanoseconds(999999999), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(999999999), FromProto(d));
 
   d.set_seconds(1);
   d.set_nanos(0);
-  EXPECT_EQ(nanoseconds(1000000000), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(1000000000), FromProto(d));
 
   d.set_seconds(1);
   d.set_nanos(1);
-  EXPECT_EQ(nanoseconds(1000000001), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(1000000001), FromProto(d));
 
   d.set_seconds(1);
   d.set_nanos(234567890);
-  EXPECT_EQ(nanoseconds(1234567890), FromProto(d));
+  EXPECT_EQ(std::chrono::nanoseconds(1234567890), FromProto(d));
 }
 
 TEST(Time, ToProto) {
-  Timestamp ts;
+  google::protobuf::Timestamp ts;
 
-  ts = ToProto(system_clock::from_time_t(-1) - microseconds(999999));
+  ts = ToProto(FromTimeT(-1) - std::chrono::nanoseconds(999999999));
   EXPECT_EQ(-2, ts.seconds());
-  EXPECT_EQ(1000, ts.nanos());
+  EXPECT_EQ(1, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(-1) - microseconds(1));
+  ts = ToProto(FromTimeT(-1) - std::chrono::nanoseconds(1));
   EXPECT_EQ(-2, ts.seconds());
-  EXPECT_EQ(999999000, ts.nanos());
+  EXPECT_EQ(999999999, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(-1));
+  ts = ToProto(FromTimeT(-1));
   EXPECT_EQ(-1, ts.seconds());
   EXPECT_EQ(0, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(0) - microseconds(999999));
+  ts = ToProto(FromTimeT(0) - std::chrono::nanoseconds(999999999));
   EXPECT_EQ(-1, ts.seconds());
-  EXPECT_EQ(1000, ts.nanos());
+  EXPECT_EQ(1, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(0) - microseconds(1));
+  ts = ToProto(FromTimeT(0) - std::chrono::nanoseconds(1));
   EXPECT_EQ(-1, ts.seconds());
-  EXPECT_EQ(999999000, ts.nanos());
+  EXPECT_EQ(999999999, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(0));
+  ts = ToProto(FromTimeT(0));
   EXPECT_EQ(0, ts.seconds());
   EXPECT_EQ(0, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(0) + microseconds(1));
+  ts = ToProto(FromTimeT(0) + std::chrono::nanoseconds(1));
   EXPECT_EQ(0, ts.seconds());
-  EXPECT_EQ(1000, ts.nanos());
+  EXPECT_EQ(1, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(0) + microseconds(999999));
+  ts = ToProto(FromTimeT(0) + std::chrono::nanoseconds(999999999));
   EXPECT_EQ(0, ts.seconds());
-  EXPECT_EQ(999999000, ts.nanos());
+  EXPECT_EQ(999999999, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(1));
+  ts = ToProto(FromTimeT(1));
   EXPECT_EQ(1, ts.seconds());
   EXPECT_EQ(0, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(1) + microseconds(1));
+  ts = ToProto(FromTimeT(1) + std::chrono::nanoseconds(1));
   EXPECT_EQ(1, ts.seconds());
-  EXPECT_EQ(1000, ts.nanos());
+  EXPECT_EQ(1, ts.nanos());
 
-  ts = ToProto(system_clock::from_time_t(1) + microseconds(999999));
+  ts = ToProto(FromTimeT(1) + std::chrono::nanoseconds(999999999));
   EXPECT_EQ(1, ts.seconds());
-  EXPECT_EQ(999999000, ts.nanos());
+  EXPECT_EQ(999999999, ts.nanos());
 }
 
 TEST(Time, FromProto) {
-  Timestamp ts;
+  google::protobuf::Timestamp ts;
 
   ts.set_seconds(-2);
-  ts.set_nanos(1000);
-  EXPECT_EQ(system_clock::from_time_t(-1) - microseconds(999999),
-            FromProto(ts));
+  ts.set_nanos(1);
+  EXPECT_EQ(FromTimeT(-1) - std::chrono::nanoseconds(999999999), FromProto(ts));
 
   ts.set_seconds(-2);
-  ts.set_nanos(999999000);
-  EXPECT_EQ(system_clock::from_time_t(-1) - microseconds(1), FromProto(ts));
+  ts.set_nanos(999999999);
+  EXPECT_EQ(FromTimeT(-1) - std::chrono::nanoseconds(1), FromProto(ts));
 
   ts.set_seconds(-1);
   ts.set_nanos(0);
-  EXPECT_EQ(system_clock::from_time_t(-1), FromProto(ts));
+  EXPECT_EQ(FromTimeT(-1), FromProto(ts));
 
   ts.set_seconds(-1);
-  ts.set_nanos(1000);
-  EXPECT_EQ(system_clock::from_time_t(0) - microseconds(999999), FromProto(ts));
+  ts.set_nanos(1);
+  EXPECT_EQ(FromTimeT(0) - std::chrono::nanoseconds(999999999), FromProto(ts));
 
   ts.set_seconds(-1);
-  ts.set_nanos(999999000);
-  EXPECT_EQ(system_clock::from_time_t(0) - microseconds(1), FromProto(ts));
+  ts.set_nanos(999999999);
+  EXPECT_EQ(FromTimeT(0) - std::chrono::nanoseconds(1), FromProto(ts));
 
   ts.set_seconds(0);
   ts.set_nanos(0);
-  EXPECT_EQ(system_clock::from_time_t(0), FromProto(ts));
+  EXPECT_EQ(FromTimeT(0), FromProto(ts));
 
   ts.set_seconds(0);
-  ts.set_nanos(1000);
-  EXPECT_EQ(system_clock::from_time_t(0) + microseconds(1), FromProto(ts));
+  ts.set_nanos(1);
+  EXPECT_EQ(FromTimeT(0) + std::chrono::nanoseconds(1), FromProto(ts));
 
   ts.set_seconds(0);
-  ts.set_nanos(999999000);
-  EXPECT_EQ(system_clock::from_time_t(0) + microseconds(999999), FromProto(ts));
+  ts.set_nanos(999999999);
+  EXPECT_EQ(FromTimeT(0) + std::chrono::nanoseconds(999999999), FromProto(ts));
 
   ts.set_seconds(1);
   ts.set_nanos(0);
-  EXPECT_EQ(system_clock::from_time_t(1), FromProto(ts));
+  EXPECT_EQ(FromTimeT(1), FromProto(ts));
 
   ts.set_seconds(1);
-  ts.set_nanos(1000);
-  EXPECT_EQ(system_clock::from_time_t(1) + microseconds(1), FromProto(ts));
+  ts.set_nanos(1);
+  EXPECT_EQ(FromTimeT(1) + std::chrono::nanoseconds(1), FromProto(ts));
 
   ts.set_seconds(1);
-  ts.set_nanos(999999000);
-  EXPECT_EQ(system_clock::from_time_t(1) + microseconds(999999), FromProto(ts));
+  ts.set_nanos(999999999);
+  EXPECT_EQ(FromTimeT(1) + std::chrono::nanoseconds(999999999), FromProto(ts));
 }
 
 TEST(Time, TimestampToString) {
-  time_point tp = system_clock::from_time_t(1561135942);
-  EXPECT_EQ("2019-06-21T16:52:22Z", TimestampToString(tp));
-  tp += microseconds(6);
-  EXPECT_EQ("2019-06-21T16:52:22.000006Z", TimestampToString(tp));
-  tp += microseconds(50);
-  EXPECT_EQ("2019-06-21T16:52:22.000056Z", TimestampToString(tp));
-  tp += microseconds(400);
-  EXPECT_EQ("2019-06-21T16:52:22.000456Z", TimestampToString(tp));
-  tp += microseconds(3000);
-  EXPECT_EQ("2019-06-21T16:52:22.003456Z", TimestampToString(tp));
-  tp += microseconds(20000);
-  EXPECT_EQ("2019-06-21T16:52:22.023456Z", TimestampToString(tp));
-  tp += microseconds(100000);
-  EXPECT_EQ("2019-06-21T16:52:22.123456Z", TimestampToString(tp));
-  tp -= microseconds(6);
-  EXPECT_EQ("2019-06-21T16:52:22.12345Z", TimestampToString(tp));
-  tp -= microseconds(50);
-  EXPECT_EQ("2019-06-21T16:52:22.1234Z", TimestampToString(tp));
-  tp -= microseconds(400);
-  EXPECT_EQ("2019-06-21T16:52:22.123Z", TimestampToString(tp));
-  tp -= microseconds(3000);
-  EXPECT_EQ("2019-06-21T16:52:22.12Z", TimestampToString(tp));
-  tp -= microseconds(20000);
-  EXPECT_EQ("2019-06-21T16:52:22.1Z", TimestampToString(tp));
-  tp -= microseconds(100000);
-  EXPECT_EQ("2019-06-21T16:52:22Z", TimestampToString(tp));
+  Timestamp ts = FromTimeT(1561135942);
+  EXPECT_EQ("2019-06-21T16:52:22Z", TimestampToString(ts));
+  ts += std::chrono::nanoseconds(9);
+  EXPECT_EQ("2019-06-21T16:52:22.000000009Z", TimestampToString(ts));
+  ts += std::chrono::nanoseconds(80);
+  EXPECT_EQ("2019-06-21T16:52:22.000000089Z", TimestampToString(ts));
+  ts += std::chrono::nanoseconds(700);
+  EXPECT_EQ("2019-06-21T16:52:22.000000789Z", TimestampToString(ts));
+  ts += std::chrono::nanoseconds(6000);
+  EXPECT_EQ("2019-06-21T16:52:22.000006789Z", TimestampToString(ts));
+  ts += std::chrono::nanoseconds(50000);
+  EXPECT_EQ("2019-06-21T16:52:22.000056789Z", TimestampToString(ts));
+  ts += std::chrono::nanoseconds(400000);
+  EXPECT_EQ("2019-06-21T16:52:22.000456789Z", TimestampToString(ts));
+  ts += std::chrono::nanoseconds(3000000);
+  EXPECT_EQ("2019-06-21T16:52:22.003456789Z", TimestampToString(ts));
+  ts += std::chrono::nanoseconds(20000000);
+  EXPECT_EQ("2019-06-21T16:52:22.023456789Z", TimestampToString(ts));
+  ts += std::chrono::nanoseconds(100000000);
+  EXPECT_EQ("2019-06-21T16:52:22.123456789Z", TimestampToString(ts));
+  ts -= std::chrono::nanoseconds(9);
+  EXPECT_EQ("2019-06-21T16:52:22.12345678Z", TimestampToString(ts));
+  ts -= std::chrono::nanoseconds(80);
+  EXPECT_EQ("2019-06-21T16:52:22.1234567Z", TimestampToString(ts));
+  ts -= std::chrono::nanoseconds(700);
+  EXPECT_EQ("2019-06-21T16:52:22.123456Z", TimestampToString(ts));
+  ts -= std::chrono::nanoseconds(6000);
+  EXPECT_EQ("2019-06-21T16:52:22.12345Z", TimestampToString(ts));
+  ts -= std::chrono::nanoseconds(50000);
+  EXPECT_EQ("2019-06-21T16:52:22.1234Z", TimestampToString(ts));
+  ts -= std::chrono::nanoseconds(400000);
+  EXPECT_EQ("2019-06-21T16:52:22.123Z", TimestampToString(ts));
+  ts -= std::chrono::nanoseconds(3000000);
+  EXPECT_EQ("2019-06-21T16:52:22.12Z", TimestampToString(ts));
+  ts -= std::chrono::nanoseconds(20000000);
+  EXPECT_EQ("2019-06-21T16:52:22.1Z", TimestampToString(ts));
+  ts -= std::chrono::nanoseconds(100000000);
+  EXPECT_EQ("2019-06-21T16:52:22Z", TimestampToString(ts));
 }
 
 TEST(Time, TimestampToStringLimit) {
-  time_point tp = system_clock::from_time_t(-9223372036L);
-  EXPECT_EQ("1677-09-21T00:12:44Z", TimestampToString(tp));
+  Timestamp ts = FromTimeT(-9223372036L);
+  EXPECT_EQ("1677-09-21T00:12:44Z", TimestampToString(ts));
 
-  tp = system_clock::from_time_t(9223372036L) + microseconds(775807);
-  EXPECT_EQ("2262-04-11T23:47:16.775807Z", TimestampToString(tp));
+  ts = FromTimeT(9223372036L) + std::chrono::nanoseconds(854775807);
+  EXPECT_EQ("2262-04-11T23:47:16.854775807Z", TimestampToString(ts));
 }
 
 TEST(Time, TimestampFromString) {
-  time_point tp = system_clock::from_time_t(1561135942);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22Z").value());
-  tp += microseconds(6);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.000006Z").value());
-  tp += microseconds(50);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.000056Z").value());
-  tp += microseconds(400);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.000456Z").value());
-  tp += microseconds(3000);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.003456Z").value());
-  tp += microseconds(20000);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.023456Z").value());
-  tp += microseconds(100000);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.123456Z").value());
-  tp -= microseconds(6);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.12345Z").value());
-  tp -= microseconds(50);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.1234Z").value());
-  tp -= microseconds(400);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.123Z").value());
-  tp -= microseconds(3000);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.12Z").value());
-  tp -= microseconds(20000);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22.1Z").value());
-  tp -= microseconds(100000);
-  EXPECT_EQ(tp, TimestampFromString("2019-06-21T16:52:22Z").value());
+  Timestamp ts = FromTimeT(1561135942);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22Z").value());
+  ts += std::chrono::nanoseconds(9);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.000000009Z").value());
+  ts += std::chrono::nanoseconds(80);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.000000089Z").value());
+  ts += std::chrono::nanoseconds(700);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.000000789Z").value());
+  ts += std::chrono::nanoseconds(6000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.000006789Z").value());
+  ts += std::chrono::nanoseconds(50000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.000056789Z").value());
+  ts += std::chrono::nanoseconds(400000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.000456789Z").value());
+  ts += std::chrono::nanoseconds(3000000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.003456789Z").value());
+  ts += std::chrono::nanoseconds(20000000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.023456789Z").value());
+  ts += std::chrono::nanoseconds(100000000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.123456789Z").value());
+  ts -= std::chrono::nanoseconds(9);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.12345678Z").value());
+  ts -= std::chrono::nanoseconds(80);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.1234567Z").value());
+  ts -= std::chrono::nanoseconds(700);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.123456Z").value());
+  ts -= std::chrono::nanoseconds(6000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.12345Z").value());
+  ts -= std::chrono::nanoseconds(50000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.1234Z").value());
+  ts -= std::chrono::nanoseconds(400000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.123Z").value());
+  ts -= std::chrono::nanoseconds(3000000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.12Z").value());
+  ts -= std::chrono::nanoseconds(20000000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22.1Z").value());
+  ts -= std::chrono::nanoseconds(100000000);
+  EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22Z").value());
 }
 
 TEST(Time, TimestampFromStringFailure) {

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -32,6 +32,7 @@ spanner_client_hdrs = [
     "retry_policy.h",
     "row.h",
     "sql_statement.h",
+    "timestamp.h",
     "value.h",
     "version.h",
     "version_info.h",

--- a/google/cloud/spanner/timestamp.h
+++ b/google/cloud/spanner/timestamp.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/spanner/version.h"
 #include <chrono>
-#include <cstdint>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/timestamp.h
+++ b/google/cloud/spanner/timestamp.h
@@ -1,0 +1,46 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TIMESTAMP_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TIMESTAMP_H_
+
+#include "google/cloud/spanner/version.h"
+#include <chrono>
+#include <cstdint>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+/**
+ * An instant in time. A std::chrono::time_point using the system (walltime)
+ * clock, represented as a signed integer count (>= 64 bits) of nanoseconds
+ * from the clock's epoch.
+ *
+ * Most implementations use an epoch of 1970-01-01T00:00:00+00:00, where the
+ * range of values would be about 1677-09-21 through to 2262-04-11.
+ *
+ * Note that this may differ from std::chrono::system_clock::time_point on a
+ * particular platform.
+ */
+using Timestamp = std::chrono::time_point<std::chrono::system_clock,
+                                          std::chrono::nanoseconds>;
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TIMESTAMP_H_

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -140,7 +140,7 @@ google::spanner::v1::Type Value::MakeTypeProto(std::string const&) {
   return t;
 }
 
-google::spanner::v1::Type Value::MakeTypeProto(time_point) {
+google::spanner::v1::Type Value::MakeTypeProto(Timestamp) {
   google::spanner::v1::Type t;
   t.set_code(google::spanner::v1::TypeCode::TIMESTAMP);
   return t;
@@ -194,7 +194,7 @@ google::protobuf::Value Value::MakeValueProto(std::string s) {
   return v;
 }
 
-google::protobuf::Value Value::MakeValueProto(time_point ts) {
+google::protobuf::Value Value::MakeValueProto(Timestamp ts) {
   google::protobuf::Value v;
   v.set_string_value(internal::TimestampToString(ts));
   return v;
@@ -274,9 +274,9 @@ StatusOr<std::string> Value::GetValue(std::string const&,
   return pv.string_value();
 }
 
-StatusOr<std::chrono::system_clock::time_point> Value::GetValue(
-    time_point, google::protobuf::Value const& pv,
-    google::spanner::v1::Type const&) {
+StatusOr<Timestamp> Value::GetValue(Timestamp,
+                                    google::protobuf::Value const& pv,
+                                    google::spanner::v1::Type const&) {
   if (pv.kind_case() != google::protobuf::Value::kStringValue) {
     return Status(StatusCode::kUnknown, "missing TIMESTAMP");
   }

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/date.h"
 #include "google/cloud/spanner/internal/tuple_utils.h"
+#include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/optional.h"
@@ -59,7 +60,7 @@ std::pair<google::spanner::v1::Type, google::protobuf::Value> ToProto(Value v);
  * INT64        | `std::int64_t`
  * FLOAT64      | `double`
  * STRING       | `std::string`
- * TIMESTAMP    | `std::chrono::system_clock::time_point`
+ * TIMESTAMP    | `google::cloud::spanner::Timestamp`
  * DATE         | `google::cloud::spanner::Date`
  * ARRAY        | `std::vector<T>`  // [1]
  * STRUCT       | `std::tuple<Ts...>`
@@ -156,8 +157,7 @@ class Value {
   explicit Value(std::int64_t v) : Value(PrivateConstructor{}, v) {}
   explicit Value(double v) : Value(PrivateConstructor{}, v) {}
   explicit Value(std::string v) : Value(PrivateConstructor{}, std::move(v)) {}
-  explicit Value(std::chrono::system_clock::time_point v)
-      : Value(PrivateConstructor{}, std::move(v)) {}
+  explicit Value(Timestamp v) : Value(PrivateConstructor{}, std::move(v)) {}
   explicit Value(Date v) : Value(PrivateConstructor{}, std::move(v)) {}
 
   /**
@@ -335,8 +335,6 @@ class Value {
   friend void PrintTo(Value const& v, std::ostream* os);
 
  private:
-  using time_point = std::chrono::system_clock::time_point;
-
   // Metafunction that returns true if `T` is an optional<U>
   template <typename T>
   struct is_optional : std::false_type {};
@@ -355,7 +353,7 @@ class Value {
   static google::spanner::v1::Type MakeTypeProto(std::int64_t);
   static google::spanner::v1::Type MakeTypeProto(double);
   static google::spanner::v1::Type MakeTypeProto(std::string const&);
-  static google::spanner::v1::Type MakeTypeProto(time_point);
+  static google::spanner::v1::Type MakeTypeProto(Timestamp);
   static google::spanner::v1::Type MakeTypeProto(Date);
   static google::spanner::v1::Type MakeTypeProto(int);
   static google::spanner::v1::Type MakeTypeProto(char const*);
@@ -412,7 +410,7 @@ class Value {
   static google::protobuf::Value MakeValueProto(std::int64_t i);
   static google::protobuf::Value MakeValueProto(double d);
   static google::protobuf::Value MakeValueProto(std::string s);
-  static google::protobuf::Value MakeValueProto(time_point ts);
+  static google::protobuf::Value MakeValueProto(Timestamp ts);
   static google::protobuf::Value MakeValueProto(Date d);
   static google::protobuf::Value MakeValueProto(int i);
   static google::protobuf::Value MakeValueProto(char const* s);
@@ -467,9 +465,8 @@ class Value {
   static StatusOr<std::string> GetValue(std::string const&,
                                         google::protobuf::Value const&,
                                         google::spanner::v1::Type const&);
-  static StatusOr<time_point> GetValue(time_point,
-                                       google::protobuf::Value const&,
-                                       google::spanner::v1::Type const&);
+  static StatusOr<Timestamp> GetValue(Timestamp, google::protobuf::Value const&,
+                                      google::spanner::v1::Type const&);
   static StatusOr<Date> GetValue(Date, google::protobuf::Value const&,
                                  google::spanner::v1::Type const&);
   template <typename T>

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -134,14 +134,15 @@ TEST(Value, BasicSemantics) {
            9223372036L    // near the limit of 64-bit/ns system_clock
        }) {
     auto tp = std::chrono::system_clock::from_time_t(t);
-    for (auto micros : {-1, 0, 1}) {
-      auto ts = tp + std::chrono::microseconds(micros);
-      SCOPED_TRACE("Testing: std::chrono::system_clock::time_point " +
+    for (auto nanos : {-1, 0, 1}) {
+      auto ts = std::chrono::time_point_cast<Timestamp::duration>(tp) +
+                std::chrono::nanoseconds(nanos);
+      SCOPED_TRACE("Testing: google::cloud::spanner::Timestamp " +
                    internal::TimestampToString(ts));
       TestBasicSemantics(ts);
-      std::vector<std::chrono::system_clock::time_point> v(5, ts);
+      std::vector<Timestamp> v(5, ts);
       TestBasicSemantics(v);
-      std::vector<optional<std::chrono::system_clock::time_point>> ov(5, ts);
+      std::vector<optional<Timestamp>> ov(5, ts);
       ov.resize(10);
       TestBasicSemantics(ov);
     }
@@ -488,8 +489,9 @@ TEST(Value, ProtoConversionTimestamp) {
            9223372036L    // near the limit of 64-bit/ns system_clock
        }) {
     auto tp = std::chrono::system_clock::from_time_t(t);
-    for (auto micros : {-1, 0, 1}) {
-      auto ts = tp + std::chrono::microseconds(micros);
+    for (auto nanos : {-1, 0, 1}) {
+      auto ts = std::chrono::time_point_cast<Timestamp::duration>(tp) +
+                std::chrono::nanoseconds(nanos);
       Value const v(ts);
       auto const p = internal::ToProto(v);
       EXPECT_EQ(v, internal::FromProto(p.first, p.second));
@@ -667,27 +669,26 @@ TEST(Value, GetBadInt) {
 }
 
 TEST(Value, GetBadTimestamp) {
-  using time_point = std::chrono::system_clock::time_point;
-  Value v(time_point{});
+  Value v(Timestamp{});
   ClearProtoKind(v);
-  EXPECT_TRUE(v.is<time_point>());
-  EXPECT_FALSE(v.get<time_point>().ok());
+  EXPECT_TRUE(v.is<Timestamp>());
+  EXPECT_FALSE(v.get<Timestamp>().ok());
 
   SetProtoKind(v, google::protobuf::NULL_VALUE);
-  EXPECT_TRUE(v.is<time_point>());
-  EXPECT_FALSE(v.get<time_point>().ok());
+  EXPECT_TRUE(v.is<Timestamp>());
+  EXPECT_FALSE(v.get<Timestamp>().ok());
 
   SetProtoKind(v, true);
-  EXPECT_TRUE(v.is<time_point>());
-  EXPECT_FALSE(v.get<time_point>().ok());
+  EXPECT_TRUE(v.is<Timestamp>());
+  EXPECT_FALSE(v.get<Timestamp>().ok());
 
   SetProtoKind(v, 0.0);
-  EXPECT_TRUE(v.is<time_point>());
-  EXPECT_FALSE(v.get<time_point>().ok());
+  EXPECT_TRUE(v.is<Timestamp>());
+  EXPECT_FALSE(v.get<Timestamp>().ok());
 
   SetProtoKind(v, "blah");
-  EXPECT_TRUE(v.is<time_point>());
-  EXPECT_FALSE(v.get<time_point>().ok());
+  EXPECT_TRUE(v.is<Timestamp>());
+  EXPECT_FALSE(v.get<Timestamp>().ok());
 }
 
 TEST(Value, GetBadDate) {


### PR DESCRIPTION
Previously we chose `std::chrono::system_clock::time_point` to represent
a spanner TIMESTAMP, but it has a platform-specific resolution. Now
we use `time_point<system_clock, nanoseconds>` to explicitly match the
resolution required by Spanner. This allows a timestamp generated on one
machine to be reconstituted intact on another machine.

Revert to testing with nanoseconds. Previously we used microseconds as
that was the common resolution of `system_clock::time_point` over all
supported platforms.

Fixes #138.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/169)
<!-- Reviewable:end -->
