### PR TITLE
cleanup: Refactor RandomDatabaseName() function.

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -112,9 +112,12 @@ function (spanner_client_define_tests)
 
     find_package(google_cloud_cpp_testing CONFIG REQUIRED)
 
-    add_library(spanner_client_testing testing/matchers.h)
+    add_library(spanner_client_testing testing/matchers.h
+                                       testing/random_database_name.cc
+                                       testing/random_database_name.h)
     target_link_libraries(spanner_client_testing
                           PUBLIC googleapis-c++::spanner_client
+                                 google_cloud_cpp_testing
                                  GTest::gmock_main
                                  GTest::gmock
                                  GTest::gtest)

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -24,6 +24,7 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
     tags = ["integration-tests"],
     deps = [
         "//google/cloud/spanner:spanner_client",
+        "//google/cloud/spanner:spanner_client_testing",
         "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -49,6 +49,7 @@ function (spanner_client_define_integration_tests)
         add_executable(${target} ${fname})
         target_link_libraries(${target}
                               PRIVATE googleapis-c++::spanner_client
+                                      spanner_client_testing
                                       google_cloud_cpp_testing
                                       GTest::gmock_main
                                       GTest::gmock

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
@@ -26,20 +27,6 @@ namespace {
 
 using ::testing::EndsWith;
 
-std::string RandomDatabaseName(
-    google::cloud::internal::DefaultPRNG& generator) {
-  // A database ID must be between 2 and 30 characters, fitting the regular
-  // expression `[a-z][a-z0-9_\-]*[a-z0-9]`
-  int max_size = 30;
-  std::string const prefix = "db-";
-  auto size = static_cast<int>(max_size - 1 - prefix.size());
-  return prefix +
-         google::cloud::internal::Sample(
-             generator, size, "abcdefghijlkmnopqrstuvwxyz012345689_-") +
-         google::cloud::internal::Sample(generator, 1,
-                                         "abcdefghijlkmnopqrstuvwxyz");
-}
-
 /// @test Verify the basic CRUD operations for databases work.
 TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
   auto project_id =
@@ -51,7 +38,7 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
   ASSERT_FALSE(instance_id.empty());
 
   auto generator = google::cloud::internal::MakeDefaultPRNG();
-  std::string database_id = RandomDatabaseName(generator);
+  std::string database_id = spanner_testing::RandomDatabaseName(generator);
 
   DatabaseAdminClient client;
   auto database_future =

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -18,7 +18,9 @@
 
 spanner_client_testing_hdrs = [
     "testing/matchers.h",
+    "testing/random_database_name.h",
 ]
 
 spanner_client_testing_srcs = [
+    "testing/random_database_name.cc",
 ]

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -18,7 +18,6 @@ namespace google {
 namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
-
 std::string RandomDatabaseName(
     google::cloud::internal::DefaultPRNG& generator) {
   // A database ID must be between 2 and 30 characters, fitting the regular
@@ -29,8 +28,8 @@ std::string RandomDatabaseName(
   return prefix +
          google::cloud::internal::Sample(
              generator, size, "abcdefghijlkmnopqrstuvwxyz012345689_-") +
-         google::cloud::internal::Sample(generator, 1,
-                                         "abcdefghijlkmnopqrstuvwxyz");
+         google::cloud::internal::Sample(
+             generator, 1, "abcdefghijlkmnopqrstuvwxyz01234567890");
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -29,7 +29,7 @@ std::string RandomDatabaseName(
          google::cloud::internal::Sample(
              generator, size, "abcdefghijlkmnopqrstuvwxyz012345689_-") +
          google::cloud::internal::Sample(
-             generator, 1, "abcdefghijlkmnopqrstuvwxyz01234567890");
+             generator, 1, "abcdefghijlkmnopqrstuvwxyz0123456789");
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/testing/random_database_name.h"
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+
+std::string RandomDatabaseName(
+    google::cloud::internal::DefaultPRNG& generator) {
+  // A database ID must be between 2 and 30 characters, fitting the regular
+  // expression `[a-z][a-z0-9_\-]*[a-z0-9]`
+  int max_size = 30;
+  std::string const prefix = "db-";
+  auto size = static_cast<int>(max_size - 1 - prefix.size());
+  return prefix +
+         google::cloud::internal::Sample(
+             generator, size, "abcdefghijlkmnopqrstuvwxyz012345689_-") +
+         google::cloud::internal::Sample(generator, 1,
+                                         "abcdefghijlkmnopqrstuvwxyz");
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/testing/random_database_name.h
+++ b/google/cloud/spanner/testing/random_database_name.h
@@ -1,0 +1,34 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_RANDOM_DATABASE_NAME_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_RANDOM_DATABASE_NAME_H_
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/internal/random.h"
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+
+/// Create a random database name given a PRNG generator.
+std::string RandomDatabaseName(google::cloud::internal::DefaultPRNG& generator);
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_RANDOM_DATABASE_NAME_H_

--- a/google/cloud/spanner/testing/random_database_name.h
+++ b/google/cloud/spanner/testing/random_database_name.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/random.h"
+#include <string>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
I am going to create a new integration test, and want to use this
function in it. Refactor the function to the testing library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/292)
<!-- Reviewable:end -->
