### PR TITLE
fix: RowParser now behaves better and only consumes a Value when it must

### DIFF
--- a/google/cloud/spanner/row_parser.h
+++ b/google/cloud/spanner/row_parser.h
@@ -127,6 +127,7 @@ class RowParser {
    private:
     friend RowParser;
     explicit iterator(RowParser* p) : parser_(p) {
+      /* if (parser_) parser_->Advance(); */
       if (parser_ && !parser_->curr_) parser_->Advance();
     }
 

--- a/google/cloud/spanner/row_parser.h
+++ b/google/cloud/spanner/row_parser.h
@@ -127,7 +127,6 @@ class RowParser {
    private:
     friend RowParser;
     explicit iterator(RowParser* p) : parser_(p) {
-      /* if (parser_) parser_->Advance(); */
       if (parser_ && !parser_->curr_) parser_->Advance();
     }
 


### PR DESCRIPTION
These changes make it so RowParser never consumes a value on construction nor move nor copy. Only its iterators consume a value and only when they must: on first construction, and `op++`. I believe this provides the safest and least surprising semantics. For example:

```cc
auto rp1 = result_set.Rows<A, B, C>();
auto rp2 = result_set.Rows<A, B, C>();  // OK: no values consumed
auto rp3 = rp2;  // OK; no values consumed.

auto it = rp3.begin();  // 1st value consumed
assert(it == rp3.begin());  // No additional values consumed

assert(it != rp3.end());  // No values consumed
auto x = *it;  // No values consumed
assert(x == *it);

++it;  // 2nd value consumed
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/248)
<!-- Reviewable:end -->
