### PR TITLE
bug: Fix Bazel presubmit configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cmake-out/
 # Common bazel output directories
 bazel-*
 !bazel-dependency*.cfg
+!bazel-*.cfg
 
 # Backup files for Emacs
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ cmake-out/
 
 # Common bazel output directories
 bazel-*
-!bazel-dependency*.cfg
 !bazel-*.cfg
 
 # Backup files for Emacs


### PR DESCRIPTION
I missed the configuration file because it was captured by one of
the .gitignore globs. Add the configuration file and fixed .gitignore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/304)
<!-- Reviewable:end -->
