### PR TITLE
feat: Generalize internal::Visit(Transaction).

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -101,13 +101,11 @@ StatusOr<std::int64_t> Client::ExecutePartitionedDml(
 
 StatusOr<CommitResult> Client::Commit(Transaction transaction,
                                       std::vector<Mutation> const& mutations) {
-  using F = std::function<StatusOr<CommitResult>(
-      spanner_proto::TransactionSelector&)>;
   return internal::Visit(
       std::move(transaction),
-      F([this, &mutations](spanner_proto::TransactionSelector& s) {
+      [this, &mutations](spanner_proto::TransactionSelector& s) {
         return this->Commit(s, mutations);
-      }));
+      });
 }
 
 Status Client::Rollback(Transaction const& /*transaction*/) {

--- a/google/cloud/spanner/transaction.h
+++ b/google/cloud/spanner/transaction.h
@@ -26,6 +26,7 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+
 class Transaction;  // defined below
 
 // Internal forward declarations to befriend.

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -74,6 +74,20 @@ TEST(Transaction, RegularSemantics) {
   EXPECT_NE(j, h);
 }
 
+TEST(Transaction, Visit) {
+  Transaction a = MakeReadOnlyTransaction();
+  internal::Visit(a, [](google::spanner::v1::TransactionSelector& s) {
+    EXPECT_TRUE(s.has_begin());
+    EXPECT_TRUE(s.begin().has_read_only());
+    s.set_id("test-txn-id");
+    return 0;
+  });
+  internal::Visit(a, [](google::spanner::v1::TransactionSelector& s) {
+    EXPECT_EQ("test-txn-id", s.id());
+    return 0;
+  });
+}
+
 }  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner


### PR DESCRIPTION
The function was using a `std::function<T(...)>` and made it hard to use
with lambdas. Since it was already a template (and its implementation
too), I decided to use the functor type all the way through.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/313)
<!-- Reviewable:end -->
