### PR TITLE
Cleaned up .clang-tidy file.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,29 +4,24 @@
 # Disabled:
 #  -google-readability-namespace-comments the *_CLIENT_NS is a macro, and
 #   clang-tidy fails to match it against the initial value.
-Checks: >-
+Checks: >
+  -*,
   bugprone-*,
-  google-readability-*,
+  google-*,
   misc-*,
   modernize-*,
-  readability-*,
   performance-*,
+  portability-*,
+  readability-*,
   -google-readability-namespace-comments,
+  -google-runtime-references,
+  -misc-non-private-member-variables-in-classes,
   -readability-named-parameter,
   -readability-braces-around-statements,
   -readability-magic-numbers
 
-# Enable most warnings as errors.
-WarningsAsErrors: >-
-  bugprone-*,
-  clang-*,
-  google-*,
-  misc-*,
-  modernize-*,
-  readability-*,
-  performance-*,
-  -readability-braces-around-statements,
-  -readability-magic-numbers
+# Turn all the warnings from the checks above into errors.
+WarningsAsErrors: "*"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -28,12 +28,10 @@ namespace {
 using ::testing::_;
 using ::testing::HasSubstr;
 
-// NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
 class MockConnection : public Connection {
  public:
   ~MockConnection() override = default;
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD1(Commit, StatusOr<CommitResult>(CommitParams));
 };
 

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -28,33 +28,26 @@ namespace gcsa = ::google::spanner::admin::database::v1;
 
 // gmock makes clang-tidy very angry, disable a few warnings that we have no
 // control over.
-// NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
 class MockDatabaseAdminClientStub : public internal::DatabaseAdminStub {
  public:
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(CreateDatabase,
                StatusOr<google::longrunning::Operation>(
                    grpc::ClientContext&, gcsa::CreateDatabaseRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD1(AwaitCreateDatabase, future<StatusOr<gcsa::Database>>(
                                         google::longrunning::Operation));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(UpdateDatabase, StatusOr<google::longrunning::Operation>(
                                    grpc::ClientContext&,
                                    gcsa::UpdateDatabaseDdlRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD1(AwaitUpdateDatabase,
                future<StatusOr<gcsa::UpdateDatabaseDdlMetadata>>(
                    google::longrunning::Operation));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(DropDatabase,
                Status(grpc::ClientContext&, gcsa::DropDatabaseRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(GetOperation,
                StatusOr<google::longrunning::Operation>(
                    grpc::ClientContext&,

--- a/google/cloud/spanner/internal/build_info.cc.in
+++ b/google/cloud/spanner/internal/build_info.cc.in
@@ -24,6 +24,16 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
+namespace {
+// Returns the given string as all lower case.
+std::string LowerString(std::string s) {
+  for (char& c : s) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  return s;
+}
+}  // namespace
+
 std::string BuildFlags() {
   static auto const* const kFlags = [] {
     auto* flags = new std::string(R"""(@CMAKE_CXX_FLAGS@)""");
@@ -37,12 +47,8 @@ std::string BuildFlags() {
 
 bool IsRelease() {
   static bool const kIsRelease = []() -> bool {
-    // NOLINTNEXTLINE(readability-redundant-string-init)
-    std::string value = R"""(@GOOGLE_CLOUD_CPP_SPANNER_IS_RELEASE@)""";
-    for (char& c : value) {
-      c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-    }
-    return value == "yes" || value == "1" || value == "true";
+    std::string s = LowerString(R"""(@GOOGLE_CLOUD_CPP_SPANNER_IS_RELEASE@)""");
+    return s == "yes" || s == "1" || s == "true";
   }();
   return kIsRelease;
 }

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -30,81 +30,66 @@ namespace spanner_proto = ::google::spanner::v1;
 
 // gmock makes clang-tidy very angry, disable a few warnings that we have no
 // control over.
-// NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
 class MockSpannerStub : public internal::SpannerStub {
  public:
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(CreateSession, StatusOr<spanner_proto::Session>(
                                   grpc::ClientContext&,
                                   spanner_proto::CreateSessionRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(GetSession, StatusOr<spanner_proto::Session>(
                                grpc::ClientContext&,
                                spanner_proto::GetSessionRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(ListSessions, StatusOr<spanner_proto::ListSessionsResponse>(
                                  grpc::ClientContext&,
                                  spanner_proto::ListSessionsRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(DeleteSession,
                Status(grpc::ClientContext&,
                       spanner_proto::DeleteSessionRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(ExecuteSql, StatusOr<spanner_proto::ResultSet>(
                                grpc::ClientContext&,
                                spanner_proto::ExecuteSqlRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(
       ExecuteStreamingSql,
       std::unique_ptr<
           grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>(
           grpc::ClientContext&, spanner_proto::ExecuteSqlRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(ExecuteBatchDml,
                StatusOr<spanner_proto::ExecuteBatchDmlResponse>(
                    grpc::ClientContext&,
                    spanner_proto::ExecuteBatchDmlRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(Read,
                StatusOr<spanner_proto::ResultSet>(
                    grpc::ClientContext&, spanner_proto::ReadRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(
       StreamingRead,
       std::unique_ptr<
           grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>(
           grpc::ClientContext&, spanner_proto::ReadRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(BeginTransaction,
                StatusOr<spanner_proto::Transaction>(
                    grpc::ClientContext&,
                    spanner_proto::BeginTransactionRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(Commit,
                StatusOr<spanner_proto::CommitResponse>(
                    grpc::ClientContext&, spanner_proto::CommitRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(Rollback, Status(grpc::ClientContext&,
                                 spanner_proto::RollbackRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(PartitionQuery,
                StatusOr<spanner_proto::PartitionResponse>(
                    grpc::ClientContext&,
                    spanner_proto::PartitionQueryRequest const&));
 
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD2(PartitionRead, StatusOr<spanner_proto::PartitionResponse>(
                                   grpc::ClientContext&,
                                   spanner_proto::PartitionReadRequest const&));

--- a/google/cloud/spanner/internal/partial_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader_test.cc
@@ -47,7 +47,8 @@ using ::testing::SetArgPointee;
 class ReaderValueMatcher
     : public testing::MatcherInterface<StatusOr<optional<Value>> const&> {
  public:
-  ReaderValueMatcher(Value expected) : expected_(std::move(expected)) {}
+  explicit ReaderValueMatcher(Value expected)
+      : expected_(std::move(expected)) {}
 
   bool MatchAndExplain(StatusOr<optional<Value>> const& actual,
                        testing::MatchResultListener* listener) const override {
@@ -82,19 +83,11 @@ testing::Matcher<StatusOr<optional<Value>> const&> IsValidAndEquals(
 
 // gmock makes clang-tidy very angry, disable a few warnings that we have no
 // control over.
-// NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
 class MockGrpcReader : public PartialResultSetReader::GrpcReader {
  public:
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD1(Read, bool(spanner_proto::PartialResultSet*));
-
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));
-
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD0(Finish, grpc::Status());
-
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD0(WaitForInitialMetadata, void());
 };
 

--- a/google/cloud/spanner/internal/retry_loop_test.cc
+++ b/google/cloud/spanner/internal/retry_loop_test.cc
@@ -81,12 +81,9 @@ TEST(RetryLoopTest, ReturnJustStatus) {
 
 // gmock makes clang-tidy very angry, disable a few warnings that we have no
 // control over.
-// NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
 class MockBackoffPolicy : public BackoffPolicy {
  public:
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_CONST_METHOD0(clone, std::unique_ptr<BackoffPolicy>());
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD0(OnCompletion, std::chrono::milliseconds());
 };
 
@@ -108,8 +105,7 @@ TEST(RetryLoopTest, UsesBackoffPolicy) {
   int counter = 0;
   std::vector<ms> sleep_for;
   StatusOr<int> actual = RetryLoopImpl(
-      TestRetryPolicy(), std::move(mock),  // NOLINT
-      true,
+      TestRetryPolicy(), std::move(mock), true,
       [&counter](grpc::ClientContext&, int request) {
         if (++counter <= 3) {
           return StatusOr<int>(Status(StatusCode::kUnavailable, "try again"));

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -30,7 +30,7 @@ namespace spanner_proto = ::google::spanner::v1;
  */
 class DefaultSpannerStub : public SpannerStub {
  public:
-  DefaultSpannerStub(
+  explicit DefaultSpannerStub(
       std::unique_ptr<spanner_proto::Spanner::StubInterface> grpc_stub)
       : grpc_stub_(std::move(grpc_stub)) {}
 

--- a/google/cloud/spanner/result_set_test.cc
+++ b/google/cloud/spanner/result_set_test.cc
@@ -31,14 +31,10 @@ namespace spanner_proto = ::google::spanner::v1;
 using ::google::cloud::internal::make_unique;
 using ::testing::Return;
 
-// NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
 class MockResultSetSource : public internal::ResultSetSource {
  public:
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD0(NextValue, StatusOr<optional<Value>>());
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD0(Metadata, optional<spanner_proto::ResultSetMetadata>());
-  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD0(Stats, optional<spanner_proto::ResultSetStats>());
 };
 

--- a/google/cloud/spanner/spanner_version_test.cc
+++ b/google/cloud/spanner/spanner_version_test.cc
@@ -26,10 +26,10 @@ using ::testing::StartsWith;
 
 /// @test A trivial test for the Google Cloud Spanner C++ Client
 TEST(StorageVersionTest, Simple) {
-  EXPECT_FALSE(spanner::version_string().empty());
-  EXPECT_EQ(SPANNER_CLIENT_VERSION_MAJOR, spanner::version_major());
-  EXPECT_EQ(SPANNER_CLIENT_VERSION_MINOR, spanner::version_minor());
-  EXPECT_EQ(SPANNER_CLIENT_VERSION_PATCH, spanner::version_patch());
+  EXPECT_FALSE(spanner::VersionString().empty());
+  EXPECT_EQ(SPANNER_CLIENT_VERSION_MAJOR, spanner::VersionMajor());
+  EXPECT_EQ(SPANNER_CLIENT_VERSION_MINOR, spanner::VersionMinor());
+  EXPECT_EQ(SPANNER_CLIENT_VERSION_PATCH, spanner::VersionPatch());
 }
 
 /// @test Verify the version string starts with the version numbers.
@@ -37,7 +37,7 @@ TEST(StorageVersionTest, Format) {
   std::ostringstream os;
   os << "v" << SPANNER_CLIENT_VERSION_MAJOR << "."
      << SPANNER_CLIENT_VERSION_MINOR << "." << SPANNER_CLIENT_VERSION_PATCH;
-  EXPECT_THAT(version_string(), StartsWith(os.str()));
+  EXPECT_THAT(VersionString(), StartsWith(os.str()));
 }
 
 /// @test Verify the version does not contain build info for release builds.
@@ -45,7 +45,7 @@ TEST(StorageVersionTest, NoBuildInfoInRelease) {
   if (!google::cloud::internal::is_release()) {
     return;
   }
-  EXPECT_THAT(version_string(),
+  EXPECT_THAT(VersionString(),
               Not(HasSubstr("+" + google::cloud::internal::build_metadata())));
 }
 
@@ -54,7 +54,7 @@ TEST(StorageVersionTest, HasBuildInfoInDevelopment) {
   if (google::cloud::internal::is_release()) {
     return;
   }
-  EXPECT_THAT(version_string(),
+  EXPECT_THAT(VersionString(),
               HasSubstr("+" + google::cloud::internal::build_metadata()));
 }
 

--- a/google/cloud/spanner/sql_partition_test.cc
+++ b/google/cloud/spanner/sql_partition_test.cc
@@ -23,7 +23,7 @@ inline namespace SPANNER_CLIENT_NS {
 class SqlPartitionTester {
  public:
   SqlPartitionTester() = default;
-  SqlPartitionTester(SqlPartition partition)
+  explicit SqlPartitionTester(SqlPartition partition)
       : partition_(std::move(partition)) {}
   SqlStatement const& Statement() const { return partition_.sql_statement(); }
   std::string const& PartitionToken() const {
@@ -48,8 +48,8 @@ TEST(SqlPartitionTest, MakeSqlPartition) {
   std::string session_id("session");
   std::string transaction_id("foo");
 
-  SqlPartitionTester actual_partition = internal::MakeSqlPartition(
-      transaction_id, session_id, partition_token, SqlStatement(stmt, params));
+  SqlPartitionTester actual_partition(internal::MakeSqlPartition(
+      transaction_id, session_id, partition_token, SqlStatement(stmt, params)));
   EXPECT_EQ(stmt, actual_partition.Statement().sql());
   EXPECT_EQ(params, actual_partition.Statement().params());
   EXPECT_EQ(partition_token, actual_partition.PartitionToken());
@@ -64,8 +64,8 @@ TEST(SqlPartitionTest, Constructor) {
   std::string session_id("session");
   std::string transaction_id("foo");
 
-  SqlPartitionTester actual_partition = internal::MakeSqlPartition(
-      transaction_id, session_id, partition_token, SqlStatement(stmt, params));
+  SqlPartitionTester actual_partition(internal::MakeSqlPartition(
+      transaction_id, session_id, partition_token, SqlStatement(stmt, params)));
   EXPECT_EQ(stmt, actual_partition.Statement().sql());
   EXPECT_EQ(params, actual_partition.Statement().params());
   EXPECT_EQ(partition_token, actual_partition.PartitionToken());
@@ -80,8 +80,8 @@ TEST(SqlPartitionTester, RegularSemantics) {
   std::string session_id("session");
   std::string transaction_id("foo");
 
-  SqlPartition sql_partition = internal::MakeSqlPartition(
-      transaction_id, session_id, partition_token, SqlStatement(stmt, params));
+  SqlPartition sql_partition(internal::MakeSqlPartition(
+      transaction_id, session_id, partition_token, SqlStatement(stmt, params)));
 
   EXPECT_NE(sql_partition, SqlPartition());
 

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -22,7 +22,7 @@ namespace google {
 namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
-// NOLINTNEXTLINE
+
 MATCHER_P(IsProtoEqual, value, "") {
   std::string delta;
   google::protobuf::util::MessageDifferencer differencer;

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -249,7 +249,7 @@ StatusOr<std::int64_t> Value::GetValue(std::int64_t,
   auto const& s = pv.string_value();
   char* end = nullptr;
   errno = 0;
-  long long x = std::strtoll(s.c_str(), &end, 10);
+  std::int64_t x = {std::strtoll(s.c_str(), &end, 10)};
   if (errno != 0) {
     auto const err = std::string(std::strerror(errno));
     return Status(StatusCode::kUnknown, err + ": \"" + s + "\"");

--- a/google/cloud/spanner/version.cc
+++ b/google/cloud/spanner/version.cc
@@ -20,12 +20,11 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-// NOLINTNEXTLINE(readability-identifier-naming)
-std::string version_string() {
+std::string VersionString() {
   static std::string const kVersion = [] {
     std::ostringstream os;
-    os << "v" << version_major() << "." << version_minor() << "."
-       << version_patch();
+    os << "v" << VersionMajor() << "." << VersionMinor() << "."
+       << VersionPatch();
     if (!google::cloud::internal::is_release()) {
       os << "+" << google::cloud::internal::build_metadata();
     }

--- a/google/cloud/spanner/version.h
+++ b/google/cloud/spanner/version.h
@@ -42,25 +42,25 @@ inline namespace SPANNER_CLIENT_NS {
 /**
  * The Cloud spanner C++ Client major version.
  */
-int constexpr version_major() { return SPANNER_CLIENT_VERSION_MAJOR; }
+int constexpr VersionMajor() { return SPANNER_CLIENT_VERSION_MAJOR; }
 
 /**
  * The Cloud spanner C++ Client minor version.
  */
-int constexpr version_minor() { return SPANNER_CLIENT_VERSION_MINOR; }
+int constexpr VersionMinor() { return SPANNER_CLIENT_VERSION_MINOR; }
 
 /**
  * The Cloud spanner C++ Client patch version.
  */
-int constexpr version_patch() { return SPANNER_CLIENT_VERSION_PATCH; }
+int constexpr VersionPatch() { return SPANNER_CLIENT_VERSION_PATCH; }
 
 /// A single integer representing the Major/Minor/Patch version.
-int constexpr version() {
-  return 100 * (100 * version_major() + version_minor()) + version_patch();
+int constexpr Version() {
+  return 100 * (100 * VersionMajor() + VersionMinor()) + VersionPatch();
 }
 
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.
-std::string version_string();
+std::string VersionString();
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner


### PR DESCRIPTION
Enabled a few more clang-tidy checks, and removed some checks that were
unnecessarily noisy and causing us to need `NOLINT`. Removed or worked
around all of our existing `NOLINT` declarations.

Fixes #316 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/333)
<!-- Reviewable:end -->
