### PR TITLE
chore: Small style cleanup to keys.h

### DIFF
--- a/google/cloud/spanner/keys.cc
+++ b/google/cloud/spanner/keys.cc
@@ -44,13 +44,13 @@ namespace internal {
     google::spanner::v1::KeyRange kr;
     auto& start = range.mutable_start();
     auto& end = range.mutable_end();
-    if (start.mode() == KeySet::ValueBound::Mode::MODE_CLOSED) {
+    if (start.mode() == KeySet::ValueBound::Mode::kClosed) {
       *kr.mutable_start_closed() = make_key(std::move(start.mutable_key()));
     } else {
       *kr.mutable_start_open() = make_key(std::move(start.mutable_key()));
     }
 
-    if (end.mode() == KeySet::ValueBound::Mode::MODE_CLOSED) {
+    if (end.mode() == KeySet::ValueBound::Mode::kClosed) {
       *kr.mutable_end_closed() = make_key(std::move(end.mutable_key()));
     } else {
       *kr.mutable_end_open() = make_key(std::move(end.mutable_key()));

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -64,12 +64,12 @@ class Bound {
   /**
    * Constructs a closed `Bound` with a default constructed key of `KeyType`.
    */
-  Bound() : Bound(RowType(), Mode::MODE_CLOSED) {}
+  Bound() : Bound(RowType(), Mode::kClosed) {}
   /**
    * Constructs a closed `Bound` with the provided key.
    * @param key spanner::Row<Types...>
    */
-  explicit Bound(RowType key) : Bound(std::move(key), Mode::MODE_CLOSED) {}
+  explicit Bound(RowType key) : Bound(std::move(key), Mode::kClosed) {}
 
   // Copy and move constructors and assignment operators.
   Bound(Bound const& key_range) = default;
@@ -78,8 +78,8 @@ class Bound {
   Bound& operator=(Bound&& rhs) = default;
 
   RowType const& key() const { return key_; }
-  bool IsClosed() const { return mode_ == Mode::MODE_CLOSED; }
-  bool IsOpen() const { return mode_ == Mode::MODE_OPEN; }
+  bool IsClosed() const { return mode_ == Mode::kClosed; }
+  bool IsOpen() const { return mode_ == Mode::kOpen; }
 
   friend bool operator==(Bound const& lhs, Bound const& rhs) {
     return lhs.key_ == rhs.key_ && lhs.mode_ == rhs.mode_;
@@ -89,7 +89,7 @@ class Bound {
   }
 
  private:
-  enum class Mode { MODE_CLOSED, MODE_OPEN };
+  enum class Mode { kClosed, kOpen };
 
   Bound(RowType key, Mode mode) : key_(std::move(key)), mode_(mode) {}
 
@@ -117,7 +117,7 @@ class Bound {
  */
 template <typename RowType>
 Bound<RowType> MakeBoundClosed(RowType key) {
-  return Bound<RowType>(std::move(key), Bound<RowType>::Mode::MODE_CLOSED);
+  return Bound<RowType>(std::move(key), Bound<RowType>::Mode::kClosed);
 }
 
 /**
@@ -130,7 +130,7 @@ Bound<RowType> MakeBoundClosed(RowType key) {
  */
 template <typename RowType>
 Bound<RowType> MakeBoundOpen(RowType key) {
-  return Bound<RowType>(std::move(key), Bound<RowType>::Mode::MODE_OPEN);
+  return Bound<RowType>(std::move(key), Bound<RowType>::Mode::kOpen);
 }
 
 /**
@@ -199,8 +199,8 @@ class KeyRange {
 template <typename RowType>
 KeyRange<RowType> MakeKeyRange(RowType start, RowType end) {
   return KeyRange<RowType>(
-      Bound<RowType>(std::move(start), Bound<RowType>::Mode::MODE_CLOSED),
-      Bound<RowType>(std::move(end), Bound<RowType>::Mode::MODE_CLOSED));
+      Bound<RowType>(std::move(start), Bound<RowType>::Mode::kClosed),
+      Bound<RowType>(std::move(end), Bound<RowType>::Mode::kClosed));
 }
 
 /**
@@ -252,11 +252,11 @@ class KeySet {
     for (auto const& range : builder.key_ranges()) {
       key_ranges_.push_back(ValueKeyRange(
           ValueBound(ValueRow(range.start().key().values()),
-                     range.start().IsClosed() ? ValueBound::Mode::MODE_CLOSED
-                                              : ValueBound::Mode::MODE_OPEN),
+                     range.start().IsClosed() ? ValueBound::Mode::kClosed
+                                              : ValueBound::Mode::kOpen),
           ValueBound(ValueRow(range.end().key().values()),
-                     range.end().IsClosed() ? ValueBound::Mode::MODE_CLOSED
-                                            : ValueBound::Mode::MODE_OPEN)));
+                     range.end().IsClosed() ? ValueBound::Mode::kClosed
+                                            : ValueBound::Mode::kOpen)));
     }
   }
 
@@ -285,7 +285,7 @@ class KeySet {
 
   class ValueBound {
    public:
-    enum class Mode { MODE_CLOSED, MODE_OPEN };
+    enum class Mode { kClosed, kOpen };
     explicit ValueBound(ValueRow key, ValueBound::Mode mode)
         : key_(std::move(key)), mode_(mode) {}
 

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -337,19 +337,20 @@ class KeySet {
  * // EmployeeTable has a primary key on EmployeeID.
  * using EmployeeTablePrimaryKey = Row<std::int64_t>;
  *
- * // A KeySet where EmployeeID >= 1 and EmployeeID < 10.
+ * // A KeySet where EmployeeID >= 1 and EmployeeID <= 10.
  * auto first_ten_employees =
- *   KeySetBuilder<EmployeeTablePrimaryKey>(
- *     MakeKeyRangeBoundClosed(MakeRow(1)),
- *     MakeKeyRangeBoundOpen(MakeRow(10)));
+ *   KeySetBuilder<EmployeeTablePrimaryKey>()
+ *       .Add(MakeKeyRange(MakeRow(1), MakeRow(10))
+ *       .Build();
  *
  * // EmployeeTable also has an index on LastName, FirstName.
  * using EmployeeNameKey = Row<std::string, std::string>;
  *
  * // A KeySet where LastName, FirstName is ("Smith", "John").
  * auto all_employees_named_john_smith =
- *   KeySetBuilder<EmployeeNameKey>(MakeRow("Smith", "John"));
- *
+ *   KeySetBuilder<EmployeeNameKey>()
+ *       .Add(MakeRow("Smith", "John")))
+ *       .Build();
  * @endcode
  */
 template <typename RowType>

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -28,9 +28,8 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+
 class KeySet;
-template <typename RowType>
-class KeyRange;
 template <typename RowType>
 class KeySetBuilder;
 
@@ -99,9 +98,6 @@ class Bound {
   template <typename T>
   friend Bound<T> MakeBoundOpen(T key);
 
-  template <typename T>
-  friend KeyRange<T> MakeKeyRange(T start, T end);
-
   RowType key_;
   Mode mode_;
 };
@@ -162,8 +158,8 @@ class KeyRange {
    * Constructs a `KeyRange` closed on both `Bound`s.
    */
   explicit KeyRange(RowType start, RowType end)
-      : KeyRange(std::move(Bound<RowType>(start)),
-                 std::move(Bound<RowType>(end))) {}
+      : KeyRange(MakeBoundClosed(std::move(start)),
+                 MakeBoundClosed(std::move(end))) {}
 
   // Copy and move constructors and assignment operators.
   KeyRange(KeyRange const& key_range) = default;
@@ -198,9 +194,8 @@ class KeyRange {
  */
 template <typename RowType>
 KeyRange<RowType> MakeKeyRange(RowType start, RowType end) {
-  return KeyRange<RowType>(
-      Bound<RowType>(std::move(start), Bound<RowType>::Mode::kClosed),
-      Bound<RowType>(std::move(end), Bound<RowType>::Mode::kClosed));
+  return MakeKeyRange(MakeBoundClosed(std::move(start)),
+                      MakeBoundClosed(std::move(end)));
 }
 
 /**


### PR DESCRIPTION
A few small cleanups to `keys.h`

* Renamed enum from MACRO_STYLE to kConstant style, per the style guide.

* Use some existing factory functions and removed the need for some friendships.

* Tweak to `KeySetBuilder` docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/354)
<!-- Reviewable:end -->
