### PR TITLE
bug: PartialResultSet can have no row types.

### DIFF
--- a/google/cloud/spanner/integration_tests/mutate_and_read_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/mutate_and_read_integration_test.cc
@@ -115,9 +115,8 @@ class MutateAndReadIntegrationTest : public ::testing::Test {
         MakeConnection(MakeDatabaseName(project_id, instance_id, database_id)));
 
     auto txn = MakeReadWriteTransaction();
-    auto reader =
-        client_->ExecuteSql(txn,
-                            SqlStatement("DELETE FROM Singers WHERE true;"));
+    auto reader = client_->ExecuteSql(
+        txn, SqlStatement("DELETE FROM Singers WHERE true;"));
     EXPECT_STATUS_OK(reader);
     auto commit = client_->Commit(txn, {});
     EXPECT_STATUS_OK(commit);

--- a/google/cloud/spanner/internal/partial_result_set_reader.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader.cc
@@ -46,6 +46,10 @@ StatusOr<optional<Value>> PartialResultSetReader::NextValue() {
   if (finished_) {
     return optional<Value>();
   }
+  if (metadata_->row_type().fields().empty()) {
+    return Status(StatusCode::kInternal,
+                  "response metadata is missing row type information");
+  }
   if (next_value_index_ >= values_.size()) {
     // Ran out of buffered values - try to read some more from gRPC.
     next_value_index_ = 0;

--- a/google/cloud/spanner/internal/partial_result_set_reader.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader.cc
@@ -39,11 +39,6 @@ PartialResultSetReader::Create(std::unique_ptr<grpc::ClientContext> context,
     return Status(StatusCode::kInternal, "response contained no metadata");
   }
 
-  // The metadata must contain row type information.
-  if (reader->metadata_->row_type().fields().empty()) {
-    return Status(StatusCode::kInternal,
-                  "response metadata was missing row type information");
-  }
   return {std::move(reader)};
 }
 

--- a/google/cloud/spanner/internal/partial_result_set_reader.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader.cc
@@ -46,10 +46,6 @@ StatusOr<optional<Value>> PartialResultSetReader::NextValue() {
   if (finished_) {
     return optional<Value>();
   }
-  if (metadata_->row_type().fields().empty()) {
-    return Status(StatusCode::kInternal,
-                  "response metadata is missing row type information");
-  }
   if (next_value_index_ >= values_.size()) {
     // Ran out of buffered values - try to read some more from gRPC.
     next_value_index_ = 0;
@@ -63,6 +59,11 @@ StatusOr<optional<Value>> PartialResultSetReader::NextValue() {
     if (values_.empty()) {
       return Status(StatusCode::kInternal, "response has no values");
     }
+  }
+
+  if (metadata_->row_type().fields().empty()) {
+    return Status(StatusCode::kInternal,
+                  "response metadata is missing row type information");
   }
 
   // The metadata tells us the sequence of types for the field Values;

--- a/google/cloud/spanner/internal/partial_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader_test.cc
@@ -156,13 +156,38 @@ TEST(PartialResultSetReaderTest, MissingMetadata) {
 }
 
 /**
- * @test Verify the behavior when the received metadata does not contain row
- * type information.
+ * @test Verify the behavior when the received metadata does not contain data
+ * nor row type information.
  */
-TEST(PartialResultSetReaderTest, MissingRowType) {
+TEST(PartialResultSetReaderTest, MissingRowTypeNoData) {
   auto grpc_reader = make_unique<MockGrpcReader>();
   spanner_proto::PartialResultSet response;
   ASSERT_TRUE(TextFormat::ParseFromString(R"pb(metadata: {})pb", &response));
+  EXPECT_CALL(*grpc_reader, Read(_))
+      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
+
+  auto context = make_unique<grpc::ClientContext>();
+  auto reader = PartialResultSetReader::Create(std::move(context),
+                                               std::move(grpc_reader));
+  ASSERT_STATUS_OK(reader);
+  StatusOr<optional<Value>> value = reader.value()->NextValue();
+  EXPECT_STATUS_OK(value);
+  EXPECT_FALSE(value->has_value());
+}
+
+/**
+ * @test Verify the behavior when the received metadata contains data but not
+ * row type information.
+ */
+TEST(PartialResultSetReaderTest, MissingRowTypeWithData) {
+  auto grpc_reader = make_unique<MockGrpcReader>();
+  spanner_proto::PartialResultSet response;
+  ASSERT_TRUE(TextFormat::ParseFromString(R"pb(
+                                            metadata: {}
+                                            values: { string_value: "10" })pb",
+                                          &response));
   EXPECT_CALL(*grpc_reader, Read(_))
       .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
@@ -172,7 +197,6 @@ TEST(PartialResultSetReaderTest, MissingRowType) {
                                                std::move(grpc_reader));
   ASSERT_STATUS_OK(reader);
   StatusOr<optional<Value>> value = reader.value()->NextValue();
-  EXPECT_FALSE(value);
   EXPECT_EQ(value.status().code(), StatusCode::kInternal);
   EXPECT_THAT(value.status().message(),
               HasSubstr("missing row type information"));

--- a/google/cloud/spanner/internal/partial_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader_test.cc
@@ -170,7 +170,7 @@ TEST(PartialResultSetReaderTest, MissingRowType) {
   auto context = make_unique<grpc::ClientContext>();
   auto reader = PartialResultSetReader::Create(std::move(context),
                                                std::move(grpc_reader));
-  EXPECT_TRUE(reader.status().ok());
+  ASSERT_STATUS_OK(reader);
   StatusOr<optional<Value>> value = reader.value()->NextValue();
   EXPECT_FALSE(value);
   EXPECT_EQ(value.status().code(), StatusCode::kInternal);

--- a/google/cloud/spanner/internal/partial_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader_test.cc
@@ -155,27 +155,6 @@ TEST(PartialResultSetReaderTest, MissingMetadata) {
 }
 
 /**
- * @test Verify the behavior when the received metadata does not contain row
- * type information.
- */
-TEST(PartialResultSetReaderTest, MissingRowType) {
-  auto grpc_reader = make_unique<MockGrpcReader>();
-  spanner_proto::PartialResultSet response;
-  ASSERT_TRUE(TextFormat::ParseFromString(R"pb(metadata: {})pb", &response));
-  EXPECT_CALL(*grpc_reader, Read(_))
-      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)));
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
-
-  auto context = make_unique<grpc::ClientContext>();
-  auto reader = PartialResultSetReader::Create(std::move(context),
-                                               std::move(grpc_reader));
-  EXPECT_FALSE(reader.status().ok());
-  EXPECT_EQ(reader.status().code(), StatusCode::kInternal);
-  EXPECT_EQ(reader.status().message(),
-            "response metadata was missing row type information");
-}
-
-/**
  * @test Verify the functionality of the PartialResultSetReader, including
  * properly handling metadata, stats, and data values.
  * All of the data is returned in a single Read() from the gRPC reader.


### PR DESCRIPTION
Spanner returns no row types for DELETE and (I think) INSERT queries.

Fixes #360

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/363)
<!-- Reviewable:end -->
