### PR TITLE
bug: Install dependencies on Kokoro.

### DIFF
--- a/ci/kokoro/macos/build-cmake.sh
+++ b/ci/kokoro/macos/build-cmake.sh
@@ -31,9 +31,14 @@ readonly NCPU
 source "${PROJECT_ROOT}/ci/colors.sh"
 
 echo "================================================================"
+echo "Update or install dependencies at $(date)."
+brew install libressl
+
+echo "================================================================"
 echo "Compiling on $(date) with ${NCPU} cpus"
 echo "================================================================"
 cd "${PROJECT_ROOT}"
+export OPENSSL_ROOT_DIR=/usr/local/opt/libressl
 cmake_flags=("-DCMAKE_INSTALL_PREFIX=$HOME/staging")
 
 cmake "-H${SOURCE_DIR}" "-B${BINARY_DIR}" "${cmake_flags[@]}"


### PR DESCRIPTION
On Kokoro the dependencies (libressl in our case) need to be manually
installed before running the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/309)
<!-- Reviewable:end -->
