### PR TITLE
Update Bazel to 0.28.0

### DIFF
--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -66,12 +66,12 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-1.21.0",
+            strip_prefix = "grpc-1.22.0",
             urls = [
-                "https://github.com/grpc/grpc/archive/v1.21.0.tar.gz",
-                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.21.0.tar.gz",
+                "https://github.com/grpc/grpc/archive/v1.22.0.tar.gz",
+                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.22.0.tar.gz",
             ],
-            sha256 = "8da7f32cc8978010d2060d740362748441b81a34e5425e108596d3fcd63a97f2",
+            sha256 = "11ac793c562143d52fd440f6549588712badc79211cdc8c509b183cb69bddad8",
         )
 
     # We use the cc_proto_library() rule from @com_google_protobuf, which

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -18,7 +18,7 @@ set -eu
 readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" \
   |  tr '[:upper:]' '[:lower:]')
 
-readonly BAZEL_VERSION="0.24.0"
+readonly BAZEL_VERSION="0.28.0"
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"


### PR DESCRIPTION
Fixes #104 

This also updates gRPC. At some point, Bazel flipped the default value of `incompatible_depset_is_not_iterable` from `false` to `true`, requiring the `to_list()` method to be used. Those changes are available in a newer version of gRPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/220)
<!-- Reviewable:end -->
