### PR TITLE
chore: Use KeySet proto as type-erased storage

### DIFF
--- a/google/cloud/spanner/keys.cc
+++ b/google/cloud/spanner/keys.cc
@@ -23,43 +23,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
 ::google::spanner::v1::KeySet ToProto(KeySet keyset) {
-  ::google::spanner::v1::KeySet proto;
-  proto.set_all(keyset.IsAll());
-
-  auto make_key = [](KeySet::ValueRow key) {
-    google::protobuf::ListValue lv;
-    for (Value& v : key.mutable_column_values()) {
-      std::pair<google::spanner::v1::Type, google::protobuf::Value> p =
-          ToProto(std::move(v));
-      *lv.add_values() = std::move(p.second);
-    }
-    return lv;
-  };
-
-  for (KeySet::ValueRow& key : keyset.key_values_) {
-    *proto.add_keys() = make_key(std::move(key));
-  }
-
-  for (KeySet::ValueKeyRange& range : keyset.key_ranges_) {
-    google::spanner::v1::KeyRange kr;
-    auto& start = range.mutable_start();
-    auto& end = range.mutable_end();
-    if (start.mode() == KeySet::ValueBound::Mode::kClosed) {
-      *kr.mutable_start_closed() = make_key(std::move(start.mutable_key()));
-    } else {
-      *kr.mutable_start_open() = make_key(std::move(start.mutable_key()));
-    }
-
-    if (end.mode() == KeySet::ValueBound::Mode::kClosed) {
-      *kr.mutable_end_closed() = make_key(std::move(end.mutable_key()));
-    } else {
-      *kr.mutable_end_open() = make_key(std::move(end.mutable_key()));
-    }
-
-    *proto.add_ranges() = std::move(kr);
-  }
-
-  return proto;
+  return std::move(keyset.proto_);
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -296,7 +296,7 @@ class KeySet {
  * // A KeySet where EmployeeID >= 1 and EmployeeID <= 10.
  * auto first_ten_employees =
  *   KeySetBuilder<EmployeeTablePrimaryKey>()
- *       .Add(MakeKeyRange(MakeRow(1), MakeRow(10))
+ *       .Add(MakeKeyRange(MakeRow(1), MakeRow(10)))
  *       .Build();
  *
  * // EmployeeTable also has an index on LastName, FirstName.

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -226,7 +226,11 @@ class KeySet {
   /**
    * Returns a `KeySet` that represents the set of "All" keys for the index.
    */
-  static KeySet All() { return KeySet(true); }
+  static KeySet All() {
+    KeySet ks;
+    ks.proto_.set_all(true);
+    return ks;
+  }
 
   /**
    * Constructs an empty `KeySet`.
@@ -240,74 +244,31 @@ class KeySet {
    */
   template <typename RowType>
   explicit KeySet(KeySetBuilder<RowType> const& builder) {
-    for (auto const& key : builder.keys()) {
-      key_values_.push_back(ValueRow(key.values()));
+    for (auto& key : builder.keys()) {
+      Append(proto_.add_keys(), std::move(key).values());
     }
-
-    for (auto const& range : builder.key_ranges()) {
-      key_ranges_.push_back(ValueKeyRange(
-          ValueBound(ValueRow(range.start().key().values()),
-                     range.start().IsClosed() ? ValueBound::Mode::kClosed
-                                              : ValueBound::Mode::kOpen),
-          ValueBound(ValueRow(range.end().key().values()),
-                     range.end().IsClosed() ? ValueBound::Mode::kClosed
-                                            : ValueBound::Mode::kOpen)));
+    for (auto& range : builder.key_ranges()) {
+      auto* kr = proto_.add_ranges();
+      auto* start = range.start().IsClosed() ? kr->mutable_start_closed()
+                                             : kr->mutable_start_open();
+      Append(start, std::move(range).start().key().values());
+      auto* end = range.end().IsClosed() ? kr->mutable_end_closed()
+                                         : kr->mutable_end_open();
+      Append(end, std::move(range).end().key().values());
     }
   }
-
-  /**
-   * Does the `KeySet` represent all keys for an index.
-   */
-  bool IsAll() const { return all_; }
 
  private:
   friend ::google::spanner::v1::KeySet internal::ToProto(KeySet keyset);
 
-  explicit KeySet(bool all) : all_(all) {}
+  template <std::size_t N>
+  static void Append(google::protobuf::ListValue* lv, std::array<Value, N> a) {
+    for (auto& v : a) {
+      *lv->add_values() = internal::ToProto(std::move(v)).second;
+    }
+  }
 
-  class ValueRow {
-   public:
-    template <std::size_t N>
-    explicit ValueRow(std::array<Value, N> column_values)
-        : column_values_(std::make_move_iterator(column_values.begin()),
-                         std::make_move_iterator(column_values.end())) {}
-
-    std::vector<Value>& mutable_column_values() { return column_values_; }
-
-   private:
-    std::vector<Value> column_values_;
-  };
-
-  class ValueBound {
-   public:
-    enum class Mode { kClosed, kOpen };
-    explicit ValueBound(ValueRow key, Mode mode)
-        : key_(std::move(key)), mode_(mode) {}
-
-    ValueRow& mutable_key() { return key_; }
-    Mode mode() { return mode_; }
-
-   private:
-    ValueRow key_;
-    Mode mode_;
-  };
-
-  class ValueKeyRange {
-   public:
-    explicit ValueKeyRange(ValueBound start, ValueBound end)
-        : start_(std::move(start)), end_(std::move(end)) {}
-
-    ValueBound& mutable_start() { return start_; }
-    ValueBound& mutable_end() { return end_; }
-
-   private:
-    ValueBound start_;
-    ValueBound end_;
-  };
-
-  std::vector<ValueRow> key_values_;
-  std::vector<ValueKeyRange> key_ranges_;
-  bool all_ = false;
+  google::spanner::v1::KeySet proto_;
 };
 
 /**

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -26,13 +26,26 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 TEST(KeySetTest, NoKeys) {
+  ::google::spanner::v1::KeySet expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+      )pb",
+      &expected));
   KeySet no_keys;
-  EXPECT_FALSE(no_keys.IsAll());
+  ::google::spanner::v1::KeySet result = internal::ToProto(no_keys);
+  EXPECT_THAT(result, spanner_testing::IsProtoEqual(expected));
 }
 
 TEST(KeySetTest, AllKeys) {
+  ::google::spanner::v1::KeySet expected;
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        all: true
+      )pb",
+      &expected));
   auto all_keys = KeySet::All();
-  EXPECT_TRUE(all_keys.IsAll());
+  ::google::spanner::v1::KeySet result = internal::ToProto(all_keys);
+  EXPECT_THAT(result, spanner_testing::IsProtoEqual(expected));
 }
 
 TEST(KeyRangeTest, ConstructorBoundModeUnspecified) {


### PR DESCRIPTION
We don't need to implement our own type-erased key and range types if we
directly use the `KeySet` proto, which itself is type erased. This also
eliminates a copy/move since we ultimately need the data in proto form
anyway.

Also note that this PR removes `KeySet::IsAll()`. We could add that back, but I removed it because it's not longer needed, and we don't have any other accessors on `KeySet`, so exposing the accessor for `IsAll()` seemed odd.

I'll have an upcoming PR after this one that makes better use of "moves" so we don't copy the Values around as much. But I was trying to break up the changes into small chunks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/362)
<!-- Reviewable:end -->
