### PR TITLE
Silence shellcheck warning.

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -58,6 +58,9 @@ if [[ "${CODE_COVERAGE:-}" == "yes" ]]; then
     "-DCMAKE_BUILD_TYPE=Coverage")
 fi
 
+# We disable the shellcheck warning because we want ${CMAKE_FLAGS} to expand as
+# separate arguments.
+# shellcheck disable=SC2086
 cmake "-DCMAKE_INSTALL_PREFIX=$HOME/staging" \
       ${CMAKE_FLAGS:-} \
       "-H${SOURCE_DIR}" "-B${BINARY_DIR}" "${cmake_flags[@]}"


### PR DESCRIPTION
We want the `CMAKE_FLAGS` variable to expand as separate arguments, so
we disable the shellcheck warning on that line. This is copying the [same
technique done in google-cloud-cpp](https://github.com/googleapis/google-cloud-cpp/blob/master/ci/kokoro/docker/build-in-docker-cmake.sh#L76).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/259)
<!-- Reviewable:end -->
