### PR TITLE
feat: Add `internal::Base64Encode()` and `internal::Base64Decode()`

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(spanner_client
             database_admin_client.cc
             database_admin_client.h
             date.h
+            internal/base64.cc
+            internal/base64.h
             internal/database_admin_retry.cc
             internal/database_admin_retry.h
             internal/database_admin_stub.cc
@@ -106,6 +108,7 @@ function (spanner_client_define_tests)
         client_options_test.cc
         database_admin_client_test.cc
         date_test.cc
+        internal/base64_test.cc
         internal/date_test.cc
         internal/polling_loop_test.cc
         internal/retry_loop_test.cc

--- a/google/cloud/spanner/internal/base64.cc
+++ b/google/cloud/spanner/internal/base64.cc
@@ -1,0 +1,129 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/internal/base64.h"
+#include <climits>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+namespace {
+
+constexpr char kPadding = '=';
+
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+constexpr char kIndexToChar[64 + 1] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789"
+    "+/";
+
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+constexpr unsigned char kCharToIndexExcessOne[UCHAR_MAX + 1] = {
+    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+    0,  0,  0,  0,  0,  0,  0,  63, 0,  0,  0,  64, 53, 54, 55, 56, 57, 58,
+    59, 60, 61, 62, 0,  0,  0,  0,  0,  0,  0,  1,  2,  3,  4,  5,  6,  7,
+    8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+    26, 0,  0,  0,  0,  0,  0,  27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+    38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52,
+};
+
+}  // namespace
+
+// NOTE: If `UCHAR_MAX` > 255 we have no way to indicate that a `bytes[i]`
+// value is not representable in 8-bits, and that is why we may be better
+// off using `std::vector<std::uint8_t> const& bytes` for binary blobs.
+// For now, we let the extra bits fall where they may.
+std::string Base64Encode(std::string const& bytes) {
+  std::string encoded;
+  auto* p = reinterpret_cast<unsigned char const*>(bytes.data());
+  auto* const ep = p + bytes.size();
+  encoded.reserve((ep - p + 2) / 3 * 4);  // 3 octets to 4 sextets
+  while (ep - p >= 3) {
+    unsigned int const v = p[0] << 16 | p[1] << 8 | p[2];
+    encoded.push_back(kIndexToChar[v >> 18]);
+    encoded.push_back(kIndexToChar[v >> 12 & 0x3f]);
+    encoded.push_back(kIndexToChar[v >> 6 & 0x3f]);
+    encoded.push_back(kIndexToChar[v & 0x3f]);
+    p += 3;
+  }
+  switch (ep - p) {
+    case 2: {
+      unsigned int const v = p[0] << 16 | p[1] << 8;
+      encoded.push_back(kIndexToChar[v >> 18]);
+      encoded.push_back(kIndexToChar[v >> 12 & 0x3f]);
+      encoded.push_back(kIndexToChar[v >> 6 & 0x3f]);
+      encoded.push_back(kPadding);
+      break;
+    }
+    case 1: {
+      unsigned int const v = p[0] << 16;
+      encoded.push_back(kIndexToChar[v >> 18]);
+      encoded.push_back(kIndexToChar[v >> 12 & 0x3f]);
+      encoded.append(2, kPadding);
+      break;
+    }
+  }
+  return encoded;
+}
+
+StatusOr<std::string> Base64Decode(std::string const& base64) {
+  std::string decoded;
+  auto* p = reinterpret_cast<unsigned char const*>(base64.data());
+  auto* ep = p + base64.size();
+  decoded.reserve((ep - p + 3) / 4 * 3);  // 4 sextets to 3 octets
+  while (ep - p >= 4) {
+    auto i0 = kCharToIndexExcessOne[p[0]];
+    auto i1 = kCharToIndexExcessOne[p[1]];
+    if (--i0 >= 64 || --i1 >= 64) break;
+    if (p[3] == kPadding) {
+      if (p[2] == kPadding) {
+        if ((i1 & 0xf) != 0) break;
+        decoded.push_back(i0 << 2 | i1 >> 4);
+      } else {
+        auto i2 = kCharToIndexExcessOne[p[2]];
+        if (--i2 >= 64 || (i2 & 0x3) != 0) break;
+        decoded.push_back(i0 << 2 | i1 >> 4);
+        decoded.push_back(i1 << 4 | i2 >> 2);
+      }
+      p += 4;
+      break;
+    }
+    auto i2 = kCharToIndexExcessOne[p[2]];
+    auto i3 = kCharToIndexExcessOne[p[3]];
+    if (--i2 >= 64 || --i3 >= 64) break;
+    decoded.push_back(i0 << 2 | i1 >> 4);
+    decoded.push_back(i1 << 4 | i2 >> 2);
+    decoded.push_back(i2 << 6 | i3);
+    p += 4;
+  }
+  if (p != ep) {
+    auto const offset = reinterpret_cast<char const*>(p) - base64.data();
+    auto const bad_chunk = base64.substr(offset, 4);
+    auto message = "Invalid base64 chunk \"" + bad_chunk + "\"" +
+                   " at offset " + std::to_string(offset);
+    return Status(StatusCode::kInvalidArgument, std::move(message));
+  }
+  return decoded;
+}
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/internal/base64.h
+++ b/google/cloud/spanner/internal/base64.h
@@ -1,0 +1,53 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_BASE64_H_
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_BASE64_H_
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/status_or.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+
+/**
+ * Convert binary data `bytes` to a base64-encoded, US-ASCII string.
+ *
+ * The base64 alphabet is "A-Za-z+/", with "=" padding characters.
+ *
+ * @see https://tools.ietf.org/html/rfc4648#section-4
+ * @see `Base64Decode()`
+ */
+std::string Base64Encode(std::string const& bytes);
+
+/**
+ * Convert a base64-encoded, US-ASCII string to binary data.
+ *
+ * @return an error `Status` if the input string is unparsable.
+ *
+ * @see `Base64Encode()`
+ */
+StatusOr<std::string> Base64Decode(std::string const& base64);
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_INTERNAL_BASE64_H_

