### PR TITLE
feat: give SqlPartition equality support

### DIFF
--- a/google/cloud/spanner/sql_partition.cc
+++ b/google/cloud/spanner/sql_partition.cc
@@ -29,6 +29,13 @@ SqlPartition::SqlPartition(std::string transaction_id, std::string session_id,
       partition_token_(std::move(partition_token)),
       sql_statement_(std::move(sql_statement)) {}
 
+bool operator==(SqlPartition const& a, SqlPartition const& b) {
+  return a.transaction_id_ == b.transaction_id_ &&
+         a.session_id_ == b.session_id_ &&
+         a.partition_token_ == b.partition_token_ &&
+         a.sql_statement_ == b.sql_statement_;
+}
+
 StatusOr<std::string> SerializeSqlPartition(SqlPartition const& sql_partition) {
   google::spanner::v1::ExecuteSqlRequest proto;
   proto.set_partition_token(sql_partition.partition_token());

--- a/google/cloud/spanner/sql_partition.h
+++ b/google/cloud/spanner/sql_partition.h
@@ -26,6 +26,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 class SqlPartition;
+
 /**
  * Serializes an instance of `SqlPartition` for transmission to another process.
  *
@@ -77,8 +78,8 @@ SqlPartition MakeSqlPartition(std::string const& transaction_id,
 }  // namespace internal
 
 /**
- * The `SqlPartition` class is a semi-regular type that represents a single
- * slice of a parallel SQL read.
+ * The `SqlPartition` class is a regular type that represents a single slice of
+ * a parallel SQL read.
  *
  * Instances of `SqlPartition` are created by `Client::PartitionSql`. Once
  * created, `SqlPartition` objects can be serialized, transmitted to separate
@@ -92,16 +93,26 @@ class SqlPartition {
    */
   SqlPartition() = default;
 
-  // Copy and move.
+  /// @name Copy and move
+  ///@{
   SqlPartition(SqlPartition const&) = default;
   SqlPartition(SqlPartition&&) = default;
   SqlPartition& operator=(SqlPartition const&) = default;
   SqlPartition& operator=(SqlPartition&&) = default;
+  ///@}
 
   /**
    * Accessor for the `SqlStatement` associated with this `SqlPartition`.
    */
   SqlStatement const& sql_statement() const { return sql_statement_; }
+
+  /// @name Equality
+  ///@{
+  friend bool operator==(SqlPartition const& a, SqlPartition const& b);
+  friend bool operator!=(SqlPartition const& a, SqlPartition const& b) {
+    return !(a == b);
+  }
+  ///@}
 
  private:
   friend class SqlPartitionTester;

--- a/google/cloud/spanner/sql_partition_test.cc
+++ b/google/cloud/spanner/sql_partition_test.cc
@@ -73,6 +73,29 @@ TEST(SqlPartitionTest, Constructor) {
   EXPECT_EQ(session_id, actual_partition.SessionId());
 }
 
+TEST(SqlPartitionTester, RegularSemantics) {
+  std::string stmt("select * from foo where name = @name");
+  SqlStatement::ParamType params = {{"name", Value("Bob")}};
+  std::string partition_token("token");
+  std::string session_id("session");
+  std::string transaction_id("foo");
+
+  SqlPartition sql_partition = internal::MakeSqlPartition(
+      transaction_id, session_id, partition_token, SqlStatement(stmt, params));
+
+  EXPECT_NE(sql_partition, SqlPartition());
+
+  SqlPartition copy = sql_partition;
+  EXPECT_EQ(copy, sql_partition);
+
+  SqlPartition assign;
+  assign = copy;
+  EXPECT_EQ(assign, copy);
+
+  SqlPartition moved = std::move(copy);
+  EXPECT_EQ(moved, assign);
+}
+
 TEST(SqlPartitionTest, SerializeDeserialize) {
   SqlPartitionTester expected_partition(internal::MakeSqlPartition(
       "foo", "session", "token",


### PR DESCRIPTION
Since @tmatsuo added equality to `SqlStatement` in #216, we can now make
`SqlPartition` a regular type with equality support. Also adds unit test
for this functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/252)
<!-- Reviewable:end -->
