### PR TITLE
bug: Always require column names for mutations.

### DIFF
--- a/google/cloud/spanner/mutations.h
+++ b/google/cloud/spanner/mutations.h
@@ -104,10 +104,6 @@ void PopulateListValue(google::protobuf::ListValue& lv, T&& head,
 template <typename Op>
 class WriteMutationBuilder {
  public:
-  explicit WriteMutationBuilder(std::string table_name) {
-    Op::mutable_field(m_).set_table(std::move(table_name));
-  }
-
   WriteMutationBuilder(std::string table_name,
                        std::vector<std::string> column_names) {
     auto& field = Op::mutable_field(m_);
@@ -188,8 +184,9 @@ using InsertMutationBuilder =
 
 /// Creates a simple insert mutation for the values in @p values.
 template <typename... Ts>
-Mutation MakeInsertMutation(std::string table_name, Ts&&... values) {
-  return InsertMutationBuilder(std::move(table_name))
+Mutation MakeInsertMutation(std::string table_name,
+                            std::vector<std::string> columns, Ts&&... values) {
+  return InsertMutationBuilder(std::move(table_name), std::move(columns))
       .EmplaceRow(std::forward<Ts>(values)...)
       .Build();
 }
@@ -208,8 +205,9 @@ using UpdateMutationBuilder =
 
 /// Creates a simple update mutation for the values in @p values.
 template <typename... Ts>
-Mutation MakeUpdateMutation(std::string table_name, Ts&&... values) {
-  return UpdateMutationBuilder(std::move(table_name))
+Mutation MakeUpdateMutation(std::string table_name,
+                            std::vector<std::string> columns, Ts&&... values) {
+  return UpdateMutationBuilder(std::move(table_name), std::move(columns))
       .EmplaceRow(std::forward<Ts>(values)...)
       .Build();
 }
@@ -228,8 +226,11 @@ using InsertOrUpdateMutationBuilder =
 
 /// Creates a simple "insert or update" mutation for the values in @p values.
 template <typename... Ts>
-Mutation MakeInsertOrUpdateMutation(std::string table_name, Ts&&... values) {
-  return InsertOrUpdateMutationBuilder(std::move(table_name))
+Mutation MakeInsertOrUpdateMutation(std::string table_name,
+                                    std::vector<std::string> columns,
+                                    Ts&&... values) {
+  return InsertOrUpdateMutationBuilder(std::move(table_name),
+                                       std::move(columns))
       .EmplaceRow(std::forward<Ts>(values)...)
       .Build();
 }
@@ -248,8 +249,9 @@ using ReplaceMutationBuilder =
 
 /// Creates a simple "replace" mutation for the values in @p values.
 template <typename... Ts>
-Mutation MakeReplaceMutation(std::string table_name, Ts&&... values) {
-  return ReplaceMutationBuilder(std::move(table_name))
+Mutation MakeReplaceMutation(std::string table_name,
+                             std::vector<std::string> columns, Ts&&... values) {
+  return ReplaceMutationBuilder(std::move(table_name), std::move(columns))
       .EmplaceRow(std::forward<Ts>(values)...)
       .Build();
 }

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -32,7 +32,7 @@ TEST(MutationsTest, Default) {
 
 TEST(MutationsTest, PrintTo) {
   Mutation insert =
-      MakeInsertMutation("table-name", std::string("test-string"));
+      MakeInsertMutation("table-name", {}, std::string("test-string"));
   std::ostringstream os;
   PrintTo(insert, &os);
   auto actual = std::move(os).str();
@@ -42,8 +42,9 @@ TEST(MutationsTest, PrintTo) {
 
 TEST(MutationsTest, InsertSimple) {
   Mutation empty;
-  Mutation insert = MakeInsertMutation("table-name", std::string("foo"),
-                                       std::string("bar"), true);
+  Mutation insert =
+      MakeInsertMutation("table-name", {"col_a", "col_b", "col_c"},
+                         std::string("foo"), std::string("bar"), true);
   EXPECT_EQ(insert, insert);
   EXPECT_NE(insert, empty);
 
@@ -51,6 +52,9 @@ TEST(MutationsTest, InsertSimple) {
   google::spanner::v1::Mutation expected;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
               insert: {
+                columns: "col_a"
+                columns: "col_b"
+                columns: "col_c"
                 table: "table-name"
                 values {
                   values {
@@ -123,8 +127,9 @@ TEST(MutationsTest, InsertComplex) {
 
 TEST(MutationsTest, UpdateSimple) {
   Mutation empty;
-  Mutation update = MakeUpdateMutation("table-name", std::string("foo"),
-                                       std::string("bar"), true);
+  Mutation update =
+      MakeUpdateMutation("table-name", {"col_a", "col_b", "col_c"},
+                         std::string("foo"), std::string("bar"), true);
   EXPECT_EQ(update, update);
   EXPECT_NE(update, empty);
 
@@ -133,6 +138,9 @@ TEST(MutationsTest, UpdateSimple) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
               update: {
                 table: "table-name"
+                columns: "col_a"
+                columns: "col_b"
+                columns: "col_c"
                 values {
                   values {
                     string_value: "foo"
@@ -205,8 +213,9 @@ TEST(MutationsTest, UpdateComplex) {
 
 TEST(MutationsTest, InsertOrUpdateSimple) {
   Mutation empty;
-  Mutation update = MakeInsertOrUpdateMutation("table-name", std::string("foo"),
-                                               std::string("bar"), true);
+  Mutation update =
+      MakeInsertOrUpdateMutation("table-name", {"col_a", "col_b", "col_c"},
+                                 std::string("foo"), std::string("bar"), true);
   EXPECT_EQ(update, update);
   EXPECT_NE(update, empty);
 
@@ -215,6 +224,9 @@ TEST(MutationsTest, InsertOrUpdateSimple) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
               insert_or_update: {
                 table: "table-name"
+                columns: "col_a"
+                columns: "col_b"
+                columns: "col_c"
                 values {
                   values {
                     string_value: "foo"
@@ -285,8 +297,9 @@ TEST(MutationsTest, InsertOrUpdateComplex) {
 
 TEST(MutationsTest, ReplaceSimple) {
   Mutation empty;
-  Mutation replace = MakeReplaceMutation("table-name", std::string("foo"),
-                                         std::string("bar"), true);
+  Mutation replace =
+      MakeReplaceMutation("table-name", {"col_a", "col_b", "col_c"},
+                          std::string("foo"), std::string("bar"), true);
   EXPECT_EQ(replace, replace);
   EXPECT_NE(replace, empty);
 
@@ -295,6 +308,9 @@ TEST(MutationsTest, ReplaceSimple) {
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
               replace: {
                 table: "table-name"
+                columns: "col_a"
+                columns: "col_b"
+                columns: "col_c"
                 values {
                   values {
                     string_value: "foo"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/233)
<!-- Reviewable:end -->
