### PR TITLE
feat: Use policies to control polling.

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(spanner_client
             internal/time_format.cc
             internal/time_format.h
             internal/tuple_utils.h
+            polling_policy.h
             retry_policy.h
             row.h
             row_parser.h
@@ -97,6 +98,7 @@ function (spanner_client_define_tests)
         database_admin_client_test.cc
         date_test.cc
         internal/date_test.cc
+        internal/polling_loop_test.cc
         internal/retry_loop_test.cc
         internal/spanner_stub_test.cc
         internal/time_format_test.cc

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(spanner_client
             internal/database_admin_stub.h
             internal/date.cc
             internal/date.h
+            internal/polling_loop.h
             internal/retry_loop.cc
             internal/retry_loop.h
             internal/spanner_stub.cc

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -22,8 +23,8 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 using ::testing::_;
-using ::testing::HasSubstr;
 using ::testing::Invoke;
+namespace gcsa = ::google::spanner::admin::database::v1;
 
 // gmock makes clang-tidy very angry, disable a few warnings that we have no
 // control over.
@@ -31,17 +32,17 @@ using ::testing::Invoke;
 class MockDatabaseAdminClientStub : public internal::DatabaseAdminStub {
  public:
   // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  MOCK_METHOD2(
-      CreateDatabase,
-      StatusOr<google::longrunning::Operation>(
-          grpc::ClientContext&,
-          google::spanner::admin::database::v1::CreateDatabaseRequest const&));
+  MOCK_METHOD2(CreateDatabase,
+               StatusOr<google::longrunning::Operation>(
+                   grpc::ClientContext&, gcsa::CreateDatabaseRequest const&));
 
   // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-  MOCK_METHOD2(
-      DropDatabase,
-      Status(grpc::ClientContext&,
-             google::spanner::admin::database::v1::DropDatabaseRequest const&));
+  MOCK_METHOD1(AwaitCreateDatabase, future<StatusOr<gcsa::Database>>(
+                                        google::longrunning::Operation));
+
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
+  MOCK_METHOD2(DropDatabase,
+               Status(grpc::ClientContext&, gcsa::DropDatabaseRequest const&));
 
   // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(GetOperation,
@@ -50,6 +51,40 @@ class MockDatabaseAdminClientStub : public internal::DatabaseAdminStub {
                    google::longrunning::GetOperationRequest const&));
 };
 
