### PR TITLE
bug: Add CMAKE_PREFIX_PATH to external/curl.cmake

### DIFF
--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -49,6 +49,7 @@ if (NOT TARGET curl-project)
                    -DHTTP_ONLY=ON
                    -DCMAKE_ENABLE_OPENSSL=ON
                    -DENABLE_ARES=ON
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}
                    -DCMAKE_INSTALL_PATH=${GOOGLE_CLOUD_CPP_INSTALL_PATH}
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/cmake/external/curl.cmake
+++ b/cmake/external/curl.cmake
@@ -49,7 +49,7 @@ if (NOT TARGET curl-project)
                    -DHTTP_ONLY=ON
                    -DCMAKE_ENABLE_OPENSSL=ON
                    -DENABLE_ARES=ON
-                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}
+                   -DCMAKE_PREFIX_PATH=${GOOGLE_CLOUD_CPP_PREFIX_PATH}
                    -DCMAKE_INSTALL_PATH=${GOOGLE_CLOUD_CPP_INSTALL_PATH}
                    -DCMAKE_INSTALL_RPATH=${GOOGLE_CLOUD_CPP_INSTALL_RPATH}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-cpp-spanner/issues/249

This took me way longer to notice than I would like to admit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/250)
<!-- Reviewable:end -->
