### PR TITLE
Fix some compile warnings with clang 3.8

### DIFF
--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -269,9 +269,9 @@ namespace internal {
 // this will promote it to type std::int64_t. Similarly, a C++ string literal
 // will be "promoted" to type std::string.
 template <typename T>
-constexpr T PromoteLiteralImpl(T);
-constexpr std::string PromoteLiteralImpl(char const*);
-constexpr std::int64_t PromoteLiteralImpl(int);
+T PromoteLiteralImpl(T);
+std::string PromoteLiteralImpl(char const*);
+std::int64_t PromoteLiteralImpl(int);
 template <typename T>
 using PromoteLiteral = decltype(PromoteLiteralImpl(std::declval<T>()));
 

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -220,7 +220,9 @@ TEST(Row, ParseRowEmpty) {
 }
 
 TEST(Row, ParseRowOneValue) {
-  std::array<Value, 1> const array = {Value(42)};
+  // The extra braces are working around an old clang bug that was fixed in 6.0
+  // https://bugs.llvm.org/show_bug.cgi?id=21629
+  std::array<Value, 1> const array = {{Value(42)}};
   auto const row = ParseRow<std::int64_t>(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(42), *row);
@@ -231,7 +233,9 @@ TEST(Row, ParseRowOneValue) {
 }
 
 TEST(Row, ParseRowThree) {
-  std::array<Value, 3> array = {Value(true), Value(42), Value("hello")};
+  // The extra braces are working around an old clang bug that was fixed in 6.0
+  // https://bugs.llvm.org/show_bug.cgi?id=21629
+  std::array<Value, 3> array = {{Value(true), Value(42), Value("hello")}};
   auto row = ParseRow<bool, std::int64_t, std::string>(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(true, 42, "hello"), *row);


### PR DESCRIPTION
The fixes don't actually change any behavior, and the previous code was
also correct. However, clang 3.8 incorrectly warned about some valid
constructs. But since we have a CI build for clang 3.8, it would be good
to not produce the warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/260)
<!-- Reviewable:end -->
