### PR TITLE
feat: add Read and ExecuteSql methods

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -24,27 +24,29 @@ inline namespace SPANNER_CLIENT_NS {
 
 namespace spanner_proto = ::google::spanner::v1;
 
-StatusOr<ResultSet> Client::Read(std::string const& /*table*/,
-                                 KeySet const& /*keys*/,
-                                 std::vector<std::string> const& /*columns*/,
-                                 ReadOptions const& /*read_options*/) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
+StatusOr<ResultSet> Client::Read(std::string table, KeySet keys,
+                                 std::vector<std::string> columns,
+                                 ReadOptions read_options) {
+  return conn_->Read(
+      {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
+       std::move(table), std::move(keys), std::move(columns),
+       std::move(read_options)});
 }
 
 StatusOr<ResultSet> Client::Read(
-    Transaction::SingleUseOptions const& /*transaction_options*/,
-    std::string const& /*table*/, KeySet const& /*keys*/,
-    std::vector<std::string> const& /*columns*/,
-    ReadOptions const& /*read_options*/) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
+    Transaction::SingleUseOptions transaction_options, std::string table,
+    KeySet keys, std::vector<std::string> columns, ReadOptions read_options) {
+  return conn_->Read(
+      {internal::MakeSingleUseTransaction(std::move(transaction_options)),
+       std::move(table), std::move(keys), std::move(columns),
+       std::move(read_options)});
 }
 
