### PR TITLE
bug: Fix crashes in Client::Read and Client::ExecuteSql.

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/internal/connection_impl.h"
 #include "google/cloud/spanner/internal/partial_result_set_reader.h"
 #include "google/cloud/spanner/internal/time.h"
+#include "google/cloud/internal/make_unique.h"
 #include <google/spanner/v1/spanner.pb.h>
 
 namespace google {
@@ -88,9 +89,10 @@ StatusOr<ResultSet> ConnectionImpl::Read(spanner_proto::TransactionSelector& s,
   *request.mutable_key_set() = internal::ToProto(std::move(rp.keys));
   request.set_limit(rp.read_options.limit);
 
-  grpc::ClientContext context;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  auto rpc = stub_->StreamingRead(*context, request);
   auto reader = internal::PartialResultSetReader::Create(
-      stub_->StreamingRead(context, request));
+      std::move(context), std::move(rpc));
   if (!reader.ok()) {
     return std::move(reader).status();
   }
@@ -123,9 +125,10 @@ StatusOr<ResultSet> ConnectionImpl::ExecuteSql(
       std::move(*sql_statement.mutable_param_types());
   request.set_seqno(seqno);
 
-  grpc::ClientContext context;
+  auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
+  auto rpc = stub_->ExecuteStreamingSql(*context, request);
   auto reader = internal::PartialResultSetReader::Create(
-      stub_->ExecuteStreamingSql(context, request));
+      std::move(context), std::move(rpc));
   if (!reader.ok()) {
     return std::move(reader).status();
   }

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -91,8 +91,8 @@ StatusOr<ResultSet> ConnectionImpl::Read(spanner_proto::TransactionSelector& s,
 
   auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
   auto rpc = stub_->StreamingRead(*context, request);
-  auto reader = internal::PartialResultSetReader::Create(
-      std::move(context), std::move(rpc));
+  auto reader = internal::PartialResultSetReader::Create(std::move(context),
+                                                         std::move(rpc));
   if (!reader.ok()) {
     return std::move(reader).status();
   }
@@ -127,8 +127,8 @@ StatusOr<ResultSet> ConnectionImpl::ExecuteSql(
 
   auto context = google::cloud::internal::make_unique<grpc::ClientContext>();
   auto rpc = stub_->ExecuteStreamingSql(*context, request);
-  auto reader = internal::PartialResultSetReader::Create(
-      std::move(context), std::move(rpc));
+  auto reader = internal::PartialResultSetReader::Create(std::move(context),
+                                                         std::move(rpc));
   if (!reader.ok()) {
     return std::move(reader).status();
   }

--- a/google/cloud/spanner/internal/partial_result_set_reader.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader.cc
@@ -23,9 +23,10 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
 StatusOr<std::unique_ptr<PartialResultSetReader>>
-PartialResultSetReader::Create(std::unique_ptr<GrpcReader> grpc_reader) {
+PartialResultSetReader::Create(std::unique_ptr<grpc::ClientContext> context,
+    std::unique_ptr<GrpcReader> grpc_reader) {
   std::unique_ptr<PartialResultSetReader> reader(
-      new PartialResultSetReader(std::move(grpc_reader)));
+      new PartialResultSetReader(std::move(context), std::move(grpc_reader)));
 
   // Do the first read so the metadata is immediately available.
   auto status = reader->ReadFromStream();

--- a/google/cloud/spanner/internal/partial_result_set_reader.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader.cc
@@ -24,7 +24,7 @@ namespace internal {
 
 StatusOr<std::unique_ptr<PartialResultSetReader>>
 PartialResultSetReader::Create(std::unique_ptr<grpc::ClientContext> context,
-    std::unique_ptr<GrpcReader> grpc_reader) {
+                               std::unique_ptr<GrpcReader> grpc_reader) {
   std::unique_ptr<PartialResultSetReader> reader(
       new PartialResultSetReader(std::move(context), std::move(grpc_reader)));
 

--- a/google/cloud/spanner/internal/partial_result_set_reader.h
+++ b/google/cloud/spanner/internal/partial_result_set_reader.h
@@ -43,6 +43,7 @@ class PartialResultSetReader : public internal::ResultSetSource {
 
   /// Factory method to create a PartialResultSetReader.
   static StatusOr<std::unique_ptr<PartialResultSetReader>> Create(
+      std::unique_ptr<grpc::ClientContext> context,
       std::unique_ptr<GrpcReader> grpc_reader);
   ~PartialResultSetReader() override;
 
@@ -55,11 +56,13 @@ class PartialResultSetReader : public internal::ResultSetSource {
   }
 
  private:
-  PartialResultSetReader(std::unique_ptr<GrpcReader> grpc_reader)
-      : grpc_reader_(std::move(grpc_reader)) {}
+  PartialResultSetReader(std::unique_ptr<grpc::ClientContext> context,
+                         std::unique_ptr<GrpcReader> grpc_reader)
+      : context_(std::move(context)), grpc_reader_(std::move(grpc_reader)) {}
 
   Status ReadFromStream();
 
+  std::unique_ptr<grpc::ClientContext> context_;
   std::unique_ptr<GrpcReader> grpc_reader_;
 
   google::protobuf::RepeatedPtrField<google::protobuf::Value> values_;


### PR DESCRIPTION
In gRPC the `grpc::ClientContext` used for a streaming RPC must
have a lifetime at least as long as the RPC does.  The client context
is used to store any metadata headers (potentially) returned by the
server, and those are not updated until the `Finish()` call.

Because `grpc::ClientContext` disallows copying and moves, we need
to wrap it in a `std::unique_ptr`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/353)
<!-- Reviewable:end -->
