### PR TITLE
cleanup: Support metadata as result in PollingLoop.

### DIFF
--- a/google/cloud/spanner/internal/database_admin_retry.cc
+++ b/google/cloud/spanner/internal/database_admin_retry.cc
@@ -118,7 +118,8 @@ future<StatusOr<gcsa::Database>> DatabaseAdminRetry::AwaitCreateDatabase(
          std::unique_ptr<PollingPolicy> polling_policy,
          google::cloud::promise<StatusOr<gcsa::Database>> promise,
          char const* location) mutable {
-        auto result = internal::PollingLoop<gcsa::Database>(
+        auto result = internal::PollingLoop<
+            internal::PollingLoopResponseExtractor<gcsa::Database>>(
             std::move(polling_policy),
             [stub](grpc::ClientContext& context,
                    google::longrunning::GetOperationRequest const& request) {


### PR DESCRIPTION
Some operations (like the upcoming `UpdateMetadata()`) use long-running
operations, but all the interesting results are in the metadata field,
not the response field. This change refactors the code to support
extracting the result from either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/201)
<!-- Reviewable:end -->