-StatusOr<ResultSet> Client::Read(Transaction const& /*transaction*/,
-                                 std::string const& /*table*/,
-                                 KeySet const& /*keys*/,
-                                 std::vector<std::string> const& /*columns*/,
-                                 ReadOptions const& /*read_options*/) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
+StatusOr<ResultSet> Client::Read(Transaction transaction, std::string table,
+                                 KeySet keys, std::vector<std::string> columns,
+                                 ReadOptions read_options) {
+  return conn_->Read({std::move(transaction), std::move(table), std::move(keys),
+                      std::move(columns), std::move(read_options)});
 }
 
 StatusOr<ResultSet> Client::Read(SqlPartition const& /*partition*/) {
@@ -59,19 +61,22 @@ StatusOr<std::vector<SqlPartition>> Client::PartitionRead(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StatusOr<ResultSet> Client::ExecuteSql(SqlStatement const& /*statement*/) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
+StatusOr<ResultSet> Client::ExecuteSql(SqlStatement statement) {
+  return conn_->ExecuteSql(
+      {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
+       std::move(statement)});
 }
 
 StatusOr<ResultSet> Client::ExecuteSql(
-    Transaction::SingleUseOptions const& /*transaction_options*/,
-    SqlStatement const& /*statement*/) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
+    Transaction::SingleUseOptions transaction_options, SqlStatement statement) {
+  return conn_->ExecuteSql(
+      {internal::MakeSingleUseTransaction(std::move(transaction_options)),
+       std::move(statement)});
 }
 
-StatusOr<ResultSet> Client::ExecuteSql(Transaction const& /*transaction*/,
-                                       SqlStatement const& /*statement*/) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
+StatusOr<ResultSet> Client::ExecuteSql(Transaction transaction,
+                                       SqlStatement statement) {
+  return conn_->ExecuteSql({std::move(transaction), std::move(statement)});
 }
 
 StatusOr<ResultSet> Client::ExecuteSql(SqlPartition const& /* partition */) {

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CLIENT_H_
 
-#include "google/cloud/spanner/client_options.h"  // XXX(salty)
+#include "google/cloud/spanner/client_options.h"
 #include "google/cloud/spanner/commit_result.h"
 #include "google/cloud/spanner/connection.h"
 #include "google/cloud/spanner/keys.h"

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CLIENT_H_
 
+#include "google/cloud/spanner/client_options.h"  // XXX(salty)
 #include "google/cloud/spanner/commit_result.h"
 #include "google/cloud/spanner/connection.h"
 #include "google/cloud/spanner/keys.h"
@@ -36,25 +37,6 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-
-/// Options passed to `Read` or `PartitionRead`.
-struct ReadOptions {
-  /**
-   * If non-empty, the name of an index on a database table. This index is used
-   * instead of the table primary key when interpreting the `KeySet`and sorting
-   * result rows.
-   */
-  std::string index_name;
-
-  /**
-   * Limit on the number of rows to yield, or 0 for no limit.
-   * A limit cannot be specified when calling`PartitionRead`.
-   */
-  std::int64_t limit = 0;
-};
-
-/// Options passed to `PartitionRead` or `PartitionQuery`
-using PartitionOptions = google::spanner::v1::PartitionOptions;
 
 /**
  * Performs database client operations on Spanner.
@@ -91,7 +73,7 @@ using PartitionOptions = google::spanner::v1::PartitionOptions;
  *
  * auto db = cs::MakeDatabaseName("my_project", "my_instance", "my_db_id"));
  * auto conn = cs::MakeConnection(std::move(db));
- * auto client = cs::Client(conn);(
+ * auto client = cs::Client(conn);
  *
  * StatusOr<cs::ResultSet> result = client.Read(...);
  * if (!result) {
@@ -158,29 +140,27 @@ class Client {
    *     No individual row in the `ResultSet` can exceed 100 MiB, and no column
    *     value can exceed 10 MiB.
    */
-  StatusOr<ResultSet> Read(std::string const& table, KeySet const& keys,
-                           std::vector<std::string> const& columns,
-                           ReadOptions const& read_options = {});
+  StatusOr<ResultSet> Read(std::string table, KeySet keys,
+                           std::vector<std::string> columns,
+                           ReadOptions read_options = {});
   /**
    * @copydoc Read
    *
    * @param transaction_options Execute this read in a single-use transaction
    * with these options.
    */
-  StatusOr<ResultSet> Read(
-      Transaction::SingleUseOptions const& transaction_options,
-      std::string const& table, KeySet const& keys,
-      std::vector<std::string> const& columns,
-      ReadOptions const& read_options = {});
+  StatusOr<ResultSet> Read(Transaction::SingleUseOptions transaction_options,
+                           std::string table, KeySet keys,
+                           std::vector<std::string> columns,
+                           ReadOptions read_options = {});
   /**
    * @copydoc Read
    *
    * @param transaction Execute this read as part of an existing transaction.
    */
-  StatusOr<ResultSet> Read(Transaction const& transaction,
-                           std::string const& table, KeySet const& keys,
-                           std::vector<std::string> const& columns,
-                           ReadOptions const& read_options = {});
+  StatusOr<ResultSet> Read(Transaction transaction, std::string table,
+                           KeySet keys, std::vector<std::string> columns,
+                           ReadOptions read_options = {});
   //@}
 
   /**
@@ -249,25 +229,25 @@ class Client {
    *     No individual row in the `ResultSet` can exceed 100 MiB, and no column
    *     value can exceed 10 MiB.
    */
-  StatusOr<ResultSet> ExecuteSql(SqlStatement const& statement);
+  StatusOr<ResultSet> ExecuteSql(SqlStatement statement);
 
   /**
-   * @copydoc ExecuteSql(SqlStatement const&)
+   * @copydoc ExecuteSql(SqlStatement)
    *
    * @param transaction_options Execute this query in a single-use transaction
    *     with these options.
    */
   StatusOr<ResultSet> ExecuteSql(
-      Transaction::SingleUseOptions const& transaction_options,
-      SqlStatement const& statement);
+      Transaction::SingleUseOptions transaction_options,
+      SqlStatement statement);
 
   /**
-   * @copydoc ExecuteSql(SqlStatement const&)
+   * @copydoc ExecuteSql(SqlStatement)
    *
    * @param transaction Execute this query as part of an existing transaction.
    */
-  StatusOr<ResultSet> ExecuteSql(Transaction const& transaction,
-                                 SqlStatement const& statement);
+  StatusOr<ResultSet> ExecuteSql(Transaction transaction,
+                                 SqlStatement statement);
   //@}
 
   /**

--- a/google/cloud/spanner/client_options.h
+++ b/google/cloud/spanner/client_options.h
@@ -57,9 +57,7 @@ class ClientOptions {
   std::string admin_endpoint_;
 };
 
-// XXX(salty) where to put these???
-
-/// Options passed to `Read` or `PartitionRead`.
+/// Options passed to `Client::Read` or `Client::PartitionRead`.
 struct ReadOptions {
   /**
    * If non-empty, the name of an index on a database table. This index is used
@@ -75,7 +73,7 @@ struct ReadOptions {
   std::int64_t limit = 0;
 };
 
-/// Options passed to `PartitionRead` or `PartitionQuery`
+/// Options passed to `Client::PartitionRead` or `Client::PartitionQuery`
 using PartitionOptions = google::spanner::v1::PartitionOptions;
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/client_options.h
+++ b/google/cloud/spanner/client_options.h
@@ -18,7 +18,10 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
+#include <google/spanner/v1/spanner.pb.h>
 #include <grpcpp/grpcpp.h>
+#include <cstdint>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -53,6 +56,27 @@ class ClientOptions {
   std::shared_ptr<grpc::ChannelCredentials> credentials_;
   std::string admin_endpoint_;
 };
+
+// XXX(salty) where to put these???
+
+/// Options passed to `Read` or `PartitionRead`.
+struct ReadOptions {
+  /**
+   * If non-empty, the name of an index on a database table. This index is used
+   * instead of the table primary key when interpreting the `KeySet`and sorting
+   * result rows.
+   */
+  std::string index_name;
+
+  /**
+   * Limit on the number of rows to yield, or 0 for no limit.
+   * A limit cannot be specified when calling`PartitionRead`.
+   */
+  std::int64_t limit = 0;
+};
+
+/// Options passed to `PartitionRead` or `PartitionQuery`
+using PartitionOptions = google::spanner::v1::PartitionOptions;
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -43,7 +43,6 @@ using ::testing::Return;
 
 class MockConnection : public Connection {
  public:
-  ~MockConnection() override = default;
   MOCK_METHOD1(Read, StatusOr<ResultSet>(ReadParams));
   MOCK_METHOD1(ExecuteSql, StatusOr<ResultSet>(ExecuteSqlParams));
   MOCK_METHOD1(Commit, StatusOr<CommitResult>(CommitParams));
@@ -52,7 +51,6 @@ class MockConnection : public Connection {
 
 class MockResultSetSource : public internal::ResultSetSource {
  public:
-  ~MockResultSetSource() override = default;
   MOCK_METHOD0(NextValue, StatusOr<optional<Value>>());
   MOCK_METHOD0(Metadata, optional<spanner_proto::ResultSetMetadata>());
   MOCK_METHOD0(Stats, optional<spanner_proto::ResultSetStats>());

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -89,15 +89,20 @@ TEST(ClientTest, ReadSuccess) {
 
   auto source = make_unique<MockResultSetSource>();
   spanner_proto::ResultSetMetadata metadata;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    row_type: {
-      fields: [
-        { name: "Name", type: { code: INT64 } },
-        { name: "Id", type: { code: INT64 } }
-      ]
-    }
-  )""",
-                                          &metadata));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        row_type: {
+          fields: {
+            name: "Name",
+            type: { code: INT64 }
+          }
+          fields: {
+            name: "Id",
+            type: { code: INT64 }
+          }
+        }
+      )pb",
+      &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, Stats())
       .WillRepeatedly(Return(optional<spanner_proto::ResultSetStats>()));
@@ -134,9 +139,16 @@ TEST(ClientTest, ReadFailure) {
 
   auto source = make_unique<MockResultSetSource>();
   spanner_proto::ResultSetMetadata metadata;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    row_type: { fields: [ { name: "Name", type: { code: INT64 } } ] })""",
-                                          &metadata));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        row_type: {
+          fields: {
+            name: "Name",
+            type: { code: INT64 }
+          }
+        }
+      )pb",
+      &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, Stats())
       .WillRepeatedly(Return(optional<spanner_proto::ResultSetStats>()));
