### PR TITLE
Delete "makes clang-tidy angry" comments.

### DIFF
--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -26,8 +26,6 @@ using ::testing::_;
 using ::testing::Invoke;
 namespace gcsa = ::google::spanner::admin::database::v1;
 
-// gmock makes clang-tidy very angry, disable a few warnings that we have no
-// control over.
 class MockDatabaseAdminClientStub : public internal::DatabaseAdminStub {
  public:
   MOCK_METHOD2(CreateDatabase,

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -29,8 +29,6 @@ using ::testing::_;
 using ::testing::HasSubstr;
 namespace spanner_proto = ::google::spanner::v1;
 
-// gmock makes clang-tidy very angry, disable a few warnings that we have no
-// control over.
 class MockSpannerStub : public internal::SpannerStub {
  public:
   MOCK_METHOD2(CreateSession, StatusOr<spanner_proto::Session>(

--- a/google/cloud/spanner/internal/partial_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader_test.cc
@@ -81,8 +81,6 @@ testing::Matcher<StatusOr<optional<Value>> const&> IsValidAndEquals(
   return testing::MakeMatcher(new ReaderValueMatcher(std::move(expected)));
 }
 
-// gmock makes clang-tidy very angry, disable a few warnings that we have no
-// control over.
 class MockGrpcReader : public PartialResultSetReader::GrpcReader {
  public:
   MOCK_METHOD1(Read, bool(spanner_proto::PartialResultSet*));

--- a/google/cloud/spanner/internal/retry_loop_test.cc
+++ b/google/cloud/spanner/internal/retry_loop_test.cc
@@ -79,8 +79,6 @@ TEST(RetryLoopTest, ReturnJustStatus) {
   EXPECT_STATUS_OK(actual);
 }
 
-// gmock makes clang-tidy very angry, disable a few warnings that we have no
-// control over.
 class MockBackoffPolicy : public BackoffPolicy {
  public:
   MOCK_CONST_METHOD0(clone, std::unique_ptr<BackoffPolicy>());


### PR DESCRIPTION
These are no longer applicable since #333

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/341)
<!-- Reviewable:end -->