--- a/google/cloud/spanner/internal/base64_test.cc
+++ b/google/cloud/spanner/internal/base64_test.cc
@@ -1,0 +1,219 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/internal/base64.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include <gmock/gmock.h>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(Base64, RoundTrip) {
+  char c = std::numeric_limits<char>::min();
+  std::string chars(1, c);
+  while (c != std::numeric_limits<char>::max()) {
+    chars.push_back(++c);
+  }
+
+  // Empty string.
+  std::string bytes;
+  auto const encoded = internal::Base64Encode(bytes);
+  EXPECT_EQ(0, encoded.size());
+  auto const decoded = internal::Base64Decode(encoded);
+  EXPECT_STATUS_OK(decoded) << encoded;
+  if (decoded) {
+    EXPECT_EQ(bytes, *decoded);
+  }
+
+  // All 1-char strings.
+  bytes.resize(1);
+  for (auto c : chars) {
+    bytes[0] = c;
+    auto const encoded = internal::Base64Encode(bytes);
+    EXPECT_EQ(4, encoded.size()) << bytes;
+    auto const decoded = internal::Base64Decode(encoded);
+    EXPECT_STATUS_OK(decoded) << encoded;
+    if (decoded) {
+      EXPECT_EQ(bytes, *decoded) << encoded;
+    }
+  }
+
+  // All 2-char strings.
+  bytes.resize(2);
+  for (auto c0 : chars) {
+    bytes[0] = c0;
+    for (auto c1 : chars) {
+      bytes[1] = c1;
+      auto const encoded = internal::Base64Encode(bytes);
+      EXPECT_EQ(4, encoded.size()) << bytes;
+      auto const decoded = internal::Base64Decode(encoded);
+      EXPECT_STATUS_OK(decoded) << encoded;
+      if (decoded) {
+        EXPECT_EQ(bytes, *decoded) << encoded;
+      }
+    }
+  }
+
+  // Some 3-char strings.
+  bytes.resize(3);
+  for (auto c0 : {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'}) {
+    bytes[0] = c0;
+    for (auto c1 : chars) {
+      bytes[1] = c1;
+      for (auto c2 : chars) {
+        bytes[2] = c2;
+        auto const encoded = internal::Base64Encode(bytes);
+        EXPECT_EQ(4, encoded.size()) << bytes;
+        auto const decoded = internal::Base64Decode(encoded);
+        EXPECT_STATUS_OK(decoded) << encoded;
+        if (decoded) {
+          EXPECT_EQ(bytes, *decoded) << encoded;
+        }
+      }
+    }
+  }
+}
+
+TEST(Base64, LongerRoundTrip) {
+  std::vector<std::pair<std::string, std::string>> test_cases = {
+      {"abcd", "YWJjZA=="},
+      {"abcde", "YWJjZGU="},
+      {"abcdef", "YWJjZGVm"},
+      {"abcdefg", "YWJjZGVmZw=="},
+      {"abcdefgh", "YWJjZGVmZ2g="},
+      {"abcdefghi", "YWJjZGVmZ2hp"},
+      {"abcdefghij", "YWJjZGVmZ2hpag=="},
+      {"abcdefghijk", "YWJjZGVmZ2hpams="},
+      {"abcdefghijkl", "YWJjZGVmZ2hpamts"},
+      {"abcdefghijklm", "YWJjZGVmZ2hpamtsbQ=="},
+      {"abcdefghijklmn", "YWJjZGVmZ2hpamtsbW4="},
+      {"abcdefghijklmno", "YWJjZGVmZ2hpamtsbW5v"},
+      {"abcdefghijklmnop", "YWJjZGVmZ2hpamtsbW5vcA=="},
+      {"abcdefghijklmnopq", "YWJjZGVmZ2hpamtsbW5vcHE="},
+      {"abcdefghijklmnopqr", "YWJjZGVmZ2hpamtsbW5vcHFy"},
+      {"abcdefghijklmnopqrs", "YWJjZGVmZ2hpamtsbW5vcHFycw=="},
+      {"abcdefghijklmnopqrst", "YWJjZGVmZ2hpamtsbW5vcHFyc3Q="},
+      {"abcdefghijklmnopqrstu", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1"},
+      {"abcdefghijklmnopqrstuv", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dg=="},
+      {"abcdefghijklmnopqrstuvw", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnc="},
+      {"abcdefghijklmnopqrstuvwx", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4"},
+      {"abcdefghijklmnopqrstuvwxy", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eQ=="},
+      {"abcdefghijklmnopqrstuvwxyz", "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo="},
+  };
+  for (auto const& test_case : test_cases) {
+    EXPECT_EQ(test_case.second, internal::Base64Encode(test_case.first));
+    auto const decoded = internal::Base64Decode(test_case.second);
+    EXPECT_STATUS_OK(decoded) << test_case.second;
+    if (decoded) {
+      EXPECT_EQ(test_case.first, *decoded);
+    }
+  }
+}
+
+TEST(Base64, RFC4648TestVectors) {
+  // https://tools.ietf.org/html/rfc4648#section-10
+  std::vector<std::pair<std::string, std::string>> test_cases = {
+      {"", ""},
+      {"f", "Zg=="},
+      {"fo", "Zm8="},
+      {"foo", "Zm9v"},
+      {"foob", "Zm9vYg=="},
+      {"fooba", "Zm9vYmE="},
+      {"foobar", "Zm9vYmFy"},
+  };
+  for (auto const& test_case : test_cases) {
+    EXPECT_EQ(test_case.second, internal::Base64Encode(test_case.first));
+    auto const decoded = internal::Base64Decode(test_case.second);
+    EXPECT_STATUS_OK(decoded) << test_case.second;
+    if (decoded) {
+      EXPECT_EQ(test_case.first, *decoded);
+    }
+  }
+}
+
+TEST(Base64, WikiExample) {
+  // https://en.wikipedia.org/wiki/Base64#Examples
+  std::string const plain =
+      "Man is distinguished, not only by his reason, but by this singular "
+      "passion from other animals, which is a lust of the mind, that by a "
+      "perseverance of delight in the continued and indefatigable generation "
+      "of knowledge, exceeds the short vehemence of any carnal pleasure.";
+  std::string const coded =
+      "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0"
+      "aGlzIHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1"
+      "c3Qgb2YgdGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0"
+      "aGUgY29udGludWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdl"
+      "LCBleGNlZWRzIHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4"
+      "=";
+  EXPECT_EQ(coded, internal::Base64Encode(plain));
+  auto const decoded = internal::Base64Decode(coded);
+  EXPECT_STATUS_OK(decoded) << coded;
+  if (decoded) {
+    EXPECT_EQ(plain, *decoded);
+  }
+}
+
+TEST(Base64, DecodeFailures) {
+  // Bad lengths.
+  for (std::string const base64 : {"x", "xx", "xxx"}) {
+    auto decoded = internal::Base64Decode(base64);
+    EXPECT_FALSE(decoded.ok());
+    if (!decoded) {
+      EXPECT_THAT(decoded.status().message(), HasSubstr("Invalid base64"));
+      EXPECT_THAT(decoded.status().message(), HasSubstr("at offset 0"));
+    }
+  }
+  for (std::string const base64 : {"xxxxx", "xxxxxx", "xxxxxxx"}) {
+    auto decoded = internal::Base64Decode(base64);
+    EXPECT_FALSE(decoded.ok());
+    if (!decoded) {
+      EXPECT_THAT(decoded.status().message(), HasSubstr("Invalid base64"));
+      EXPECT_THAT(decoded.status().message(), HasSubstr("at offset 4"));
+    }
+  }
+
+  // Chars outside base64 alphabet.
+  for (std::string const base64 : {".xxx", "x.xx", "xx.x", "xxx.", "xx.="}) {
+    auto decoded = internal::Base64Decode(base64);
+    EXPECT_FALSE(decoded.ok());
+    if (!decoded) {
+      EXPECT_THAT(decoded.status().message(), HasSubstr("Invalid base64"));
+      EXPECT_THAT(decoded.status().message(), HasSubstr("at offset 0"));
+    }
+  }
+
+  // Non-zero padding bits.
+  for (std::string const base64 : {"xx==", "xxx="}) {
+    auto decoded = internal::Base64Decode(base64);
+    EXPECT_FALSE(decoded.ok());
+    if (!decoded) {
+      EXPECT_THAT(decoded.status().message(), HasSubstr("Invalid base64"));
+      EXPECT_THAT(decoded.status().message(), HasSubstr("at offset 0"));
+    }
+  }
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -21,6 +21,7 @@ spanner_client_hdrs = [
     "client_options.h",
     "database_admin_client.h",
     "date.h",
+    "internal/base64.h",
     "internal/database_admin_retry.h",
     "internal/database_admin_stub.h",
     "internal/date.h",
@@ -49,6 +50,7 @@ spanner_client_hdrs = [
 spanner_client_srcs = [
     "client_options.cc",
     "database_admin_client.cc",
+    "internal/base64.cc",
     "internal/database_admin_retry.cc",
     "internal/database_admin_stub.cc",
     "internal/date.cc",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -20,6 +20,7 @@ spanner_client_unit_tests = [
     "client_options_test.cc",
     "database_admin_client_test.cc",
     "date_test.cc",
+    "internal/base64_test.cc",
     "internal/date_test.cc",
     "internal/polling_loop_test.cc",
     "internal/retry_loop_test.cc",


### PR DESCRIPTION
Encoding and decoding of base64 strings to support the `BYTES` type.

Fixes #123.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/255)
<!-- Reviewable:end -->