@@ -174,15 +186,20 @@ TEST(ClientTest, ExecuteSqlSuccess) {
 
   auto source = make_unique<MockResultSetSource>();
   spanner_proto::ResultSetMetadata metadata;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    row_type: {
-      fields: [
-        { name: "Name", type: { code: INT64 } },
-        { name: "Id", type: { code: INT64 } }
-      ]
-    }
-  )""",
-                                          &metadata));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        row_type: {
+          fields: {
+            name: "Name",
+            type: { code: INT64 }
+          }
+          fields: {
+            name: "Id",
+            type: { code: INT64 }
+          }
+        }
+      )pb",
+      &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, Stats())
       .WillRepeatedly(Return(optional<spanner_proto::ResultSetStats>()));
@@ -220,9 +237,16 @@ TEST(ClientTest, ExecuteSqlFailure) {
 
   auto source = make_unique<MockResultSetSource>();
   spanner_proto::ResultSetMetadata metadata;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"""(
-    row_type: { fields: [ { name: "Name", type: { code: INT64 } } ] })""",
-                                          &metadata));
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        row_type: {
+          fields: {
+            name: "Name",
+            type: { code: INT64 }
+          }
+        }
+      )pb",
+      &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, Stats())
       .WillRepeatedly(Return(optional<spanner_proto::ResultSetStats>()));

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -32,7 +32,8 @@ using ::testing::Return;
 class MockConnection : public Connection {
  public:
   ~MockConnection() override = default;
-
+  MOCK_METHOD1(Read, StatusOr<ResultSet>(ReadParams));
+  MOCK_METHOD1(ExecuteSql, StatusOr<ResultSet>(ExecuteSqlParams));
   MOCK_METHOD1(Commit, StatusOr<CommitResult>(CommitParams));
   MOCK_METHOD1(Rollback, Status(RollbackParams));
 };
@@ -60,6 +61,11 @@ TEST(ClientTest, CopyAndMove) {
   // Move assignment
   c1 = std::move(c4);
   EXPECT_EQ(c1, c2);
+}
+
+TEST(ClientTest, ReadSuccess) {
+  auto conn = std::make_shared<MockConnection>();
+  Client client(conn);
 }
 
 TEST(ClientTest, CommitSuccess) {

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_H_
 
-#include "google/cloud/spanner/client_options.h"  // XXX(salty)
+#include "google/cloud/spanner/client_options.h"
 #include "google/cloud/spanner/commit_result.h"
 #include "google/cloud/spanner/keys.h"
 #include "google/cloud/spanner/mutations.h"

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -15,11 +15,16 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_H_
 
+#include "google/cloud/spanner/client_options.h"  // XXX(salty)
 #include "google/cloud/spanner/commit_result.h"
+#include "google/cloud/spanner/keys.h"
 #include "google/cloud/spanner/mutations.h"
+#include "google/cloud/spanner/result_set.h"
+#include "google/cloud/spanner/sql_statement.h"
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
+#include <string>
 #include <vector>
 
 namespace google {
@@ -42,6 +47,21 @@ inline namespace SPANNER_CLIENT_NS {
 class Connection {
  public:
   virtual ~Connection() = default;
+
+  struct ReadParams {
+    Transaction transaction;
+    std::string table;
+    KeySet keys;
+    std::vector<std::string> columns;
+    ReadOptions read_options;
+  };
+  virtual StatusOr<ResultSet> Read(ReadParams) = 0;
+
+  struct ExecuteSqlParams {
+    Transaction transaction;
+    SqlStatement statement;
+  };
+  virtual StatusOr<ResultSet> ExecuteSql(ExecuteSqlParams) = 0;
 
   /**
    * Commits a transaction.

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -85,11 +85,7 @@ StatusOr<ResultSet> ConnectionImpl::Read(spanner_proto::TransactionSelector& s,
   for (auto&& column : rp.columns) {
     request.add_columns(std::move(column));
   }
-  spanner_proto::KeySet* key_set = request.mutable_key_set();
-  // TODO(#202) update this when the final KeySet is implemented.
-  if (rp.keys.IsAll()) {
-    key_set->set_all(true);
-  }
+  *request.mutable_key_set() = internal::ToProto(std::move(rp.keys));
   request.set_limit(rp.read_options.limit);
 
   grpc::ClientContext context;

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -40,6 +40,8 @@ class ConnectionImpl : public Connection {
                           std::shared_ptr<internal::SpannerStub> stub)
       : database_(std::move(database)), stub_(std::move(stub)) {}
 
+  StatusOr<ResultSet> Read(ReadParams) override;
+  StatusOr<ResultSet> ExecuteSql(ExecuteSqlParams) override;
   StatusOr<CommitResult> Commit(CommitParams) override;
   Status Rollback(RollbackParams) override;
 
@@ -59,11 +61,18 @@ class ConnectionImpl : public Connection {
   friend class SessionHolder;
   StatusOr<SessionHolder> GetSession();
 
+  /// Implementation details for Read.
+  StatusOr<ResultSet> Read(google::spanner::v1::TransactionSelector& s,
+                           ReadParams rp);
+
+  /// Implementation details for ExecuteSql
+  StatusOr<ResultSet> ExecuteSql(google::spanner::v1::TransactionSelector& s,
+                                 ExecuteSqlParams const& esp);
+
   /// Implementation details for Commit.
   StatusOr<CommitResult> Commit(google::spanner::v1::TransactionSelector& s,
-                                std::vector<Mutation> mutations);
+                                CommitParams cp);
 
-  /// Implementation details for Rollback.
   Status Rollback(google::spanner::v1::TransactionSelector& s);
 
   std::string database_;

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -20,6 +20,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -67,7 +68,7 @@ class ConnectionImpl : public Connection {
 
   /// Implementation details for ExecuteSql
   StatusOr<ResultSet> ExecuteSql(google::spanner::v1::TransactionSelector& s,
-                                 ExecuteSqlParams const& esp);
+                                 std::int64_t seqno, ExecuteSqlParams esp);
 
   /// Implementation details for Commit.
   StatusOr<CommitResult> Commit(google::spanner::v1::TransactionSelector& s,

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -72,8 +72,9 @@ class ConnectionImpl : public Connection {
 
   /// Implementation details for Commit.
   StatusOr<CommitResult> Commit(google::spanner::v1::TransactionSelector& s,
-                                CommitParams cp);
+                                std::vector<Mutation> mutations);
 
+  /// Implementation details for Rollback.
   Status Rollback(google::spanner::v1::TransactionSelector& s);
 
   std::string database_;

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -313,8 +313,6 @@ class KeySet {
   std::vector<ValueRow> key_values_;
   std::vector<ValueKeyRange> key_ranges_;
   bool all_ = false;
-  // TODO(#202) this prevents performance-move-const-arg warnings
-  std::string dummy_;
 };
 
 /**

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -313,6 +313,8 @@ class KeySet {
   std::vector<ValueRow> key_values_;
   std::vector<ValueKeyRange> key_ranges_;
   bool all_ = false;
+  // TODO(#202) this prevents performance-move-const-arg warnings
+  std::string dummy_;
 };
 
 /**


### PR DESCRIPTION
I'm still planning to add more tests, but this has basic unit tests for `Read` and `ExecuteSql` and I believe the implementation of both is complete. I think it would also be valuable to get some samples and integration tests written, which is blocked by checking this in.

Fixes #283 
Fixes #285 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/350)
<!-- Reviewable:end -->
