### PR TITLE
Make the C++ mappings of orderable Spanner types also orderable

### DIFF
--- a/google/cloud/spanner/date.h
+++ b/google/cloud/spanner/date.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/version.h"
 #include <cstdint>
+#include <tuple>
 
 namespace google {
 namespace cloud {
@@ -46,10 +47,22 @@ class Date {
 };
 
 inline bool operator==(Date const& a, Date const& b) {
-  return a.year() == b.year() && a.month() == b.month() && a.day() == b.day();
+  return std::make_tuple(a.year(), a.month(), a.day()) ==
+         std::make_tuple(b.year(), b.month(), b.day());
 }
 
 inline bool operator!=(Date const& a, Date const& b) { return !(a == b); }
+
+inline bool operator<(Date const& a, Date const& b) {
+  return std::make_tuple(a.year(), a.month(), a.day()) <
+         std::make_tuple(b.year(), b.month(), b.day());
+}
+
+inline bool operator<=(Date const& a, Date const& b) { return !(b < a); }
+
+inline bool operator>=(Date const& a, Date const& b) { return !(a < b); }
+
+inline bool operator>(Date const& a, Date const& b) { return b < a; }
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/date_test.cc
+++ b/google/cloud/spanner/date_test.cc
@@ -34,6 +34,21 @@ TEST(Date, Basics) {
   EXPECT_NE(d2, d);
 }
 
+TEST(Date, RelationalOperators) {
+  Date d1(2019, 6, 21);
+  Date d2(2019, 6, 22);
+
+  EXPECT_EQ(d1, d1);
+  EXPECT_LE(d1, d1);
+  EXPECT_GE(d1, d1);
+
+  EXPECT_NE(d1, d2);
+  EXPECT_LT(d1, d2);
+  EXPECT_LE(d1, d2);
+  EXPECT_GE(d2, d1);
+  EXPECT_GT(d2, d1);
+}
+
 TEST(Date, Normalization) {
   // Non-leap-year day overflow.
   EXPECT_EQ(Date(2019, 3, 1), Date(2019, 2, 29));

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -185,7 +185,7 @@ class Value {
    *
    * This struct is a thin wrapper around a `std::string` to distinguish BYTES
    * from STRINGs. The `.data` member can be set/get directly. Consructors and
-   * equality operators are provided for convenience and to make `Bytes` a
+   * relational operators are provided for convenience and to make `Bytes` a
    * regular type that is easy to work with.
    */
   struct Bytes {
@@ -210,6 +210,8 @@ class Value {
     }
     friend bool operator!=(Bytes const& a, Bytes const& b) { return !(a == b); }
     friend bool operator<(Bytes const& a, Bytes const& b) {
+      // Note that std::string::operator<() behaves as if the chars were
+      // unsigned, which is exactly how Spanner BYTES values compare.
       return a.data < b.data;
     }
     friend bool operator<=(Bytes const& a, Bytes const& b) { return !(b < a); }

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -203,12 +203,18 @@ class Value {
     Bytes& operator=(Bytes&&) = default;
     ///@}
 
-    /// @name Equality
+    /// @name Relational operators
     ///@{
     friend bool operator==(Bytes const& a, Bytes const& b) {
       return a.data == b.data;
     }
     friend bool operator!=(Bytes const& a, Bytes const& b) { return !(a == b); }
+    friend bool operator<(Bytes const& a, Bytes const& b) {
+      return a.data < b.data;
+    }
+    friend bool operator<=(Bytes const& a, Bytes const& b) { return !(b < a); }
+    friend bool operator>=(Bytes const& a, Bytes const& b) { return !(a < b); }
+    friend bool operator>(Bytes const& a, Bytes const& b) { return b < a; }
     ///@}
   };
   /// Constructs an instance with the specicified bytes.

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -187,6 +187,9 @@ class Value {
    * from STRINGs. The `.data` member can be set/get directly. Consructors and
    * relational operators are provided for convenience and to make `Bytes` a
    * regular type that is easy to work with.
+   *
+   * Note that the relational operators behave as if the `std::string` chars
+   * are unsigned, which is exactly how Spanner BYTES values compare.
    */
   struct Bytes {
     std::string data;
@@ -210,8 +213,6 @@ class Value {
     }
     friend bool operator!=(Bytes const& a, Bytes const& b) { return !(a == b); }
     friend bool operator<(Bytes const& a, Bytes const& b) {
-      // Note that std::string::operator<() behaves as if the chars were
-      // unsigned, which is exactly how Spanner BYTES values compare.
       return a.data < b.data;
     }
     friend bool operator<=(Bytes const& a, Bytes const& b) { return !(b < a); }

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -196,8 +196,8 @@ TEST(Value, BytesDecodingError) {
 }
 
 TEST(Value, BytesRelationalOperators) {
-  // Note that Value::Bytes inequalities should treat the bytes as unsigned.
-  // So b1 is always less than b2, independently of the signedness of char.
+  // Note that Value::Bytes inequalities treat the bytes as unsigned, so
+  // b1 is always less than b2, without respect to the signedness of char.
   Value::Bytes b1(std::string(1, '\x00'));
   Value::Bytes b2(std::string(1, '\xff'));
 

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -196,8 +196,10 @@ TEST(Value, BytesDecodingError) {
 }
 
 TEST(Value, BytesRelationalOperators) {
-  Value::Bytes b1("aaaaa");
-  Value::Bytes b2("bbbbb");
+  // Note that Value::Bytes inequalities should treat the bytes as unsigned.
+  // So b1 is always less than b2, independently of the signedness of char.
+  Value::Bytes b1(std::string(1, '\x00'));
+  Value::Bytes b2(std::string(1, '\xff'));
 
   EXPECT_EQ(b1, b1);
   EXPECT_LE(b1, b1);

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -195,6 +195,21 @@ TEST(Value, BytesDecodingError) {
   EXPECT_THAT(bytes.status().message(), testing::HasSubstr("Invalid base64"));
 }
 
+TEST(Value, BytesRelationalOperators) {
+  Value::Bytes b1("aaaaa");
+  Value::Bytes b2("bbbbb");
+
+  EXPECT_EQ(b1, b1);
+  EXPECT_LE(b1, b1);
+  EXPECT_GE(b1, b1);
+
+  EXPECT_NE(b1, b2);
+  EXPECT_LT(b1, b2);
+  EXPECT_LE(b1, b2);
+  EXPECT_GE(b2, b1);
+  EXPECT_GT(b2, b1);
+}
+
 TEST(Value, ConstructionFromLiterals) {
   Value v_int64(42);
   EXPECT_EQ(42, *v_int64.get<std::int64_t>());


### PR DESCRIPTION
Add all relational operators to `Date` and `Value::Bytes`, so
that the ordering of each Spanner types is now reflected in the
ordering of its C++ mapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/319)
<!-- Reviewable:end -->
