### PR TITLE
Enable clang-format proto raw string formatting.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,3 +23,11 @@ IncludeCategories:
   Priority: 4000
 - Regex: '^<[^/]*>'
   Priority: 5000
+
+# Format raw string literals with a `pb` or `proto` tag as proto.
+RawStringFormats:
+- Language: TextProto
+  Delimiters:
+  - 'pb'
+  - 'proto'
+  BasedOnStyle: Google

--- a/google/cloud/spanner/internal/partial_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader_test.cc
@@ -118,7 +118,8 @@ TEST(PartialResultSetReaderTest, ReadSuccessThenFailure) {
             }
           }
         }
-        values: { string_value: "80" })pb",
+        values: { string_value: "80" }
+      )pb",
       &response));
   EXPECT_CALL(*grpc_reader, Read(_))
       .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
@@ -296,16 +297,19 @@ TEST(PartialResultSetReaderTest, MultipleResponses) {
   ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         values: { string_value: "10" }
-        values: { string_value: "user10" })pb",
+        values: { string_value: "user10" }
+      )pb",
       &response[1]));
   ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         values: { string_value: "22" }
-        values: { string_value: "user22" })pb",
+        values: { string_value: "user22" }
+      )pb",
       &response[2]));
   ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
-        values: { string_value: "99" })pb",
+        values: { string_value: "99" }
+      )pb",
       &response[3]));
   ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(

--- a/google/cloud/spanner/internal/partial_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader_test.cc
@@ -108,23 +108,23 @@ TEST(PartialResultSetReaderTest, InitialReadFailure) {
 TEST(PartialResultSetReaderTest, ReadSuccessThenFailure) {
   auto grpc_reader = make_unique<MockGrpcReader>();
   spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    metadata: {
-      row_type: {
-        fields: [
-          { name: "AnInt", type: { code: INT64 } }
-        ]
-      }
-    }
-    values: [ { string_value: "80" } ]
-  )""",
-                                          &response));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        metadata: {
+          row_type: {
+            fields: {
+              name: "AnInt",
+              type: { code: INT64 }
+            }
+          }
+        }
+        values: { string_value: "80" })pb",
+      &response));
   EXPECT_CALL(*grpc_reader, Read(_))
       .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
       .WillOnce(Return(false));
   grpc::Status finish_status(grpc::StatusCode::CANCELLED, "cancelled");
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
-
   // The first call to NextValue() yields a value but the second gives an error.
   auto reader = PartialResultSetReader::Create(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
@@ -154,7 +154,7 @@ TEST(PartialResultSetReaderTest, MissingMetadata) {
 TEST(PartialResultSetReaderTest, MissingRowType) {
   auto grpc_reader = make_unique<MockGrpcReader>();
   spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(metadata: {})""", &response));
+  ASSERT_TRUE(TextFormat::ParseFromString(R"pb(metadata: {})pb", &response));
   EXPECT_CALL(*grpc_reader, Read(_))
       .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
