### PR TITLE
Misc small cleanups in client/connection:

### DIFF
--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -334,7 +334,7 @@ class Client {
    * `ABORTED`, the caller should re-attempt the transaction from the beginning,
    * re-using the same session.
    *
-   * @warning Read-only transactions are not permitted to call `Commit`.
+   * @warning It is an error to call `Commit` with a read-only `transaction`.
    *
    * @param transaction The transaction to commit.
    * @param mutations The mutations to be executed when this transaction
@@ -355,7 +355,7 @@ class Client {
    * that includes  one or more `Read` or `ExecuteSql` requests and ultimately
    * decides not to commit.
    *
-   * @warning Read-only transactions are not permitted to call `Rollback`.
+   * @warning It is an error to call `Rollback` with a read-only `transaction`.
    *
    * @param transaction The transaction to roll back.
    *

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -326,13 +326,15 @@ class Client {
   StatusOr<std::int64_t> ExecutePartitionedDml(SqlStatement const& statement);
 
   /**
-   * Commits a transaction.
+   * Commits a read-write transaction.
    *
    * The commit might return an `ABORTED` error. This can occur at any time;
    * commonly, the cause is conflicts with concurrent transactions. However, it
    * can also happen for a variety of other reasons. If `Commit` returns
    * `ABORTED`, the caller should re-attempt the transaction from the beginning,
    * re-using the same session.
+   *
+   * @warning Read-only transactions are not permitted to call `Commit`.
    *
    * @param transaction The transaction to commit.
    * @param mutations The mutations to be executed when this transaction
@@ -346,9 +348,14 @@ class Client {
                                 std::vector<Mutation> mutations);
 
   /**
-   * Rolls back a transaction, releasing any locks it holds. It is a good idea
-   * to call this for any transaction that includes one or more `Read` or
-   * `ExecuteSql` requests and ultimately decides not to commit.
+   * Rolls back a read-write transaction, releasing any locks it holds.
+   *
+   * At any time before `Commit`, the client can call `Rollback` to abort the
+   * transaction. It is a good idea to call this for any read-write transaction
+   * that includes  one or more `Read` or `ExecuteSql` requests and ultimately
+   * decides not to commit.
+   *
+   * @warning Read-only transactions are not permitted to call `Rollback`.
    *
    * @param transaction The transaction to roll back.
    *

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -63,28 +63,12 @@ class Connection {
   };
   virtual StatusOr<ResultSet> ExecuteSql(ExecuteSqlParams) = 0;
 
-  /**
-   * Commits a transaction.
-   *
-   * The commit might return an `ABORTED` error. This can occur at any time;
-   * commonly, the cause is conflicts with concurrent transactions. However, it
-   * can also happen for a variety of other reasons. If `Commit` returns
-   * `ABORTED`, the caller should re-attempt the transaction from the beginning,
-   * re-using the same session.
-   */
   struct CommitParams {
     Transaction transaction;
     std::vector<Mutation> mutations;
   };
   virtual StatusOr<CommitResult> Commit(CommitParams) = 0;
 
-  /**
-   * Rollback a read-write transaction.
-   *
-   * At any time before `Commit`, the client can send a `Rollback` request
-   * to abort the transaction. (Read-only transactions do not need to call
-   * `Commit` or `Rollback`. In fact, they are not permitted to do so).
-   */
   struct RollbackParams {
     Transaction transaction;
   };

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -30,9 +30,11 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-// A concrete `Connection` subclass that uses gRPC to actually talk to a real
-// Spanner instance. See `MakeConnection()` for a factory function that creates
-// and returns instances of this class.
+/**
+ * A concrete `Connection` subclass that uses gRPC to actually talk to a real
+ * Spanner instance. See `MakeConnection()` for a factory function that creates
+ * and returns instances of this class.
+ */
 class ConnectionImpl : public Connection {
  public:
   // Creates a ConnectionImpl that will talk to the specified `database` using
@@ -41,10 +43,10 @@ class ConnectionImpl : public Connection {
                           std::shared_ptr<internal::SpannerStub> stub)
       : database_(std::move(database)), stub_(std::move(stub)) {}
 
-  StatusOr<ResultSet> Read(ReadParams) override;
-  StatusOr<ResultSet> ExecuteSql(ExecuteSqlParams) override;
-  StatusOr<CommitResult> Commit(CommitParams) override;
-  Status Rollback(RollbackParams) override;
+  StatusOr<ResultSet> Read(ReadParams rp) override;
+  StatusOr<ResultSet> ExecuteSql(ExecuteSqlParams esp) override;
+  StatusOr<CommitResult> Commit(CommitParams cp) override;
+  Status Rollback(RollbackParams rp) override;
 
  private:
   class SessionHolder {
@@ -72,7 +74,7 @@ class ConnectionImpl : public Connection {
 
   /// Implementation details for Commit.
   StatusOr<CommitResult> Commit(google::spanner::v1::TransactionSelector& s,
-                                std::vector<Mutation> mutations);
+                                CommitParams cp);
 
   /// Implementation details for Rollback.
   Status Rollback(google::spanner::v1::TransactionSelector& s);


### PR DESCRIPTION
These were discussed while reviewing other PRs and/or in chat:

- Remove comments from `connection.h` in favor of `client.h` and merge the two versions of the `Rollback` comment into one.
- Add a comment about RW vs RO transactions to `Commit`.
- Remove some unnecessary namespace qualifiers.
- Change `ConnectionImpl::Commit` to take `CommitParams` for consistency.
- Add parameter names in `ConnectionImpl` methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/352)
<!-- Reviewable:end -->
