### PR TITLE
feat: Add support for Row<Value>

### DIFF
--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -288,6 +288,10 @@ struct ExtractValue {
       t = *std::move(x);
     }
   }
+  template <typename It>
+  void operator()(Value& v, It& it) const {
+    v = *it++;
+  }
 };
 }  // namespace internal
 

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -79,6 +79,20 @@ TEST(Row, TwoTypes) {
   EXPECT_EQ(std::make_tuple(std::int64_t{42}, true), (row.get<1, 0>()));
 }
 
+TEST(Row, WithValues) {
+  Row<Value, Value> row(Value(42), Value("hello"));
+  EXPECT_EQ(2, row.size());
+  EXPECT_EQ(Value(42), row.get<0>());
+  EXPECT_EQ(Value("hello"), row.get<1>());
+}
+
+TEST(Row, WithMixedValues) {
+  Row<std::int64_t, Value> row(42, Value("hello"));
+  EXPECT_EQ(2, row.size());
+  EXPECT_EQ(42, row.get<0>());
+  EXPECT_EQ(Value("hello"), row.get<1>());
+}
+
 TEST(Row, ThreeTypes) {
   Row<bool, std::int64_t, std::string> const row(true, 42, "hello");
   EXPECT_EQ(3, row.size());
@@ -222,6 +236,17 @@ TEST(Row, UnparseRow) {
   RoundTripRow(MakeRow(42, 42));
   RoundTripRow(MakeRow(42, "hello"));
   RoundTripRow(MakeRow(42, "hello", 3.14));
+
+  RoundTripRow(MakeRow(Value(42)));
+  RoundTripRow(MakeRow(Value(42), "hello"));
+  RoundTripRow(MakeRow(Value(42), Value("hello"), 3.14));
+  RoundTripRow(MakeRow(Value(42), Value("hello"), Value(3.14)));
+}
+
+TEST(Row, ParseValues) {
+  std::array<Value, 3> array = {Value(42), Value("hello"), Value(3.14)};
+  auto parsed = ParseRow<Value, Value, Value>(array);
+  EXPECT_TRUE(parsed.ok());
 }
 
 TEST(Row, ValuesAccessorRvalue) {

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -243,12 +243,6 @@ TEST(Row, UnparseRow) {
   RoundTripRow(MakeRow(Value(42), Value("hello"), Value(3.14)));
 }
 
-TEST(Row, ParseValues) {
-  std::array<Value, 3> array = {Value(42), Value("hello"), Value(3.14)};
-  auto parsed = ParseRow<Value, Value, Value>(array);
-  EXPECT_TRUE(parsed.ok());
-}
-
 TEST(Row, ValuesAccessorRvalue) {
   // There's no good way to test that move semantics actually *work* when using
   // types that you don't own. So this test just verifies that properly written


### PR DESCRIPTION
A `Row<Ts...>` represents a list of column values. Typically, each value
is a supported C++ type (bool, std::int64_t, std::string, etc). But
there may be cases where it's convenient to create a "row" of
`spanner::Value` objects, such as if/when one already has a `Value`
objec that they'd like to add to the Row, or maybe if one is reading the
results of a query and may doesn't know the type of the value (yet) and
would like to handle it in some type-erased way.

Related to #231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/232)
<!-- Reviewable:end -->