@@ -174,27 +174,40 @@ TEST(PartialResultSetReaderTest, MissingRowType) {
 TEST(PartialResultSetReaderTest, SingleResponse) {
   auto grpc_reader = make_unique<MockGrpcReader>();
   spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    metadata: {
-      row_type: {
-        fields: [
-          { name: "UserId", type: { code: INT64 } },
-          { name: "UserName", type: { code: STRING } }
-        ]
-      }
-    }
-    values: [ { string_value: "10" }, { string_value: "user10"} ]
-    stats: {
-      query_stats: {
-        fields: [
-          { key: "rows_returned", value: { string_value: "1" } },
-          { key: "elapsed_time", value: { string_value: "1.22 secs" } },
-          { key: "cpu_time", value: { string_value: "1.19 secs" } }
-        ]
-      }
-    }
-  )""",
-                                          &response));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        metadata: {
+          row_type: {
+            fields: {
+              name: "UserId",
+              type: { code: INT64 }
+            }
+            fields: {
+              name: "UserName",
+              type: { code: STRING }
+            }
+          }
+        }
+        values: { string_value: "10" }
+        values: { string_value: "user10" }
+        stats: {
+          query_stats: {
+            fields: {
+              key: "rows_returned",
+              value: { string_value: "1" }
+            }
+            fields: {
+              key: "elapsed_time",
+              value: { string_value: "1.22 secs" }
+            }
+            fields: {
+              key: "cpu_time",
+              value: { string_value: "1.19 secs" }
+            }
+          }
+        }
+      )pb",
+      &response));
   EXPECT_CALL(*grpc_reader, Read(_))
       .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
       .WillOnce(Return(false));
@@ -205,15 +218,20 @@ TEST(PartialResultSetReaderTest, SingleResponse) {
 
   // Verify the returned metadata is correct.
   spanner_proto::ResultSetMetadata expected_metadata;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    row_type: {
-      fields: [
-        { name: "UserId", type: { code: INT64 } },
-        { name: "UserName", type: { code: STRING } }
-      ]
-    }
-  )""",
-                                          &expected_metadata));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        row_type: {
+          fields: {
+            name: "UserId",
+            type: { code: INT64 }
+          }
+          fields: {
+            name: "UserName",
+            type: { code: STRING }
+          }
+        }
+      )pb",
+      &expected_metadata));
   auto actual_metadata = (*reader)->Metadata();
   EXPECT_TRUE(actual_metadata.has_value());
   EXPECT_THAT(*actual_metadata, IsProtoEqual(expected_metadata));
