### PR TITLE
fix: RowParser improvements

### DIFF
--- a/google/cloud/spanner/row_parser.h
+++ b/google/cloud/spanner/row_parser.h
@@ -117,16 +117,7 @@ class RowParser {
     }
 
     friend bool operator==(iterator const& a, iterator const& b) {
-      // Input iterators may only be compared to (copies of) themselves and
-      // end. See https://en.cppreference.com/w/cpp/named_req/InputIterator
-      //
-      // Note: An "end" iterator has two representations that must compare
-      // equal:
-      //   1. When iterator::parser_ is nullptr_
-      //   2. When iterator::parser_::value_source_ is nullptr_
-      bool const a_is_end = !a.parser_ || !a.parser_->value_source_;
-      bool const b_is_end = !b.parser_ || !b.parser_->value_source_;
-      return a_is_end == b_is_end;
+      return a.Equals(b);
     }
     friend bool operator!=(iterator const& a, iterator const& b) {
       return !(a == b);
@@ -135,6 +126,20 @@ class RowParser {
    private:
     friend RowParser;
     explicit iterator(RowParser* p) : parser_(p) {}
+
+    bool Equals(iterator const& b) const {
+      // Input iterators may only be compared to (copies of) themselves and
+      // end. See https://en.cppreference.com/w/cpp/named_req/InputIterator
+      //
+      // Note: An "end" iterator has two representations that must compare
+      // equal:
+      //   1. When iterator::parser_ is nullptr_
+      //   2. When iterator::parser_::value_source_ is nullptr_
+      iterator const& a = *this;
+      bool const a_is_end = !a.parser_ || !a.parser_->value_source_;
+      bool const b_is_end = !b.parser_ || !b.parser_->value_source_;
+      return a_is_end == b_is_end;
+    }
 
     RowParser* parser_;  // nullptr means end
   };

--- a/google/cloud/spanner/row_parser.h
+++ b/google/cloud/spanner/row_parser.h
@@ -124,11 +124,9 @@ class RowParser {
       // equal:
       //   1. When iterator::parser_ is nullptr_
       //   2. When iterator::parser_::value_source_ is nullptr_
-      if (!a.parser_ && b.parser_) return !b.parser_->value_source_;
-      if (a.parser_ && !b.parser_) return !a.parser_->value_source_;
-      if (a.parser_ && b.parser_)
-        return !a.parser_->value_source_ == !b.parser_->value_source_;
-      return true;  // both end with parser_ == nullptr
+      bool const a_is_end = !a.parser_ || !a.parser_->value_source_;
+      bool const b_is_end = !b.parser_ || !b.parser_->value_source_;
+      return a_is_end == b_is_end;
     }
     friend bool operator!=(iterator const& a, iterator const& b) {
       return !(a == b);

--- a/google/cloud/spanner/row_parser_test.cc
+++ b/google/cloud/spanner/row_parser_test.cc
@@ -111,6 +111,12 @@ TEST(RowParser, SuccessMovedRowParser) {
   EXPECT_NE(it2, end2);
   row = *it2;
   EXPECT_TRUE(row.ok());
+  EXPECT_EQ(1, row->get<0>());
+
+  ++it2;
+  EXPECT_NE(it2, end2);
+  row = *it2;
+  EXPECT_TRUE(row.ok());
   EXPECT_EQ(2, row->get<0>());
 
   ++it2;

--- a/google/cloud/spanner/row_parser_test.cc
+++ b/google/cloud/spanner/row_parser_test.cc
@@ -38,6 +38,26 @@ RowParser<Ts...> MakeRowParser(std::vector<Value> const& v) {
   return RowParser<Ts...>(MakeValueSource(v));
 }
 
+TEST(RowParser, IteratorEquality) {
+  // Empty range of values.
+  std::vector<Value> values = {};
+  auto rp = MakeRowParser<std::int64_t>(values);
+  auto it = rp.begin();
+  EXPECT_EQ(it, it);
+  auto end = rp.end();
+  EXPECT_EQ(end, end);
+  EXPECT_EQ(it, end);
+
+  // Non-empty range of values.
+  values = {Value(0), Value(1), Value(2)};
+  rp = MakeRowParser<std::int64_t>(values);
+  it = rp.begin();
+  EXPECT_EQ(it, it);
+  end = rp.end();
+  EXPECT_EQ(end, end);
+  EXPECT_NE(it, end);
+}
+
 TEST(RowParser, SuccessEmpty) {
   std::vector<Value> const values = {};
   auto rp = MakeRowParser<std::int64_t>(values);

--- a/google/cloud/spanner/row_parser_test.cc
+++ b/google/cloud/spanner/row_parser_test.cc
@@ -99,7 +99,7 @@ TEST(RowParser, SuccessMovedRowParser) {
   EXPECT_NE(it1, end1);
   row = *it1;
   EXPECT_TRUE(row.ok());
-  EXPECT_EQ(1, row->get<0>());
+  EXPECT_EQ(1, row->get<0>());  // <-- Line (A)
 
   // Now we move the RowParser to a new object, and continue the iteration.
   // We should resume consuming where the first RowParser left off.
@@ -110,7 +110,7 @@ TEST(RowParser, SuccessMovedRowParser) {
   EXPECT_NE(it2, end2);
   row = *it2;
   EXPECT_TRUE(row.ok());
-  EXPECT_EQ(1, row->get<0>());
+  EXPECT_EQ(1, row->get<0>());  // Same value as line (A) since op++ not called
 
   ++it2;
   EXPECT_NE(it2, end2);

--- a/google/cloud/spanner/row_parser_test.cc
+++ b/google/cloud/spanner/row_parser_test.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/spanner/row_parser.h"
 #include "google/cloud/spanner/value.h"
 #include <gmock/gmock.h>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -36,7 +35,7 @@ ValueSource MakeValueSource(std::vector<Value> const& v) {
 
 template <typename... Ts>
 RowParser<Ts...> MakeRowParser(std::vector<Value> const& v) {
-  return RowParser<Ts...>(std::make_shared<ValueSource>(MakeValueSource(v)));
+  return RowParser<Ts...>(MakeValueSource(v));
 }
 
 TEST(RowParser, SuccessEmpty) {


### PR DESCRIPTION
This PR makes several changes to `RowParser` to simplify its implementation (a bit) and to give it more natural semantics in the face of copies and moves. The changes are as follows.

1. The "advancing" logic was pulled out of `iterator::operator++` and moved into `RowParser::Advance` (private). This allows the single stored `curr_` row (the one returned when dereferencing the iterator) to be stored in the RowParser class rather than in the iterator itself. This means that the act of *moving* a `RowParser` does not also consume the next Row from the stream. This is the reason for the change in `row_parser_test.cc`, and if you look at the behavior before and after this change, I think you'll agree that the new behavior is preferable.

2. Fewer copies of the `value_source_` std::function. Now the only place this function lives is in the `RowParser`. The `iterator::operator++()` method uses it by calling the `RowParser->Advance()` method. This change means that we no longer *need* the value_source_ to be shared between the parser and the iterator.

3. The `ValueSource` is no longer required to be wrapped in a `std::shared_ptr`. The `RowParser` class has no need to require the sharing of the value_source (see point 2 above), so it makes sense to stop requiring this. Note that callers (i.e., `ResultSet`) may still *choose* to pass in a `std::function` that happens to have its own `std::shared_ptr` state captured, but that's totally up to the caller. They can do that or not do it -- `RowParser` works fine either way.

Much thanks to @devbww for the consultation, design advice, code reviews, and excellent suggestions on this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/236)
<!-- Reviewable:end -->
