### PR TITLE
Quash a clang-3.8 warning (suggest braces around initialization)

### DIFF
--- a/google/cloud/spanner/integration_tests/mutate_and_read_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/mutate_and_read_integration_test.cc
@@ -93,6 +93,8 @@ TEST(CommitIntegrationTest, Insert) {
     SCOPED_TRACE("Parsing row[" + std::to_string(row_number++) + "]");
     auto parsed_row = ParseRow<std::int64_t, std::string,
                                std::string>(std::array<Value, 3>{
+        // The extra braces are working around an old clang bug that was fixed
+        // in 6.0 (https://bugs.llvm.org/show_bug.cgi?id=21629).
         {internal::FromProto(result_set->metadata().row_type().fields(0).type(),
                              row.values(0)),
          internal::FromProto(result_set->metadata().row_type().fields(1).type(),

--- a/google/cloud/spanner/integration_tests/mutate_and_read_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/mutate_and_read_integration_test.cc
@@ -93,12 +93,12 @@ TEST(CommitIntegrationTest, Insert) {
     SCOPED_TRACE("Parsing row[" + std::to_string(row_number++) + "]");
     auto parsed_row = ParseRow<std::int64_t, std::string,
                                std::string>(std::array<Value, 3>{
-        internal::FromProto(result_set->metadata().row_type().fields(0).type(),
-                            row.values(0)),
-        internal::FromProto(result_set->metadata().row_type().fields(1).type(),
-                            row.values(1)),
-        internal::FromProto(result_set->metadata().row_type().fields(2).type(),
-                            row.values(2))});
+        {internal::FromProto(result_set->metadata().row_type().fields(0).type(),
+                             row.values(0)),
+         internal::FromProto(result_set->metadata().row_type().fields(1).type(),
+                             row.values(1)),
+         internal::FromProto(result_set->metadata().row_type().fields(2).type(),
+                             row.values(2))}});
     EXPECT_STATUS_OK(parsed_row);
     returned_rows.emplace_back(*parsed_row);
   }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/332)
<!-- Reviewable:end -->
