### PR TITLE
feat: Adds Row::values() accessor that returns std::array<Value, N>

### DIFF
--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -183,6 +183,25 @@ class Row {
   std::tuple<Types...>&& get() && { return std::move(values_); }
   std::tuple<Types...> const&& get() const&& { return std::move(values_); }
 
+  /**
+   * Returns a std::array of `Value` objects holding all the items in this row.
+   *
+   * @par Example
+   *
+   * @code
+   * auto row = MakeRow(true, "foo", 42);
+   * std::array<Value, 3> a = row.values();
+   * assert(a[0].get<bool>() == true);
+   * assert(a[1].get<std::string>() == "foo");
+   * assert(a[2].get<std::int64_t>() == 42);
+   * @endcode
+   */
+  std::array<Value, size()> values() const {
+    std::array<Value, size()> array;
+    internal::ForEach(values_, InsertValue{array, 0});
+    return array;
+  }
+
   /// @name Equality operators
   ///@{
   friend bool operator==(Row const& a, Row const& b) {
@@ -210,6 +229,17 @@ class Row {
   ///@}
 
  private:
+  // A helper functor to be used with `internal::ForEach` that adds each
+  // element of the values_ tuple to an array of `Value` objects.
+  struct InsertValue {
+    std::array<Value, size()>& array;
+    std::size_t i;
+    template <typename T>
+    void operator()(T const& t) {
+      array[i++] = Value(t);
+    }
+  };
+
   std::tuple<Types...> values_;
 };
 

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -207,6 +207,7 @@ class Row {
     internal::ForEach(values_, InsertValue{array, 0});
     return array;
   }
+  /// @copydoc values()
   std::array<Value, size()> values() && {
     std::array<Value, size()> array;
     internal::ForEach(std::move(values_), InsertValue{array, 0});

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -230,12 +230,12 @@ TEST(Row, ValuesAccessorRvalue) {
   // move-the-values-from-the-row code compiles and produces the results users
   // should expect. In particular, we do not verify that the items were
   // actually *moved-from* as opposed to copied.
-  constexpr auto data = "12345678901234567890";
-  auto row = MakeRow(data);
+  constexpr auto kData = "12345678901234567890";
+  auto row = MakeRow(kData);
   auto array = std::move(row).values();
   auto v = array[0].get<std::string>();
   EXPECT_TRUE(v.ok());
-  EXPECT_EQ(data, *v);
+  EXPECT_EQ(kData, *v);
 }
 
 }  // namespace

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -183,6 +183,7 @@ TEST(Row, ParseRowEmpty) {
   auto const row = ParseRow(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(), *row);
+  EXPECT_EQ(array, row->values());
 }
 
 TEST(Row, ParseRowOneValue) {
@@ -190,6 +191,7 @@ TEST(Row, ParseRowOneValue) {
   auto const row = ParseRow<std::int64_t>(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(42), *row);
+  EXPECT_EQ(array, row->values());
   // Tests parsing the Value with the wrong type.
   auto const error_row = ParseRow<double>(array);
   EXPECT_FALSE(error_row.ok());
@@ -200,9 +202,26 @@ TEST(Row, ParseRowThree) {
   auto row = ParseRow<bool, std::int64_t, std::string>(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(true, 42, "hello"), *row);
+  EXPECT_EQ(array, row->values());
   // Tests parsing the Value with the wrong type.
   auto const error_row = ParseRow<bool, double, std::string>(array);
   EXPECT_FALSE(error_row.ok());
+}
+
+template <typename... Ts>
+void RoundTripRow(Row<Ts...> const& row) {
+  auto array = row.values();
+  auto parsed = ParseRow<Ts...>(array);
+  EXPECT_TRUE(parsed.ok());
+  EXPECT_EQ(row, *parsed);
+}
+
+TEST(Row, UnparseRow) {
+  RoundTripRow(MakeRow());
+  RoundTripRow(MakeRow(42));
+  RoundTripRow(MakeRow(42, 42));
+  RoundTripRow(MakeRow(42, "hello"));
+  RoundTripRow(MakeRow(42, "hello", 3.14));
 }
 
 }  // namespace

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -224,6 +224,20 @@ TEST(Row, UnparseRow) {
   RoundTripRow(MakeRow(42, "hello", 3.14));
 }
 
+TEST(Row, ValuesAccessorRvalue) {
+  // There's no good way to test that move semantics actually *work* when using
+  // types that you don't own. So this test just verifies that properly written
+  // move-the-values-from-the-row code compiles and produces the results users
+  // should expect. In particular, we do not verify that the items were
+  // actually *moved-from* as opposed to copied.
+  constexpr auto data = "12345678901234567890";
+  auto row = MakeRow(data);
+  auto array = std::move(row).values();
+  auto v = array[0].get<std::string>();
+  EXPECT_TRUE(v.ok());
+  EXPECT_EQ(data, *v);
+}
+
 }  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner


### PR DESCRIPTION
This accessor lets callers extract all the columns from a row without
explicitly knowing the corresponding C++ types by getting a std::array
of Value objects. Those could then be interogated to figure out their
values, or the raw protos could be extracted.

I suspect this might be useful for the upcoming KeySet implementation: #202

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/214)
<!-- Reviewable:end -->
