### PR TITLE
fix: RowParser accepts shared_ptr<ValueSource>

### DIFF
--- a/google/cloud/spanner/row_parser.h
+++ b/google/cloud/spanner/row_parser.h
@@ -159,13 +159,11 @@ class RowParser {
   explicit RowParser(std::shared_ptr<ValueSource> vs)
       : value_source_(std::move(vs)) {}
 
-  /// @name Move-only type
-  ///@{
-  RowParser(RowParser const&) = delete;
-  RowParser& operator=(RowParser const&) = delete;
-  RowParser(RowParser&& rp) = default;
+  // Copy and assignable.
+  RowParser(RowParser const&) = default;
+  RowParser& operator=(RowParser const&) = default;
+  RowParser(RowParser&&) = default;
   RowParser& operator=(RowParser&&) = default;
-  ///@}
 
   /// Returns the begin iterator.
   iterator begin() { return iterator(value_source_); }


### PR DESCRIPTION
`RowParser<Ts...>` now accepts the ValueSource functor wrapped in a shared_ptr. This allows the ResultSet to construct a single shared ValueSource that it shares with RowParser. 

A few fallouts from this change:

1. RowParser and ResultSet will now have independent lifetimes.

2. If a RowParser is moved to another RowParser, the second one will continue where the first left off. 

Related to #221

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/226)
<!-- Reviewable:end -->
