### PR TITLE
Make EmplaceRow forward to AddRow

### DIFF
--- a/google/cloud/spanner/mutations.h
+++ b/google/cloud/spanner/mutations.h
@@ -84,22 +84,6 @@ class Mutation {
 // This namespace contains implementation details. It is not part of the public
 // API, and subject to change without notice.
 namespace internal {
-inline void PopulateListValue(google::protobuf::ListValue&) {}
-
-/**
- * Initialize a `google::protobuf::ListValue` from a variadic list of C++ types.
- *
- * This function applies the conversions defined by #Value
- */
-template <typename T, typename... Ts>
-void PopulateListValue(google::protobuf::ListValue& lv, T&& head,
-                       Ts&&... tail) {
-  google::spanner::v1::Type type;
-  google::protobuf::Value value;
-  std::tie(type, value) = internal::ToProto(Value(std::forward<T>(head)));
-  *lv.add_values() = std::move(value);
-  PopulateListValue(lv, std::forward<Ts>(tail)...);
-}
 
 template <typename Op>
 class WriteMutationBuilder {
@@ -122,22 +106,17 @@ class WriteMutationBuilder {
   Mutation Build() && { return Mutation(std::move(m_)); }
 
   template <typename... Ts>
-  WriteMutationBuilder& EmplaceRow(Ts&&... values) {
-    google::protobuf::ListValue lv;
-    internal::PopulateListValue(lv, std::forward<Ts>(values)...);
-    *Op::mutable_field(m_).add_values() = std::move(lv);
+  WriteMutationBuilder& AddRow(Row<Ts...> row) {
+    auto& lv = *Op::mutable_field(m_).add_values();
+    for (auto& v : std::move(row).values()) {
+      std::tie(std::ignore, *lv.add_values()) = internal::ToProto(std::move(v));
+    }
     return *this;
   }
 
   template <typename... Ts>
-  WriteMutationBuilder& AddRow(Row<Ts...> row) {
-    auto values = std::move(row).values();
-    google::protobuf::ListValue lv;
-    for (auto& v : values) {
-      internal::PopulateListValue(lv, std::move(v));
-    }
-    *Op::mutable_field(m_).add_values() = std::move(lv);
-    return *this;
+  WriteMutationBuilder& EmplaceRow(Ts&&... values) {
+    return AddRow(MakeRow<Ts...>(std::forward<Ts>(values)...));
   }
 
  private:

--- a/google/cloud/spanner/mutations.h
+++ b/google/cloud/spanner/mutations.h
@@ -116,7 +116,7 @@ class WriteMutationBuilder {
 
   template <typename... Ts>
   WriteMutationBuilder& EmplaceRow(Ts&&... values) {
-    return AddRow(MakeRow<Ts...>(std::forward<Ts>(values)...));
+    return AddRow(MakeRow(std::forward<Ts>(values)...));
   }
 
  private:


### PR DESCRIPTION
(I think) EmplaceRow exists as a convenience for users who have values
but no row yet. Logically users are adding a row, but since they only
have values, we'll construct the Row for them. Therefore, it may make
sense to have EmplaceRow() be a simple 1-line forwarder to AddRow(), to
have a implementation for both functions.

This also simplifies the implementation a little since `Row` already handles all the variadic stuff.

Modulo an extra move here or there, I don't think this will result in
any extra/unnecessary copies, so I think performance wise this would be
pretty close to a wash. But someone with a better eye than me may be
able to point out if/where my assumptions are wrong.

I'm not wedded to this. It's just something for us to consider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/235)
<!-- Reviewable:end -->