+/// @test Verify that successful case works.
+TEST(DatabaseAdminClientTest, CreateDatabaseSuccess) {
+  auto mock = std::make_shared<MockDatabaseAdminClientStub>();
+
+  EXPECT_CALL(*mock, CreateDatabase(_, _))
+      .WillOnce(
+          Invoke([](grpc::ClientContext&, gcsa::CreateDatabaseRequest const&) {
+            gcsa::Database database;
+            database.set_name("test-db");
+            google::longrunning::Operation op;
+            op.set_name("test-operation-name");
+            op.set_done(true);
+            op.mutable_response()->PackFrom(database);
+            return make_status_or(op);
+          }));
+  EXPECT_CALL(*mock, AwaitCreateDatabase(_))
+      .WillOnce(Invoke([](google::longrunning::Operation const& op) {
+        EXPECT_EQ("test-operation-name", op.name());
+        EXPECT_TRUE(op.done());
+        EXPECT_TRUE(op.has_response());
+        gcsa::Database database;
+        op.response().UnpackTo(&database);
+        return make_ready_future(make_status_or(database));
+      }));
+
+  DatabaseAdminClient client(mock);
+  auto fut = client.CreateDatabase("test-project", "test-instance", "test-db");
+  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  auto db = fut.get();
+  EXPECT_STATUS_OK(db);
+
+  EXPECT_EQ("test-db", db->name());
+}
+
 /// @test Verify that a permanent error in CreateDatabase is immediately
 /// reported.
 TEST(DatabaseAdminClientTest, HandleCreateDatabaseError) {
@@ -57,8 +92,7 @@ TEST(DatabaseAdminClientTest, HandleCreateDatabaseError) {
 
   EXPECT_CALL(*mock, CreateDatabase(_, _))
       .WillOnce(
-          Invoke([](grpc::ClientContext&, google::spanner::admin::database::v1::
-                                              CreateDatabaseRequest const&) {
+          Invoke([](grpc::ClientContext&, gcsa::CreateDatabaseRequest const&) {
             return StatusOr<google::longrunning::Operation>(
                 Status(StatusCode::kPermissionDenied, "uh-oh"));
           }));
@@ -70,97 +104,29 @@ TEST(DatabaseAdminClientTest, HandleCreateDatabaseError) {
   EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
 }
 
-/// @test Verify that as in the polling loop are reported.
-TEST(DatabaseAdminClientTest, HandleGetOperationError) {
+/// @test Verify that errors in the polling loop are reported.
+TEST(DatabaseAdminClientTest, HandleAwaitCreateDatabaseError) {
   auto mock = std::make_shared<MockDatabaseAdminClientStub>();
 
   EXPECT_CALL(*mock, CreateDatabase(_, _))
       .WillOnce(
-          Invoke([](grpc::ClientContext&, google::spanner::admin::database::v1::
-                                              CreateDatabaseRequest const&) {
+          Invoke([](grpc::ClientContext&, gcsa::CreateDatabaseRequest const&) {
             google::longrunning::Operation op;
             op.set_name("test-operation-name");
             op.set_done(false);
             return make_status_or(std::move(op));
           }));
-  EXPECT_CALL(*mock, GetOperation(_, _))
-      .WillOnce(
-          Invoke([](grpc::ClientContext&,
-                    google::longrunning::GetOperationRequest const& request) {
-            EXPECT_EQ("test-operation-name", request.name());
-            return StatusOr<google::longrunning::Operation>(
-                Status(StatusCode::kAborted, "oh noes"));
-          }));
-
-  DatabaseAdminClient client(mock);
-  auto db =
-      client.CreateDatabase("test-project", "test-instance", "test-db").get();
-  EXPECT_EQ(StatusCode::kAborted, db.status().code());
-}
-
-/// @test Verify that longrunning operation completing on error works.
-TEST(DatabaseAdminClientTest, HandleOperationDoneWithFailure) {
-  auto mock = std::make_shared<MockDatabaseAdminClientStub>();
-
-  EXPECT_CALL(*mock, CreateDatabase(_, _))
-      .WillOnce(Invoke([](grpc::ClientContext&,
-                          google::spanner::admin::database::v1::
-                              CreateDatabaseRequest const&) {
-        google::longrunning::Operation op;
-        op.set_name("test-operation-name");
-        op.set_done(true);
-        op.mutable_error()->set_code(static_cast<int>(StatusCode::kAborted));
-        op.mutable_error()->set_message("bad stuff happened");
-        return make_status_or(std::move(op));
+  EXPECT_CALL(*mock, AwaitCreateDatabase(_))
+      .WillOnce(Invoke([](google::longrunning::Operation const& op) {
+        EXPECT_EQ("test-operation-name", op.name());
+        return make_ready_future(
+            StatusOr<gcsa::Database>(Status(StatusCode::kAborted, "oh noes")));
       }));
 
   DatabaseAdminClient client(mock);
   auto db =
       client.CreateDatabase("test-project", "test-instance", "test-db").get();
   EXPECT_EQ(StatusCode::kAborted, db.status().code());
-  EXPECT_THAT(db.status().message(), HasSubstr("bad stuff happened"));
-}
-
-/// @test Verify handling of longrunning operation without result.
-TEST(DatabaseAdminClientTest, HandleOperationDoneWithoutContents) {
-  auto mock = std::make_shared<MockDatabaseAdminClientStub>();
-
-  EXPECT_CALL(*mock, CreateDatabase(_, _))
-      .WillOnce(
-          Invoke([](grpc::ClientContext&, google::spanner::admin::database::v1::
-                                              CreateDatabaseRequest const&) {
-            google::longrunning::Operation op;
-            op.set_name("test-operation-name");
-            op.set_done(true);
-            return make_status_or(std::move(op));
-          }));
-
-  DatabaseAdminClient client(mock);
-  auto db =
-      client.CreateDatabase("test-project", "test-instance", "test-db").get();
-  EXPECT_EQ(StatusCode::kUnknown, db.status().code());
-}
-
-/// @test Verify handling of longrunning operation with invalid contents.
-TEST(DatabaseAdminClientTest, HandleOperationDoneWithInvalidContents) {
-  auto mock = std::make_shared<MockDatabaseAdminClientStub>();
-
-  EXPECT_CALL(*mock, CreateDatabase(_, _))
-      .WillOnce(
-          Invoke([](grpc::ClientContext&, google::spanner::admin::database::v1::
-                                              CreateDatabaseRequest const&) {
-            google::longrunning::Operation op;
-            op.set_name("test-operation-name");
-            op.set_done(true);
-            google::spanner::admin::database::v1::DropDatabaseRequest invalid;
-            op.mutable_response()->PackFrom(invalid);
-            return make_status_or(std::move(op));
-          }));
-
-  DatabaseAdminClient client(mock);
-  auto db =
-      client.CreateDatabase("test-project", "test-instance", "test-db").get();
-  EXPECT_EQ(StatusCode::kInternal, db.status().code());
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/database_admin_retry.h
+++ b/google/cloud/spanner/internal/database_admin_retry.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/backoff_policy.h"
 #include "google/cloud/spanner/internal/database_admin_stub.h"
+#include "google/cloud/spanner/polling_policy.h"
 #include "google/cloud/spanner/retry_policy.h"
 
 namespace google {
@@ -50,6 +51,9 @@ class DatabaseAdminRetry : public DatabaseAdminStub {
       google::spanner::admin::database::v1::CreateDatabaseRequest const&
           request) override;
 
+  future<StatusOr<google::spanner::admin::database::v1::Database>>
+      AwaitCreateDatabase(google::longrunning::Operation) override;
+
   Status DropDatabase(
       grpc::ClientContext& context,
       google::spanner::admin::database::v1::DropDatabaseRequest const& request)
@@ -63,6 +67,7 @@ class DatabaseAdminRetry : public DatabaseAdminStub {
  private:
   void OverridePolicy(RetryPolicy const& p) { retry_policy_ = p.clone(); }
   void OverridePolicy(BackoffPolicy const& p) { backoff_policy_ = p.clone(); }
+  void OverridePolicy(PollingPolicy const& p) { polling_policy_ = p.clone(); }
   void OverridePolicies() {}
   template <typename Policy, typename... Policies>
   void OverridePolicies(Policy&& p, Policies&&... policies) {
@@ -78,6 +83,7 @@ class DatabaseAdminRetry : public DatabaseAdminStub {
   std::shared_ptr<DatabaseAdminStub> child_;
   std::unique_ptr<RetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
+  std::unique_ptr<PollingPolicy> polling_policy_;
 };
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/database_admin_stub.cc
+++ b/google/cloud/spanner/internal/database_admin_stub.cc
@@ -36,8 +36,6 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
 
   ~DefaultDatabaseAdminStub() override = default;
 
-  /// Start the long-running operation to create a new Cloud Spanner
-  /// database.
   StatusOr<google::longrunning::Operation> CreateDatabase(
       grpc::ClientContext& client_context,
       gcsa::v1::CreateDatabaseRequest const& request) override {
@@ -50,7 +48,12 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     return response;
   }
 
-  /// Drop an existing Cloud Spanner database.
+  future<StatusOr<gcsa::v1::Database>> AwaitCreateDatabase(
+      google::longrunning::Operation) override {
+    return make_ready_future(StatusOr<gcsa::v1::Database>(
+        Status(StatusCode::kUnimplemented, __func__)));
+  }
+
   Status DropDatabase(grpc::ClientContext& client_context,
                       gcsa::v1::DropDatabaseRequest const& request) override {
     google::protobuf::Empty response;
@@ -62,7 +65,6 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     return google::cloud::Status();
   }
 
-  /// Poll a long-running operation.
   StatusOr<google::longrunning::Operation> GetOperation(
       grpc::ClientContext& client_context,
       google::longrunning::GetOperationRequest const& request) override {

--- a/google/cloud/spanner/internal/database_admin_stub.h
+++ b/google/cloud/spanner/internal/database_admin_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_STUB_H_
 
 #include "google/cloud/spanner/client_options.h"
+#include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
 
@@ -36,6 +37,11 @@ class DatabaseAdminStub {
       grpc::ClientContext& client_context,
       google::spanner::admin::database::v1::CreateDatabaseRequest const&
           request) = 0;
+
+  /// Wait for a long-running operation to create a new Cloud Spanner database
+  /// completes.
+  virtual future<StatusOr<google::spanner::admin::database::v1::Database>>
+      AwaitCreateDatabase(google::longrunning::Operation) = 0;
 
   /// Drop an existing Cloud Spanner database.
   virtual Status DropDatabase(

--- a/google/cloud/spanner/internal/polling_loop_test.cc
+++ b/google/cloud/spanner/internal/polling_loop_test.cc
@@ -1,0 +1,254 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/internal/polling_loop.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include <google/protobuf/struct.pb.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+namespace {
+
+using ::testing::HasSubstr;
+
+std::unique_ptr<PollingPolicy> TestPollingPolicy() {
+  using Policy = GenericPollingPolicy<LimitedErrorCountRetryPolicy,
+                                      ExponentialBackoffPolicy>;
+  return Policy(LimitedErrorCountRetryPolicy(5),
+                ExponentialBackoffPolicy(std::chrono::microseconds(1),
+                                         std::chrono::microseconds(5), 2.0))
+      .clone();
+}
+
+TEST(PollingLoopTest, ImmediateSuccess) {
+  google::protobuf::Value expected;
+  expected.set_string_value("42");
+
+  google::longrunning::Operation operation;
+  operation.set_name("test-operation");
+  operation.set_done(true);
+  operation.mutable_response()->PackFrom(expected);
+
+  StatusOr<google::protobuf::Value> actual =
+      PollingLoop<google::protobuf::Value>(
+          TestPollingPolicy(),
+          [](grpc::ClientContext&,
+             google::longrunning::GetOperationRequest const&) {
+            // The polling operation should not be called for requests
+            EXPECT_TRUE(false);
+            return make_status_or(google::longrunning::Operation{});
+          },
+          operation, "location");
+  EXPECT_STATUS_OK(actual);
+  EXPECT_EQ(expected.string_value(), actual->string_value());
+}
+
+TEST(PollingLoopTest, ImmediateFailure) {
+  google::rpc::Status error;
+  error.set_code(static_cast<int>(StatusCode::kResourceExhausted));
+  error.set_message("cannot complete operation");
+  google::longrunning::Operation operation;
+  operation.set_name("test-operation");
+  operation.set_done(true);
+  *operation.mutable_error() = error;
+
+  StatusOr<google::protobuf::Value> actual =
+      PollingLoop<google::protobuf::Value>(
+          TestPollingPolicy(),
+          [](grpc::ClientContext&,
+             google::longrunning::GetOperationRequest const&) {
+            // The polling operation should not be called for requests
+            EXPECT_TRUE(false);
+            return make_status_or(google::longrunning::Operation{});
+          },
+          operation, "location");
+  EXPECT_EQ(StatusCode::kResourceExhausted, actual.status().code());
+  EXPECT_EQ(error.message(), actual.status().message());
+}
+
+TEST(PollingLoopTest, SuccessWithSuccessfulPolling) {
+  google::protobuf::Value expected;
+  expected.set_string_value("42");
+
+  google::longrunning::Operation operation;
+  operation.set_name("test-operation");
+  operation.set_done(false);
+
+  int counter = 3;
+  StatusOr<google::protobuf::Value> actual =
+      PollingLoop<google::protobuf::Value>(
+          TestPollingPolicy(),
+          [expected, &counter](
+              grpc::ClientContext&,
+              google::longrunning::GetOperationRequest const& r) {
+            google::longrunning::Operation op;
+            op.set_name(r.name());
+            if (--counter != 0) {
+              op.set_done(false);
+            } else {
+              op.set_done(true);
+              op.mutable_response()->PackFrom(expected);
+            }
+            return make_status_or(op);
+          },
+          operation, "location");
+  EXPECT_STATUS_OK(actual);
+  EXPECT_EQ(expected.string_value(), actual->string_value());
+}
+
+TEST(PollingLoopTest, FailureWithSuccessfulPolling) {
+  google::rpc::Status error;
+  error.set_code(static_cast<int>(StatusCode::kResourceExhausted));
+  error.set_message("cannot complete operation");
+
+  google::longrunning::Operation operation;
+  operation.set_name("test-operation");
+  operation.set_done(false);
+
+  int counter = 3;
+  StatusOr<google::protobuf::Value> actual =
+      PollingLoop<google::protobuf::Value>(
+          TestPollingPolicy(),
+          [error, &counter](grpc::ClientContext&,
+                            google::longrunning::GetOperationRequest const& r) {
+            google::longrunning::Operation op;
+            op.set_name(r.name());
+            if (--counter != 0) {
+              op.set_done(false);
+            } else {
+              op.set_done(true);
+              *op.mutable_error() = error;
+            }
+            return make_status_or(op);
+          },
+          operation, "location");
+  EXPECT_EQ(StatusCode::kResourceExhausted, actual.status().code());
+  EXPECT_EQ(error.message(), actual.status().message());
+}
+
+TEST(PollingLoopTest, SuccessWithTransientFailures) {
+  google::protobuf::Value expected;
+  expected.set_string_value("42");
+
+  google::longrunning::Operation operation;
+  operation.set_name("test-operation");
+  operation.set_done(false);
+
+  int counter = 4;
+  StatusOr<google::protobuf::Value> actual =
+      PollingLoop<google::protobuf::Value>(
+          TestPollingPolicy(),
+          [expected, &counter](
+              grpc::ClientContext&,
+              google::longrunning::GetOperationRequest const& r) {
+            google::longrunning::Operation op;
+            op.set_name(r.name());
+            counter--;
+            if (counter >= 2) {
+              return StatusOr<google::longrunning::Operation>(
+                  Status(StatusCode::kUnavailable, "try again"));
+            }
+            if (counter > 0) {
+              op.set_done(false);
+            } else {
+              op.set_done(true);
+              op.mutable_response()->PackFrom(expected);
+            }
+            return make_status_or(op);
+          },
+          operation, "location");
+  EXPECT_STATUS_OK(actual);
+  EXPECT_EQ(expected.string_value(), actual->string_value());
+}
+
+TEST(PollingLoopTest, FailurePermanentError) {
+  google::longrunning::Operation operation;
+  operation.set_name("test-operation");
+  operation.set_done(false);
+
+  StatusOr<google::protobuf::Value> actual =
+      PollingLoop<google::protobuf::Value>(
+          TestPollingPolicy(),
+          [](grpc::ClientContext&,
+             google::longrunning::GetOperationRequest const&) {
+            return StatusOr<google::longrunning::Operation>(
+                Status(StatusCode::kPermissionDenied, "uh oh"));
+          },
+          operation, "location");
+  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+}
+
+TEST(PollingLoopTest, FailureTooManyTransients) {
+  google::longrunning::Operation operation;
+  operation.set_name("test-operation");
+  operation.set_done(false);
+
+  StatusOr<google::protobuf::Value> actual =
+      PollingLoop<google::protobuf::Value>(
+          TestPollingPolicy(),
+          [](grpc::ClientContext&,
+             google::longrunning::GetOperationRequest const&) {
+            return StatusOr<google::longrunning::Operation>(
+                Status(StatusCode::kUnavailable, "just keep trying"));
+          },
+          operation, "location");
+  EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+}
+
+TEST(PollingLoopTest, FailureMissingResponseAndError) {
+  google::longrunning::Operation operation;
+  operation.set_name("test-operation");
+  operation.set_done(true);
+
+  StatusOr<google::protobuf::Value> actual =
+      PollingLoop<google::protobuf::Value>(
+          TestPollingPolicy(),
+          [](grpc::ClientContext&,
+             google::longrunning::GetOperationRequest const&) {
+            return make_status_or(google::longrunning::Operation{});
+          },
+          operation, "test-location");
+  EXPECT_EQ(StatusCode::kInternal, actual.status().code());
+  EXPECT_THAT(actual.status().message(), HasSubstr("test-location"));
+}
+
+TEST(PollingLoopTest, FailureInvalidContents) {
+  google::protobuf::Empty contents;
+  google::longrunning::Operation operation;
+  operation.set_name("test-operation");
+  operation.set_done(true);
+  operation.mutable_response()->PackFrom(contents);
+
+  StatusOr<google::protobuf::Value> actual =
+      PollingLoop<google::protobuf::Value>(
+          TestPollingPolicy(),
+          [](grpc::ClientContext&,
+             google::longrunning::GetOperationRequest const&) {
+            return make_status_or(google::longrunning::Operation{});
+          },
+          operation, "test-location");
+  EXPECT_EQ(StatusCode::kInternal, actual.status().code());
+  EXPECT_THAT(actual.status().message(), HasSubstr("test-location"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/internal/polling_loop_test.cc
+++ b/google/cloud/spanner/internal/polling_loop_test.cc
@@ -50,6 +50,7 @@ TEST(PollingLoopTest, ImmediateSuccess) {
           [](grpc::ClientContext&,
              google::longrunning::GetOperationRequest const&) {
             // The polling operation should not be called for requests
+            // FAIL() fails here (he he) because it has an embedded `return;`
             EXPECT_TRUE(false);
             return make_status_or(google::longrunning::Operation{});
           },

--- a/google/cloud/spanner/polling_policy.h
+++ b/google/cloud/spanner/polling_policy.h
@@ -1,0 +1,66 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_POLLING_POLICY_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_POLLING_POLICY_H_
+
+#include "google/cloud/spanner/backoff_policy.h"
+#include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/status.h"
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+class PollingPolicy {
+ public:
+  virtual ~PollingPolicy() = default;
+
+  virtual std::unique_ptr<PollingPolicy> clone() const = 0;
+  virtual bool OnFailure(google::cloud::Status const& status) = 0;
+  virtual std::chrono::milliseconds WaitPeriod() = 0;
+};
+
+template <typename Retry = LimitedTimeRetryPolicy,
+          typename Backoff = ExponentialBackoffPolicy>
+class GenericPollingPolicy : public PollingPolicy {
+ public:
+  GenericPollingPolicy(Retry retry_policy, Backoff backoff_policy)
+      : retry_policy_(std::move(retry_policy)),
+        backoff_policy_(std::move(backoff_policy)) {}
+
+  std::unique_ptr<PollingPolicy> clone() const override {
+    return std::unique_ptr<PollingPolicy>(new GenericPollingPolicy(*this));
+  }
+
+  bool OnFailure(google::cloud::Status const& status) override {
+    return retry_policy_.OnFailure(status);
+  }
+
+  std::chrono::milliseconds WaitPeriod() override {
+    return backoff_policy_.OnCompletion();
+  }
+
+ private:
+  Retry retry_policy_;
+  Backoff backoff_policy_;
+};
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_POLLING_POLICY_H_

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -29,6 +29,7 @@ spanner_client_hdrs = [
     "internal/time.h",
     "internal/time_format.h",
     "internal/tuple_utils.h",
+    "polling_policy.h",
     "retry_policy.h",
     "row.h",
     "row_parser.h",

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -24,6 +24,7 @@ spanner_client_hdrs = [
     "internal/database_admin_retry.h",
     "internal/database_admin_stub.h",
     "internal/date.h",
+    "internal/polling_loop.h",
     "internal/retry_loop.h",
     "internal/spanner_stub.h",
     "internal/time.h",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -21,6 +21,7 @@ spanner_client_unit_tests = [
     "database_admin_client_test.cc",
     "date_test.cc",
     "internal/date_test.cc",
+    "internal/polling_loop_test.cc",
     "internal/retry_loop_test.cc",
     "internal/spanner_stub_test.cc",
     "internal/time_format_test.cc",


### PR DESCRIPTION
This PR introduces a `spanner::PollingPolicy` to control for how long we
poll longrunning operations. We use this policy in the
`internal::DatabaseAdminRetry` decorator, and refactored the polling
loop to a function, so we can test it.

I removed a number of tests for DatabaseAdminClient because they
basically repeat the (more generic) tests for `internal::PollingLoop`.

Fixes #128 and fixes #126.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/174)
<!-- Reviewable:end -->
