### PR TITLE
cleanup: Enforce formatting on all Bazel files.

### DIFF
--- a/bazel/googleapis.BUILD
+++ b/bazel/googleapis.BUILD
@@ -99,7 +99,7 @@ cc_library(
     ],
     deps = [
         "@com_github_grpc_grpc//:grpc++",
-        "//google/rpc:status_cc_proto"
+        "//google/rpc:status_cc_proto",
     ],
 )
 
@@ -124,7 +124,7 @@ cc_grpc_library(
     well_known_protos = True,
     deps = [
         ":bigtableadmin_cc_proto",
-        "//google/longrunning:longrunning_cc_grpc"
+        "//google/longrunning:longrunning_cc_grpc",
     ],
 )
 
@@ -150,6 +150,6 @@ cc_library(
         ":bigtable_cc_proto",
         ":bigtableadmin_cc_grpc",
         ":bigtableadmin_cc_proto",
-        "//google/rpc:error_details_cc_proto"
+        "//google/rpc:error_details_cc_proto",
     ],
 )

--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -94,7 +94,8 @@ find google/cloud \( -name '*.cc' -o -name '*.h' \) -print0 |
 # Apply buildifier to fix the BUILD and .bzl formatting rules.
 #    https://github.com/bazelbuild/buildtools/tree/master/buildifier
 find . \( "${ignore[@]}" \) -prune -o \
-       \( -name BUILD -o -name '*.bzl' \) \
+       \( -name WORKSPACE -o -name BUILD \
+          -o -name '*.BUILD' -o -name '*.bzl' \) \
        -print0 |
   xargs -0 buildifier -mode=fix
 

--- a/ci/test-install/WORKSPACE
+++ b/ci/test-install/WORKSPACE
@@ -46,6 +46,7 @@ switched_rules_by_language(
 )
 
 load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+
 google_cloud_cpp_deps()
 
 # Have to manually call the corresponding function for gRPC:


### PR DESCRIPTION
We were missing WORKSPACE files and a couple other files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/241)
<!-- Reviewable:end -->