@@ -229,16 +247,24 @@ TEST(PartialResultSetReaderTest, SingleResponse) {
 
   // Verify the returned stats are correct.
   spanner_proto::ResultSetStats expected_stats;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    query_stats: {
-      fields: [
-        { key: "rows_returned", value: { string_value: "1" } },
-        { key: "elapsed_time", value: { string_value: "1.22 secs" } },
-        { key: "cpu_time", value: { string_value: "1.19 secs" } }
-      ]
-    }
-  )""",
-                                          &expected_stats));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        query_stats: {
+          fields: {
+            key: "rows_returned",
+            value: { string_value: "1" }
+          }
+          fields: {
+            key: "elapsed_time",
+            value: { string_value: "1.22 secs" }
+          }
+          fields: {
+            key: "cpu_time",
+            value: { string_value: "1.19 secs" }
+          }
+        }
+      )pb",
+      &expected_stats));
   auto actual_stats = (*reader)->Stats();
   EXPECT_TRUE(actual_stats.has_value());
   EXPECT_THAT(*actual_stats, IsProtoEqual(expected_stats));
@@ -251,38 +277,57 @@ TEST(PartialResultSetReaderTest, SingleResponse) {
 TEST(PartialResultSetReaderTest, MultipleResponses) {
   auto grpc_reader = make_unique<MockGrpcReader>();
   std::array<spanner_proto::PartialResultSet, 5> response;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    metadata: {
-      row_type: {
-        fields: [
-          { name: "UserId", type: { code: INT64 } },
-          { name: "UserName", type: { code: STRING } }
-        ]
-      }
-    }
-    )""",
-                                          &response[0]));
   ASSERT_TRUE(TextFormat::ParseFromString(
-      R"""(values: [ { string_value: "10" }, { string_value: "user10"} ])""",
+      R"pb(
+        metadata: {
+          row_type: {
+            fields: {
+              name: "UserId",
+              type: { code: INT64 }
+            }
+            fields: {
+              name: "UserName",
+              type: { code: STRING }
+            }
+          }
+        }
+      )pb",
+      &response[0]));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        values: { string_value: "10" }
+        values: { string_value: "user10" })pb",
       &response[1]));
   ASSERT_TRUE(TextFormat::ParseFromString(
-      R"""(values: [ { string_value: "22" }, { string_value: "user22"} ])""",
+      R"pb(
+        values: { string_value: "22" }
+        values: { string_value: "user22" })pb",
       &response[2]));
   ASSERT_TRUE(TextFormat::ParseFromString(
-      R"""(values: [ { string_value: "99" } ])""", &response[3]));
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    values: [ { string_value: "99user99"} ]
-    stats: {
-      query_stats: {
-        fields: [
-          { key: "rows_returned", value : { string_value : "3" } },
-          { key: "elapsed_time", value : { string_value : "4.22 secs" } },
-          { key: "cpu_time", value : { string_value : "3.19 secs" } }
-        ]
-      }
-    }
-   )""",
-                                          &response[4]));
+      R"pb(
+        values: { string_value: "99" })pb",
+      &response[3]));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        values: { string_value: "99user99" }
+        stats: {
+          query_stats: {
+            fields: {
+              key: "rows_returned",
+              value: { string_value: "3" }
+            }
+            fields: {
+              key: "elapsed_time",
+              value: { string_value: "4.22 secs" }
+            }
+            fields: {
+              key: "cpu_time",
+              value: { string_value: "3.19 secs" }
+            }
+          }
+        }
+      )pb",
+      &response[4]));
   EXPECT_CALL(*grpc_reader, Read(_))
       .WillOnce(DoAll(SetArgPointee<0>(response[0]), Return(true)))
       .WillOnce(DoAll(SetArgPointee<0>(response[1]), Return(true)))

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -184,7 +184,8 @@ TEST(InternalKeySetTest, ToProtoAll) {
   ::google::spanner::v1::KeySet expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(
-        all: true)pb",
+        all: true
+      )pb",
       &expected));
 
   ::google::spanner::v1::KeySet result = internal::ToProto(ks);
@@ -209,7 +210,8 @@ TEST(InternalKeySetTest, BuildToProtoTwoKeys) {
           values: { string_value: "foo1" }
           values: { string_value: "bar1" }
         }
-        all: false)pb",
+        all: false
+      )pb",
       &expected));
   ::google::spanner::v1::KeySet result = internal::ToProto(ks);
 

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -182,10 +182,9 @@ TEST(KeySetBuilderTest, AddKeyRangeToNonEmptyKeySetBuilder) {
 TEST(InternalKeySetTest, ToProtoAll) {
   auto ks = KeySet::All();
   ::google::spanner::v1::KeySet expected;
-  EXPECT_TRUE(::google::protobuf::TextFormat::ParseFromString(
-      R"(
-all: true
-)",
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        all: true)pb",
       &expected));
 
   ::google::spanner::v1::KeySet result = internal::ToProto(ks);
@@ -200,27 +199,17 @@ TEST(InternalKeySetTest, BuildToProtoTwoKeys) {
   KeySet ks = ksb.Build();
 
   ::google::spanner::v1::KeySet expected;
-  EXPECT_TRUE(::google::protobuf::TextFormat::ParseFromString(
-      R"(
-keys {
-  values {
-    string_value: "foo0"
-  }
-  values {
-    string_value: "bar0"
-  }
-}
-
-keys {
-  values {
-    string_value: "foo1"
-  }
-  values {
-    string_value: "bar1"
-  }
-}
-all: false
-)",
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        keys: {
+          values: { string_value: "foo0" }
+          values: { string_value: "bar0" }
+        }
+        keys: {
+          values: { string_value: "foo1" }
+          values: { string_value: "bar1" }
+        }
+        all: false)pb",
       &expected));
   ::google::spanner::v1::KeySet result = internal::ToProto(ks);
 
@@ -237,50 +226,34 @@ TEST(InternalKeySetTest, BuildToProtoTwoRanges) {
   ksb.Add(range);
 
   ::google::spanner::v1::KeySet expected;
-  EXPECT_TRUE(::google::protobuf::TextFormat::ParseFromString(
-      R"(
-ranges {
-  start_closed {
-    values {
-      string_value: "start00"
-    }
-    values {
-      string_value: "start01"
-    }
-  }
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        ranges: {
+          start_closed: {
+            values: { string_value: "start00" }
+            values: { string_value: "start01" }
+          }
 
-  end_closed {
-    values {
-      string_value: "end00"
-    }
-    values {
-      string_value: "end01"
-    }
-  }
-}
+          end_closed: {
+            values: { string_value: "end00" }
+            values { string_value: "end01" }
+          }
+        }
 
-ranges {
-  start_open {
-    values {
-      string_value: "start10"
-    }
-    values {
-      string_value: "start11"
-    }
-  }
+        ranges: {
+          start_open: {
+            values: { string_value: "start10" }
+            values: { string_value: "start11" }
+          }
 
-  end_open {
-    values {
-      string_value: "end10"
-    }
-    values {
-      string_value: "end11"
-    }
-  }
-}
+          end_open: {
+            values: { string_value: "end10" }
+            values: { string_value: "end11" }
+          }
+        }
 
-all: false
-)",
+        all: false
+      )pb",
       &expected));
   ::google::spanner::v1::KeySet result = internal::ToProto(ksb.Build());
 

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -53,26 +53,21 @@ TEST(MutationsTest, InsertSimple) {
 
   auto actual = std::move(insert).as_proto();
   google::spanner::v1::Mutation expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-              insert: {
-                columns: "col_a"
-                columns: "col_b"
-                columns: "col_c"
-                table: "table-name"
-                values {
-                  values {
-                    string_value: "foo"
-                  }
-                  values {
-                    string_value: "bar"
-                  }
-                  values {
-                    bool_value: true
-                  }
-                }
-              }
-              )""",
-                                                            &expected));
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        insert: {
+          columns: "col_a"
+          columns: "col_b"
+          columns: "col_c"
+          table: "table-name"
+          values: {
+            values: { string_value: "foo" }
+            values: { string_value: "bar" }
+            values: { bool_value: true }
+          }
+        }
+      )pb",
+      &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
@@ -88,37 +83,26 @@ TEST(MutationsTest, InsertComplex) {
 
   auto actual = std::move(insert).as_proto();
   google::spanner::v1::Mutation expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-              insert: {
-                table: "table-name"
-                columns: "col1"
-                columns: "col2"
-                columns: "col3"
-                values {
-                  values {
-                    string_value: "42"
-                  }
-                  values {
-                    string_value: "foo"
-                  }
-                  values {
-                    bool_value: false
-                  }
-                }
-                values {
-                  values {
-                    null_value: NULL_VALUE
-                  }
-                  values {
-                    string_value: "bar"
-                  }
-                  values {
-                    null_value: NULL_VALUE
-                  }
-                }
-              }
-              )""",
-                                                            &expected));
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        insert: {
+          table: "table-name"
+          columns: "col1"
+          columns: "col2"
+          columns: "col3"
+          values: {
+            values: { string_value: "42" }
+            values: { string_value: "foo" }
+            values: { bool_value: false }
+          }
+          values: {
+            values: { null_value: NULL_VALUE }
+            values: { string_value: "bar" }
+            values: { null_value: NULL_VALUE }
+          }
+        }
+      )pb",
+      &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
@@ -132,26 +116,21 @@ TEST(MutationsTest, UpdateSimple) {
 
   auto actual = std::move(update).as_proto();
   google::spanner::v1::Mutation expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-              update: {
-                table: "table-name"
-                columns: "col_a"
-                columns: "col_b"
-                columns: "col_c"
-                values {
-                  values {
-                    string_value: "foo"
-                  }
-                  values {
-                    string_value: "bar"
-                  }
-                  values {
-                    bool_value: true
-                  }
-                }
-              }
-              )""",
-                                                            &expected));
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        update: {
+          table: "table-name"
+          columns: "col_a"
+          columns: "col_b"
+          columns: "col_c"
+          values: {
+            values: { string_value: "foo" }
+            values: { string_value: "bar" }
+            values: { bool_value: true }
+          }
+        }
+      )pb",
+      &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
@@ -167,38 +146,28 @@ TEST(MutationsTest, UpdateComplex) {
 
   auto actual = std::move(update).as_proto();
   google::spanner::v1::Mutation expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-              update: {
-                table: "table-name"
-                columns: "col_a"
-                columns: "col_b"
-                values {
-                  values {
-                    list_value: {
-                    }
-                  }
-                  values {
-                    number_value: 7.0
-                  }
-                }
-                values {
-                  values {
-                    list_value: {
-                      values {
-                        string_value: "a"
-                      }
-                      values {
-                        string_value: "b"
-                      }
-                    }
-                  }
-                  values {
-                    null_value: NULL_VALUE
-                  }
-                }
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        update: {
+          table: "table-name"
+          columns: "col_a"
+          columns: "col_b"
+          values: {
+            values: { list_value: {} }
+            values: { number_value: 7.0 }
+          }
+          values: {
+            values: {
+              list_value: {
+                values: { string_value: "a" }
+                values: { string_value: "b" }
               }
-              )""",
-                                                            &expected));
+            }
+            values: { null_value: NULL_VALUE }
+          }
+        }
+      )pb",
+      &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
@@ -212,26 +181,21 @@ TEST(MutationsTest, InsertOrUpdateSimple) {
 
   auto actual = std::move(update).as_proto();
   google::spanner::v1::Mutation expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-              insert_or_update: {
-                table: "table-name"
-                columns: "col_a"
-                columns: "col_b"
-                columns: "col_c"
-                values {
-                  values {
-                    string_value: "foo"
-                  }
-                  values {
-                    string_value: "bar"
-                  }
-                  values {
-                    bool_value: true
-                  }
-                }
-              }
-              )""",
-                                                            &expected));
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        insert_or_update: {
+          table: "table-name"
+          columns: "col_a"
+          columns: "col_b"
+          columns: "col_c"
+          values: {
+            values: { string_value: "foo" }
+            values: { string_value: "bar" }
+            values: { bool_value: true }
+          }
+        }
+      )pb",
+      &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
@@ -246,37 +210,30 @@ TEST(MutationsTest, InsertOrUpdateComplex) {
 
   auto actual = std::move(update).as_proto();
   google::spanner::v1::Mutation expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-              insert_or_update: {
-                table: "table-name"
-                columns: "col_a"
-                columns: "col_b"
-                values {
-                  values {
-                    list_value: {
-                      values {
-                        string_value: "a"
-                      }
-                      values {
-                        number_value: 7.0
-                      }
-                    }
-                  }
-                }
-                values {
-                  values {
-                    list_value: {
-                      values {
-                        string_value: "b"
-                      }
-                      values {
-                        number_value: 8.0
-                      }
-                    }
-                  }
-                }
-              })""",
-                                                            &expected));
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        insert_or_update: {
+          table: "table-name"
+          columns: "col_a"
+          columns: "col_b"
+          values: {
+            values: {
+              list_value: {
+                values: { string_value: "a" }
+                values: { number_value: 7.0 }
+              }
+            }
+          }
+          values: {
+            values: {
+              list_value: {
+                values: { string_value: "b" }
+                values: { number_value: 8.0 }
+              }
+            }
+          }
+        })pb",
+      &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
@@ -290,26 +247,21 @@ TEST(MutationsTest, ReplaceSimple) {
 
   auto actual = std::move(replace).as_proto();
   google::spanner::v1::Mutation expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-              replace: {
-                table: "table-name"
-                columns: "col_a"
-                columns: "col_b"
-                columns: "col_c"
-                values {
-                  values {
-                    string_value: "foo"
-                  }
-                  values {
-                    string_value: "bar"
-                  }
-                  values {
-                    bool_value: true
-                  }
-                }
-              }
-              )""",
-                                                            &expected));
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        replace: {
+          table: "table-name"
+          columns: "col_a"
+          columns: "col_b"
+          columns: "col_c"
+          values: {
+            values: { string_value: "foo" }
+            values: { string_value: "bar" }
+            values: { bool_value: true }
+          }
+        }
+      )pb",
+      &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
@@ -324,29 +276,22 @@ TEST(MutationsTest, ReplaceComplex) {
 
   auto actual = std::move(update).as_proto();
   google::spanner::v1::Mutation expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-              replace: {
-                table: "table-name"
-                columns: "col_a"
-                columns: "col_b"
-                values {
-                  values {
-                    string_value: "a"
-                  }
-                  values {
-                    number_value: 7.0
-                  }
-                }
-                values {
-                  values {
-                    string_value: "b"
-                  }
-                  values {
-                    number_value: 8.0
-                  }
-                }
-              })""",
-                                                            &expected));
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        replace: {
+          table: "table-name"
+          columns: "col_a"
+          columns: "col_b"
+          values: {
+            values: { string_value: "a" }
+            values: { number_value: 7.0 }
+          }
+          values: {
+            values: { string_value: "b" }
+            values: { number_value: 8.0 }
+          }
+        })pb",
+      &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -232,7 +232,8 @@ TEST(MutationsTest, InsertOrUpdateComplex) {
               }
             }
           }
-        })pb",
+        }
+      )pb",
       &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -290,7 +291,8 @@ TEST(MutationsTest, ReplaceComplex) {
             values: { string_value: "b" }
             values: { number_value: 8.0 }
           }
-        })pb",
+        }
+      )pb",
       &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }

--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -155,7 +155,8 @@ TEST(SqlStatementTest, ToProtoWithParams) {
         param_types: {
           key: "first",
           value: { code: STRING }
-        })pb",
+        }
+      )pb",
       &expected));
   EXPECT_THAT(internal::ToProto(std::move(stmt)), IsProtoEqual(expected));
 }

--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -113,7 +113,7 @@ TEST(SqlStatementTest, Equality) {
 TEST(SqlStatementTest, ToProtoStatementOnly) {
   SqlStatement stmt("select * from foo");
   internal::SqlStatementProto expected;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(sql: "select * from foo")""",
