### PR TITLE
Add CMakeLists.txt.tmp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ google/cloud/storage/testbench/*.pyc
 
 # Ignore Visual Studio Code files.
 .vscode/
+
+# Temporary cmake file.
+CMakeLists.txt.tmp


### PR DESCRIPTION
I see this happen fairly often, and sometimes even accidentally add it:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	CMakeLists.txt.tmp
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/344)
<!-- Reviewable:end -->
