### PR TITLE
Revert "Add support to generate compile_commands.json file (#253)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@ _build/
 build-output/
 cmake-out/
 
-# Ignores top-level compile_commands.json files/links
-compile_commands.json
-
 # Common bazel output directories
 bazel-*
 !bazel-dependency*.cfg

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -45,11 +45,9 @@ echo "Compiling on $(date)"
 echo "================================================================"
 cd "${PROJECT_ROOT}"
 cmake_flags=()
-
 if [[ "${CLANG_TIDY:-}" = "yes" ]]; then
   cmake_flags+=("-DGOOGLE_CLOUD_CPP_CLANG_TIDY=yes")
 fi
-
 if [[ "${GOOGLE_CLOUD_CPP_CXX_STANDARD:-}" != "" ]]; then
   cmake_flags+=(
     "-DGOOGLE_CLOUD_CPP_CXX_STANDARD=${GOOGLE_CLOUD_CPP_CXX_STANDARD}")
@@ -58,10 +56,6 @@ fi
 if [[ "${CODE_COVERAGE:-}" == "yes" ]]; then
   cmake_flags+=(
     "-DCMAKE_BUILD_TYPE=Coverage")
-fi
-
-if [[ "${GENERATE_COMPILE_COMMANDS:-}" == "yes" ]]; then
-  cmake_flags+=( "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON" )
 fi
 
 cmake "-DCMAKE_INSTALL_PREFIX=$HOME/staging" \
@@ -109,13 +103,6 @@ if [[ "${TEST_INSTALL:-}" = "yes" ]]; then
     echo "Running the test install $(date)"
     echo "================================================================"
     cmake --build "${BINARY_DIR}" --target install || echo "FAILED"
-fi
-
-if [[ "${GENERATE_COMPILE_COMMANDS:-}" == "yes" ]]; then
-    echo "================================================================"
-    echo "Fixing paths in compile_commands.json $(date)"
-    echo "================================================================"
-    sed -i -e "s,/v\>,${OLD_PWD},g" "${BINARY_DIR}/compile_commands.json"
 fi
 
 echo "================================================================"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -85,7 +85,6 @@ elif [[ "${BUILD_NAME}" = "msan" ]]; then
 elif [[ "${BUILD_NAME}" = "cmake" ]]; then
   export DISTRO=fedora-install
   export DISTRO_VERSION=30
-  export GENERATE_COMPILE_COMMANDS=yes
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "cmake-super" ]]; then
   export CMAKE_SOURCE_DIR="ci/super"
@@ -218,17 +217,6 @@ docker_flags=(
     # invalid links to functions or types). Currently only the CMake builds use
     # this flag.
     "--env" "GENERATE_DOCS=${GENERATE_DOCS:-}"
-
-    # If set to 'yes', the build will output a "compile_commands.json" file in
-    # the build's output directory. This file is used by some external tools,
-    # such as clangd. Currently, only cmake knows how to generate this file.
-    "--env" "GENERATE_COMPILE_COMMANDS=${GENERATE_COMPILE_COMMANDS:-}"
-
-    # When a compile_commands.json file is generated inside a docker image, it
-    # will contain include paths that are relative to "/v". This will not work
-    # when used outside of docker. So there's a post-processing step that will
-    # replace those paths with ${OLD_PWD}.
-    "--env" "OLD_PWD=${PWD}"
 
     # If set, execute tests to verify `make install` works and produces working
     # installations.


### PR DESCRIPTION
This reverts commit 6131abb4618d00ce88a97804380602d0ff2a816e.

I'm reverting this because the `compile_commands.json` file produced by cmake in the docker image doesn't contain the needed paths to the deps because in the docker image most deps are found in standard places like /usr/local, etc, so the needed `-I ...` flags are not included in the compile commands.

We should be able to get bazel to generate a more complete compile_commands.json file for us since it sees all of our deps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/256)
<!-- Reviewable:end -->
