### PR TITLE
feat: let clang-tidy build not fail if there are edited files.

### DIFF
--- a/ci/check-style.sh
+++ b/ci/check-style.sh
@@ -121,5 +121,10 @@ find . \( "${ignore[@]}" \) -prune -o \
     replace_original_if_changed "${file}" "${file}.tmp"
   done
 
-# Report any differences created by running the formatting tools.
-git diff --ignore-submodules=all --color --exit-code .
+# Report any differences created by running the formatting tools. IFF we are
+# running as part of a CI build. Otherwise, a human probably invoked this
+# script in which case we'll just leave the formatted files in their local git
+# repo so they can diff them and commit the correctly formatted files.
+if [[ "${RUNNING_CI}" != "no" ]]; then
+  git diff --ignore-submodules=all --color --exit-code .
+fi

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -35,6 +35,13 @@ elif [[ -n "${KOKORO_JOB_NAME:-}" ]]; then
   # name.
   BUILD_NAME="$(basename "${KOKORO_JOB_NAME}" "-presubmit")"
   export BUILD_NAME
+
+  # This is passed into the environment of the docker build and its scripts to
+  # tell them if they are running as part of a CI build rather than just a
+  # human invocation of "build.sh <build-name>". This allows scripts to be
+  # strict when run in a CI, but a little more friendly when run by a human.
+  RUNNING_CI="yes"
+  export RUNNING_CI
 else
  echo "Aborting build as the build name is not defined."
  echo "If you are invoking this script via the command line use:"
@@ -236,6 +243,9 @@ docker_flags=(
 
     # Additional flags to enable CMake features.
     "--env" "CMAKE_FLAGS=${CMAKE_FLAGS:-}"
+
+    # Tells scripts whether they are running as part of a CI or not.
+    "--env" "RUNNING_CI=${RUNNING_CI:-no}"
 
     # When running the integration tests this directory contains the
     # configuration files needed to run said tests. Make it available inside


### PR DESCRIPTION
This change passes an env var to the docker builds to let them know if
they are running as part of a CI or a human invocation. In the former
case, there is no change. In the latter case, some scripts may want to
be a little more friendly. For example, in this PR, I changed the
clang-tidy build to not bail if there are existing uncommitted files.
Instead, the the clang-tidy build will simply format the local files and
leave them edited in the working dir. The author can then look at the
diffs and commit them. This makes "build.sh clang-tidy" a more useful
tool for developers who want to use it to format their existing code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/334)
<!-- Reviewable:end -->
