### PR TITLE
fix: Use 4-digit year for consistency

### DIFF
--- a/google/cloud/spanner/internal/compiler_info.cc
+++ b/google/cloud/spanner/internal/compiler_info.cc
@@ -88,7 +88,7 @@ std::string CompilerFeatures() {
 std::string LanguageVersion() {
   switch (__cplusplus) {
     case 199711L:
-      return "98";
+      return "1998";
     case 201103L:
       return "2011";
     case 201402L:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/318)
<!-- Reviewable:end -->
