### PR TITLE
Always use using-declarations for symbols in ::testing

### DIFF
--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -27,6 +27,7 @@ namespace {
 
 using ::testing::_;
 using ::testing::HasSubstr;
+using ::testing::Return;
 
 class MockConnection : public Connection {
  public:
@@ -69,7 +70,7 @@ TEST(ClientTest, CommitSuccess) {
   result.commit_timestamp = ts;
 
   Client client(conn);
-  EXPECT_CALL(*conn, Commit(_)).WillOnce(::testing::Return(result));
+  EXPECT_CALL(*conn, Commit(_)).WillOnce(Return(result));
 
   auto txn = MakeReadWriteTransaction();
   auto commit = client.Commit(txn, {});
@@ -82,8 +83,7 @@ TEST(ClientTest, CommitError) {
 
   Client client(conn);
   EXPECT_CALL(*conn, Commit(_))
-      .WillOnce(
-          ::testing::Return(Status(StatusCode::kPermissionDenied, "blah")));
+      .WillOnce(Return(Status(StatusCode::kPermissionDenied, "blah")));
 
   auto txn = MakeReadWriteTransaction();
   auto commit = client.Commit(txn, {});
@@ -95,7 +95,7 @@ TEST(ClientTest, RollbackSuccess) {
   auto conn = std::make_shared<MockConnection>();
 
   Client client(conn);
-  EXPECT_CALL(*conn, Rollback(_)).WillOnce(::testing::Return(Status()));
+  EXPECT_CALL(*conn, Rollback(_)).WillOnce(Return(Status()));
 
   auto txn = MakeReadWriteTransaction();
   auto rollback = client.Rollback(txn);
@@ -107,8 +107,7 @@ TEST(ClientTest, RollbackError) {
 
   Client client(conn);
   EXPECT_CALL(*conn, Rollback(_))
-      .WillOnce(
-          ::testing::Return(Status(StatusCode::kInvalidArgument, "blah")));
+      .WillOnce(Return(Status(StatusCode::kInvalidArgument, "blah")));
 
   auto txn = MakeReadWriteTransaction();
   auto rollback = client.Rollback(txn);

--- a/google/cloud/spanner/integration_tests/mutate_and_read_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/mutate_and_read_integration_test.cc
@@ -28,6 +28,8 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
+using ::testing::UnorderedElementsAre;
+
 /// @test Verify the basic insert operations for transaction commits.
 TEST(CommitIntegrationTest, Insert) {
   auto project_id =
@@ -106,7 +108,7 @@ TEST(CommitIntegrationTest, Insert) {
   }
 
   EXPECT_THAT(returned_rows,
-              ::testing::UnorderedElementsAre(
+              UnorderedElementsAre(
                   RowType(1, "test-first-name-1", "test-last-name-1"),
                   RowType(2, "test-first-name-2", "test-last-name-2")));
 

--- a/google/cloud/spanner/internal/build_info_test.cc
+++ b/google/cloud/spanner/internal/build_info_test.cc
@@ -22,9 +22,12 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::testing::HasSubstr;
+using ::testing::Not;
+
 TEST(BuildInfo, BuildFlags) {
   auto bf = BuildFlags();
-  EXPECT_THAT(bf, ::testing::Not(::testing::HasSubstr("@")));
+  EXPECT_THAT(bf, Not(HasSubstr("@")));
 }
 
 TEST(BuildInfo, IsRelease) {
@@ -36,7 +39,7 @@ TEST(BuildInfo, IsRelease) {
 TEST(BuildInfo, BuildMetadata) {
   auto const md = BuildMetadata();
   EXPECT_FALSE(md.empty());
-  EXPECT_THAT(md, ::testing::Not(::testing::HasSubstr("@")));
+  EXPECT_THAT(md, Not(HasSubstr("@")));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/compiler_info_test.cc
+++ b/google/cloud/spanner/internal/compiler_info_test.cc
@@ -22,11 +22,16 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::testing::AnyOf;
+using ::testing::ContainsRegex;
+using ::testing::Eq;
+using ::testing::MatchesRegex;
+
 TEST(CompilerInfo, CompilerId) {
   auto cn = CompilerId();
   EXPECT_FALSE(cn.empty());
 #ifndef _WIN32  // gMock's regex brackets don't work on Windows.
-  EXPECT_THAT(cn, ::testing::ContainsRegex(R"([A-Za-z]+)"));
+  EXPECT_THAT(cn, ContainsRegex(R"([A-Za-z]+)"));
 #endif
 }
 
@@ -35,23 +40,21 @@ TEST(CompilerInfo, CompilerVersion) {
   EXPECT_FALSE(cv.empty());
 #ifndef _WIN32  // gMock's regex brackets don't work on Windows.
   // Look for something that looks vaguely like an X.Y version number.
-  EXPECT_THAT(cv, ::testing::ContainsRegex(R"([0-9]+.[0-9]+)"));
+  EXPECT_THAT(cv, ContainsRegex(R"([0-9]+.[0-9]+)"));
 #endif
 }
 
 TEST(CompilerInfo, CompilerFeatures) {
-  using ::testing::Eq;
   auto cf = CompilerFeatures();
   EXPECT_FALSE(cf.empty());
-  EXPECT_THAT(cf, ::testing::AnyOf(Eq("noex"), Eq("ex")));
+  EXPECT_THAT(cf, AnyOf(Eq("noex"), Eq("ex")));
 }
 
 TEST(CompilerInfo, LanguageVersion) {
-  using ::testing::HasSubstr;
   auto lv = LanguageVersion();
   EXPECT_FALSE(lv.empty());
 #ifndef _WIN32  // gMock's regex brackets don't work on Windows.
-  EXPECT_THAT(lv, ::testing::MatchesRegex(R"([0-9]+)"));
+  EXPECT_THAT(lv, MatchesRegex(R"([0-9]+)"));
 #endif
 }
 

--- a/google/cloud/spanner/internal/retry_loop_test.cc
+++ b/google/cloud/spanner/internal/retry_loop_test.cc
@@ -23,6 +23,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
@@ -114,8 +115,8 @@ TEST(RetryLoopTest, UsesBackoffPolicy) {
       [&sleep_for](ms p) { sleep_for.push_back(p); });
   EXPECT_STATUS_OK(actual);
   EXPECT_EQ(84, *actual);
-  EXPECT_THAT(sleep_for, ::testing::ElementsAre(
-                             ms(10), std::chrono::milliseconds(20), ms(30)));
+  EXPECT_THAT(sleep_for,
+              ElementsAre(ms(10), std::chrono::milliseconds(20), ms(30)));
 }
 
 TEST(RetryLoopTest, TransientFailureNonIdempotent) {


### PR DESCRIPTION
IDK if everyone agrees with this, but it's what I'm used to and it makes the tests easier to read IMO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/343)
<!-- Reviewable:end -->
