### PR TITLE
feat: Remove default construction from Bound and KeyRange

### DIFF
--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -61,6 +61,9 @@ class Bound {
   static_assert(internal::IsRow<RowType>::value,
                 "KeyType must be of type spanner::Row<>.");
 
+  // Not default constructible
+  Bound() = delete;
+
   // Copy and move constructors and assignment operators.
   Bound(Bound const& key_range) = default;
   Bound& operator=(Bound const& rhs) = default;
@@ -131,24 +134,15 @@ class KeyRange {
  public:
   static_assert(internal::IsRow<RowType>::value,
                 "KeyType must be of type spanner::Row<>.");
-  /**
-   * Constructs an empty `KeyRange`.
-   */
-  KeyRange() = default;
-  ~KeyRange() = default;
+
+  // Not default constructible
+  KeyRange() = delete;
 
   /**
    * Constructs a `KeyRange` with the given `Bound`s.
    */
   explicit KeyRange(Bound<RowType> start, Bound<RowType> end)
       : start_(std::move(start)), end_(std::move(end)) {}
-
-  /**
-   * Constructs a `KeyRange` closed on both `Bound`s.
-   */
-  explicit KeyRange(RowType start, RowType end)
-      : KeyRange(MakeBoundClosed(std::move(start)),
-                 MakeBoundClosed(std::move(end))) {}
 
   // Copy and move constructors and assignment operators.
   KeyRange(KeyRange const& key_range) = default;
@@ -182,7 +176,7 @@ class KeyRange {
  * @return KeyRange<RowType>
  */
 template <typename RowType>
-KeyRange<RowType> MakeKeyRange(RowType start, RowType end) {
+KeyRange<RowType> MakeKeyRangeClosed(RowType start, RowType end) {
   return MakeKeyRange(MakeBoundClosed(std::move(start)),
                       MakeBoundClosed(std::move(end)));
 }

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -82,13 +82,15 @@ class Bound {
   }
 
  private:
+  enum class Mode { kClosed, kOpen };
+
+  Bound(RowType key, Mode mode) : key_(std::move(key)), mode_(mode) {}
+
   template <typename T>
   friend Bound<T> MakeBoundClosed(T key);
+
   template <typename T>
   friend Bound<T> MakeBoundOpen(T key);
-
-  enum class Mode { kClosed, kOpen };
-  Bound(RowType key, Mode mode) : key_(std::move(key)), mode_(mode) {}
 
   RowType key_;
   Mode mode_;

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -47,10 +47,10 @@ struct IsRow<Row<Ts...>> : std::true_type {};
  * The `Bound` class is a regular type that represents one endpoint of an
  * interval of keys.
  *
- * `Bound`s are `Closed` by default, meaning the row matching
- * the Bound will be included in the result. `Bound`s can also be
- * specified as `Open`, which will exclude the Bounds from
- * the results.
+ * `Bound`s can be "open", meaning the matching row will be excluded from the
+ * results, or "closed" meaning the matching row will be included. `Bound`
+ * instances should be created with the `MakeBoundOpen()` or
+ * `MakeBoundClosed()` factory functions.
  *
  * @tparam KeyType spanner::Row<Types...> that corresponds to the desired index
  * definition.
@@ -60,15 +60,6 @@ class Bound {
  public:
   static_assert(internal::IsRow<RowType>::value,
                 "KeyType must be of type spanner::Row<>.");
-  /**
-   * Constructs a closed `Bound` with a default constructed key of `KeyType`.
-   */
-  Bound() : Bound({}) {}
-  /**
-   * Constructs a closed `Bound` with the provided key.
-   * @param key spanner::Row<Types...>
-   */
-  explicit Bound(RowType key) : Bound(std::move(key), Mode::kClosed) {}
 
   // Copy and move constructors and assignment operators.
   Bound(Bound const& key_range) = default;
@@ -88,15 +79,13 @@ class Bound {
   }
 
  private:
-  enum class Mode { kClosed, kOpen };
-
-  Bound(RowType key, Mode mode) : key_(std::move(key)), mode_(mode) {}
-
   template <typename T>
   friend Bound<T> MakeBoundClosed(T key);
-
   template <typename T>
   friend Bound<T> MakeBoundOpen(T key);
+
+  enum class Mode { kClosed, kOpen };
+  Bound(RowType key, Mode mode) : key_(std::move(key)), mode_(mode) {}
 
   RowType key_;
   Mode mode_;

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -171,8 +171,8 @@ TEST(KeySetBuilderTest, AddKeyRangeToEmptyKeySetBuilder) {
 }
 
 TEST(KeySetBuilderTest, AddKeyRangeToNonEmptyKeySetBuilder) {
-  auto ks = KeySetBuilder<Row<std::string, std::string>>(
-      MakeKeyRangeClosed(MakeRow("start00", "start01"), MakeRow("end00", "end01")));
+  auto ks = KeySetBuilder<Row<std::string, std::string>>(MakeKeyRangeClosed(
+      MakeRow("start00", "start01"), MakeRow("end00", "end01")));
   auto range = MakeKeyRange(MakeBoundOpen(MakeRow("start10", "start11")),
                             MakeBoundOpen(MakeRow("end10", "end11")));
   ks.Add(range);
@@ -230,8 +230,8 @@ TEST(InternalKeySetTest, BuildToProtoTwoKeys) {
 }
 
 TEST(InternalKeySetTest, BuildToProtoTwoRanges) {
-  auto ksb = KeySetBuilder<Row<std::string, std::string>>(
-      MakeKeyRangeClosed(MakeRow("start00", "start01"), MakeRow("end00", "end01")));
+  auto ksb = KeySetBuilder<Row<std::string, std::string>>(MakeKeyRangeClosed(
+      MakeRow("start00", "start01"), MakeRow("end00", "end01")));
   auto range = MakeKeyRange(MakeBoundOpen(MakeRow("start10", "start11")),
                             MakeBoundOpen(MakeRow("end10", "end11")));
   ksb.Add(range);

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -52,7 +52,7 @@ TEST(KeyRangeTest, ConstructorBoundModeUnspecified) {
   std::string start_value("key0");
   std::string end_value("key1");
   KeyRange<Row<std::string>> closed_range =
-      MakeKeyRange(MakeRow(start_value), MakeRow(end_value));
+      MakeKeyRangeClosed(MakeRow(start_value), MakeRow(end_value));
 
   EXPECT_EQ(start_value, closed_range.start().key().get<0>());
   EXPECT_TRUE(closed_range.start().IsClosed());
@@ -172,11 +172,9 @@ TEST(KeySetBuilderTest, AddKeyRangeToEmptyKeySetBuilder) {
 
 TEST(KeySetBuilderTest, AddKeyRangeToNonEmptyKeySetBuilder) {
   auto ks = KeySetBuilder<Row<std::string, std::string>>(
-      KeyRange<Row<std::string, std::string>>(MakeRow("start00", "start01"),
-                                              MakeRow("end00", "end01")));
-  auto range = KeyRange<Row<std::string, std::string>>(
-      MakeBoundOpen(MakeRow("start10", "start11")),
-      MakeBoundOpen(MakeRow("end10", "end11")));
+      MakeKeyRangeClosed(MakeRow("start00", "start01"), MakeRow("end00", "end01")));
+  auto range = MakeKeyRange(MakeBoundOpen(MakeRow("start10", "start11")),
+                            MakeBoundOpen(MakeRow("end10", "end11")));
   ks.Add(range);
   EXPECT_EQ("start00", ks.key_ranges()[0].start().key().get<0>());
   EXPECT_EQ("start01", ks.key_ranges()[0].start().key().get<1>());
@@ -233,11 +231,9 @@ TEST(InternalKeySetTest, BuildToProtoTwoKeys) {
 
 TEST(InternalKeySetTest, BuildToProtoTwoRanges) {
   auto ksb = KeySetBuilder<Row<std::string, std::string>>(
-      KeyRange<Row<std::string, std::string>>(MakeRow("start00", "start01"),
-                                              MakeRow("end00", "end01")));
-  auto range = KeyRange<Row<std::string, std::string>>(
-      MakeBoundOpen(MakeRow("start10", "start11")),
-      MakeBoundOpen(MakeRow("end10", "end11")));
+      MakeKeyRangeClosed(MakeRow("start00", "start01"), MakeRow("end00", "end01")));
+  auto range = MakeKeyRange(MakeBoundOpen(MakeRow("start10", "start11")),
+                            MakeBoundOpen(MakeRow("end10", "end11")));
   ksb.Add(range);
 
   ::google::spanner::v1::KeySet expected;


### PR DESCRIPTION
As discussed offline, it seems unclear what a default constructed `Bound` means. Using a default constructed `Row` is still some valid instance, and it's not clear whether it's a good default. At this point, I don't think we need default construction, so it seems safe to remove it for now because we can always add it back later if we need to.

I also renamed `MakeKeyRange` -> `MakeKeyRangeClosed` to make it explicit that the range would be closed. This is now the only place where "closed" is a default value, and it'll be explicit at the call site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/364)
<!-- Reviewable:end -->
