### PR TITLE
bug: Fix macOS+CMake build.

### DIFF
--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -68,11 +68,6 @@ if [[ ${RUN_INTEGRATION_TESTS} == "yes" ]]; then
 fi
 
 echo "================================================================"
-echo "Testing the install target $(date)"
-echo "================================================================"
-cmake --build "${BINARY_DIR}" --target install || echo "FAILED"
-
-echo "================================================================"
 echo "Build finished at $(date)"
 echo "================================================================"
 

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -17,6 +17,7 @@
 set -eu
 
 export BAZEL_CONFIG=""
+export RUN_INTEGRATION_TESTS="no"
 driver_script="ci/kokoro/macos/build-bazel.sh"
 
 if [[ $# -eq 1 ]]; then


### PR DESCRIPTION
Fix the driver scripts for macOS+CMake, I needed the changes to
the spanner_testing library before testing said scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/303)
<!-- Reviewable:end -->
