### PR TITLE
Provide an ordering to transaction visitors

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -25,10 +25,11 @@ namespace internal {
 namespace spanner_proto = ::google::spanner::v1;
 
 StatusOr<CommitResult> ConnectionImpl::Commit(Connection::CommitParams cp) {
-  return internal::Visit(std::move(cp.transaction),
-                         [this, &cp](spanner_proto::TransactionSelector& s) {
-                           return this->Commit(s, std::move(cp.mutations));
-                         });
+  return internal::Visit(
+      std::move(cp.transaction),
+      [this, &cp](spanner_proto::TransactionSelector& s, std::int64_t) {
+        return this->Commit(s, std::move(cp.mutations));
+      });
 }
 
 StatusOr<ConnectionImpl::SessionHolder> ConnectionImpl::GetSession() {

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -169,11 +169,10 @@ TEST(ConnectionImplTest, Commit_TransactionId) {
           }));
 
   auto txn = MakeReadWriteTransaction();
-  using F = std::function<int(spanner_proto::TransactionSelector&)>;
-  internal::Visit(txn, F([](spanner_proto::TransactionSelector& s) -> int {
-                    s.set_id("test-txn-id");
-                    return 0;
-                  }));
+  internal::Visit(txn, [](spanner_proto::TransactionSelector& s, std::int64_t) {
+    s.set_id("test-txn-id");
+    return 0;
+  });
 
   auto commit = conn.Commit({txn, {}});
   EXPECT_EQ(StatusCode::kPermissionDenied, commit.status().code());

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -49,7 +49,8 @@ class TransactionImpl {
   // passed TransactionSelector in its Client::Read()/Client::ExecuteSql()
   // call. If initially selector.has_begin(), and the operation successfully
   // allocates a transaction ID, then the functor should selector.set_id(id).
-  // Otherwise the functor should not modify the selector.
+  // Otherwise the functor should not modify the selector. A monotonically-
+  // increasing sequence number is also passed to the functor.
   template <typename Functor>
   VisitInvokeResult<Functor> Visit(Functor&& f) {
     std::int64_t seqno;

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -20,6 +20,7 @@
 #include "google/cloud/internal/port_platform.h"
 #include <google/spanner/v1/transaction.pb.h>
 #include <condition_variable>
+#include <cstdint>
 #include <mutex>
 
 namespace google {
@@ -30,7 +31,7 @@ namespace internal {
 
 template <typename Functor>
 using VisitInvokeResult = google::cloud::internal::invoke_result_t<
-    Functor, google::spanner::v1::TransactionSelector&>;
+    Functor, google::spanner::v1::TransactionSelector&, std::int64_t>;
 
 /**
  * The internal representation of a google::cloud::spanner::Transaction.
@@ -38,7 +39,7 @@ using VisitInvokeResult = google::cloud::internal::invoke_result_t<
 class TransactionImpl {
  public:
   TransactionImpl(google::spanner::v1::TransactionSelector selector)
-      : selector_(std::move(selector)) {
+      : selector_(std::move(selector)), seqno_(-1) {
     state_ = selector_.has_begin() ? State::kBegin : State::kDone;
   }
 
@@ -51,12 +52,14 @@ class TransactionImpl {
   // Otherwise the functor should not modify the selector.
   template <typename Functor>
   VisitInvokeResult<Functor> Visit(Functor&& f) {
+    std::int64_t seqno;
     {
       std::unique_lock<std::mutex> lock(mu_);
+      seqno = ++seqno_;  // what about overflow?
       cond_.wait(lock, [this] { return state_ != State::kPending; });
       if (state_ == State::kDone) {
         lock.unlock();
-        return f(selector_);
+        return f(selector_, seqno);
       }
       state_ = State::kPending;
     }
@@ -64,7 +67,7 @@ class TransactionImpl {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     try {
 #endif
-      auto r = f(selector_);
+      auto r = f(selector_, seqno);
       bool done = false;
       {
         std::lock_guard<std::mutex> lock(mu_);
@@ -100,6 +103,7 @@ class TransactionImpl {
   std::mutex mu_;
   std::condition_variable cond_;
   google::spanner::v1::TransactionSelector selector_;
+  std::int64_t seqno_;
 };
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -46,7 +46,7 @@ class Client {
     kReadFails,
   };
 
-  explicit Client(Mode mode) : mode_(mode), begin_seqno_(-1) {}
+  explicit Client(Mode mode) : mode_(mode), begin_seqno_(0) {}
 
   // Set the `read_timestamp` we expect to see, and the `txn_id` we want to
   // use during the upcoming `Read()` calls.
@@ -107,7 +107,7 @@ ResultSet Client::Read(TransactionSelector& selector, std::int64_t seqno,
     if (selector.begin().has_read_only() &&
         selector.begin().read_only().has_read_timestamp()) {
       auto const& proto = selector.begin().read_only().read_timestamp();
-      if (internal::FromProto(proto) == read_timestamp_ && seqno >= 0) {
+      if (internal::FromProto(proto) == read_timestamp_ && seqno > 0) {
         std::unique_lock<std::mutex> lock(mu_);
         switch (mode_) {
           case Mode::kReadSucceeds:

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -46,7 +46,7 @@ class Client {
     kReadFails,
   };
 
-  explicit Client(Mode mode) : mode_(mode) {}
+  explicit Client(Mode mode) : mode_(mode), begin_seqno_(-1) {}
 
   // Set the `read_timestamp` we expect to see, and the `txn_id` we want to
   // use during the upcoming `Read()` calls.
@@ -67,10 +67,10 @@ class Client {
   // User-visible read operation.
   ResultSet Read(Transaction txn, std::string const& table, KeySet const& keys,
                  std::vector<std::string> const& columns) {
-    std::function<ResultSet(TransactionSelector&)> read =
-        [this, &table, &keys, &columns](TransactionSelector& selector) {
-          return this->Read(selector, table, keys, columns);
-        };
+    auto read = [this, &table, &keys, &columns](TransactionSelector& selector,
+                                                std::int64_t seqno) {
+      return this->Read(selector, seqno, table, keys, columns);
+    };
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     try {
 #endif
@@ -83,28 +83,31 @@ class Client {
   }
 
  private:
-  ResultSet Read(TransactionSelector& selector, std::string const& table,
-                 KeySet const& keys, std::vector<std::string> const& columns);
+  ResultSet Read(TransactionSelector& selector, std::int64_t seqno,
+                 std::string const& table, KeySet const& keys,
+                 std::vector<std::string> const& columns);
 
   Mode mode_;
   Timestamp read_timestamp_;
   std::string txn_id_;
   std::mutex mu_;
-  int valid_visits_;  // GUARDED_BY(mu_);
+  std::int64_t begin_seqno_;  // GUARDED_BY(mu_)
+  int valid_visits_;          // GUARDED_BY(mu_)
 };
 
 // Transaction callback.  Normally we would use the TransactionSelector
 // to make a StreamingRead() RPC, and then, if the selector was a `begin`,
 // switch the selector to use the allocated transaction ID.  Here we use
 // the pre-assigned transaction ID after checking the read timestamp.
-ResultSet Client::Read(TransactionSelector& selector, std::string const&,
-                       KeySet const&, std::vector<std::string> const&) {
+ResultSet Client::Read(TransactionSelector& selector, std::int64_t seqno,
+                       std::string const&, KeySet const&,
+                       std::vector<std::string> const&) {
   if (selector.has_begin()) {
     bool fail_with_throw = false;
     if (selector.begin().has_read_only() &&
         selector.begin().read_only().has_read_timestamp()) {
       auto const& proto = selector.begin().read_only().read_timestamp();
-      if (internal::FromProto(proto) == read_timestamp_) {
+      if (internal::FromProto(proto) == read_timestamp_ && seqno >= 0) {
         std::unique_lock<std::mutex> lock(mu_);
         switch (mode_) {
           case Mode::kReadSucceeds:
@@ -115,6 +118,7 @@ ResultSet Client::Read(TransactionSelector& selector, std::string const&,
             fail_with_throw = (valid_visits_ % 2 == 0);
             break;
         }
+        if (valid_visits_ != 0) begin_seqno_ = seqno;
       }
     }
     switch (mode_) {
@@ -134,7 +138,7 @@ ResultSet Client::Read(TransactionSelector& selector, std::string const&,
       std::unique_lock<std::mutex> lock(mu_);
       switch (mode_) {
         case Mode::kReadSucceeds:  // non-initial visits valid
-          if (valid_visits_ != 0) ++valid_visits_;
+          if (valid_visits_ != 0 && seqno > begin_seqno_) ++valid_visits_;
           break;
         case Mode::kReadFails:  // visits never valid
           break;

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -76,14 +76,19 @@ TEST(Transaction, RegularSemantics) {
 
 TEST(Transaction, Visit) {
   Transaction a = MakeReadOnlyTransaction();
-  internal::Visit(a, [](google::spanner::v1::TransactionSelector& s) {
+  std::int64_t a_seqno;
+  internal::Visit(a, [&a_seqno](google::spanner::v1::TransactionSelector& s,
+                                std::int64_t seqno) {
     EXPECT_TRUE(s.has_begin());
     EXPECT_TRUE(s.begin().has_read_only());
     s.set_id("test-txn-id");
+    a_seqno = seqno;
     return 0;
   });
-  internal::Visit(a, [](google::spanner::v1::TransactionSelector& s) {
+  internal::Visit(a, [a_seqno](google::spanner::v1::TransactionSelector& s,
+                               std::int64_t seqno) {
     EXPECT_EQ("test-txn-id", s.id());
+    EXPECT_GT(seqno, a_seqno);
     return 0;
   });
 }


### PR DESCRIPTION
Pass a monotonically-increasing sequence number to each transaction
visitor.  This will provide a way to sequence read-write `ExecuteSql()`
calls.  See ExecuteSqlRequest.seqno for more details.

Fixes #279.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/331)
<!-- Reviewable:end -->