+  ASSERT_TRUE(TextFormat::ParseFromString(R"pb(sql: "select * from foo")pb",
                                           &expected));
   EXPECT_THAT(internal::ToProto(std::move(stmt)), IsProtoEqual(expected));
 }
@@ -128,21 +128,35 @@ TEST(SqlStatementTest, ToProtoWithParams) {
       "destroyed_cars >= @destroyed_cars";
   SqlStatement stmt(sql, params);
   internal::SqlStatementProto expected;
-  ASSERT_TRUE(
-      TextFormat::ParseFromString(std::string(R"""(sql: ")""") + sql + R"""("
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      std::string(R"(sql: ")") + sql + R"(")" + R"pb(
         params: {
-          fields: [
-            { key: "destroyed_cars", value: { string_value: "103" } },
-            { key: "first", value: { string_value: "Elwood" } },
-            { key: "last", value: { string_value: "Blues" } }
-          ]
+          fields: {
+            key: "destroyed_cars",
+            value: { string_value: "103" }
+          }
+          fields: {
+            key: "first",
+            value: { string_value: "Elwood" }
+          }
+          fields: {
+            key: "last",
+            value: { string_value: "Blues" }
+          }
         }
-        param_types: [
-          { key: "destroyed_cars", value: { code: INT64 } },
-          { key: "last", value: { code: STRING } },
-          { key: "first", value: { code: STRING } }
-        ])""",
-                                  &expected));
+        param_types: {
+          key: "destroyed_cars",
+          value: { code: INT64 }
+        }
+        param_types: {
+          key: "last",
+          value: { code: STRING }
+        }
+        param_types: {
+          key: "first",
+          value: { code: STRING }
+        })pb",
+      &expected));
   EXPECT_THAT(internal::ToProto(std::move(stmt)), IsProtoEqual(expected));
 }
 


### PR DESCRIPTION
I also changed the quoting of the existing proto strings, and expanded the repeated fields and maps to use repeated field names rather than the bracket syntax, which clang-format does not seem to handle well. Then I let clang-format reformat them all.

`EnclosingFunctions` is supposed to make this "automatic" based on the function name, i.e. you can just write `R"(` rather than `R"proto(` when calling one of those functions. I decided not to use it since it appears to only look at the function name itself and I thought `ParseFromString` was overly broad. I tried to set it to `TextFormat::ParseFromString` (and the fully qualified name) but those didn't work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/349)
<!-- Reviewable:end -->
