### PR TITLE
feat: makes KeySetBuilder<T>::Build() more efficient with rvalue qualifier

### DIFF
--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -331,26 +331,31 @@ class KeySetBuilder {
     return key_ranges_;
   }
 
-  /**
-   * Adds a key `spanner::Row` to the `KeySetBuilder`.
-   */
-  KeySetBuilder& Add(RowType key) {
+  /// Adds a key `spanner::Row` to the `KeySetBuilder`.
+  KeySetBuilder&& Add(RowType key) && {
+    keys_.push_back(std::move(key));
+    return std::move(*this);
+  }
+
+  /// Adds a key `spanner::Row` to the `KeySetBuilder`.
+  KeySetBuilder& Add(RowType key) & {
     keys_.push_back(std::move(key));
     return *this;
   }
 
-  /**
-   * Adds a `KeyRange` to the `KeySetBuilder`.
-   */
-  KeySetBuilder& Add(KeyRange<RowType> key_range) {
+  /// Adds a `KeyRange` to the `KeySetBuilder`.
+  KeySetBuilder&& Add(KeyRange<RowType> key_range) && {
+    key_ranges_.push_back(std::move(key_range));
+    return std::move(*this);
+  }
+
+  /// Adds a `KeyRange` to the `KeySetBuilder`.
+  KeySetBuilder& Add(KeyRange<RowType> key_range) & {
     key_ranges_.push_back(std::move(key_range));
     return *this;
   }
 
-  /**
-   * Builds a type-erased `KeySet` from the contents of the `KeySetBuilder`.
-   *
-   */
+  /// Builds a type-erased `KeySet` from the contents of the `KeySetBuilder`.
   KeySet Build() && {
     google::spanner::v1::KeySet ks;
     for (auto& key : keys_) {
@@ -368,6 +373,7 @@ class KeySetBuilder {
     return internal::FromProto(std::move(ks));
   }
 
+  /// Builds a type-erased `KeySet` from the contents of the `KeySetBuilder`.
   KeySet Build() const& {
     auto copy = *this;
     return std::move(copy).Build();

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -71,7 +71,9 @@ class Bound {
   Bound(Bound&& key_range) = default;
   Bound& operator=(Bound&& rhs) = default;
 
-  RowType const& key() const { return key_; }
+  RowType const& key() const& { return key_; }
+  RowType&& key() && { return std::move(key_); }
+
   bool IsClosed() const { return mode_ == Mode::kClosed; }
   bool IsOpen() const { return mode_ == Mode::kOpen; }
 
@@ -153,8 +155,11 @@ class KeyRange {
   KeyRange(KeyRange&& key_range) = default;
   KeyRange& operator=(KeyRange&& rhs) = default;
 
-  Bound<RowType> const& start() const { return start_; }
-  Bound<RowType> const& end() const { return end_; }
+  Bound<RowType> const& start() const& { return start_; }
+  Bound<RowType>&& start() && { return std::move(start_); }
+
+  Bound<RowType> const& end() const& { return end_; }
+  Bound<RowType>&& end() && { return std::move(end_); }
 
   friend bool operator==(KeyRange const& lhs, KeyRange const& rhs) {
     return lhs.start_ == rhs.start_ && lhs.end_ == rhs.end_;
@@ -223,26 +228,11 @@ class KeySet {
    */
   KeySet() = default;
 
-  /**
-   * Constructs a `KeySet` from a `KeySetBuilder`.
-   * @tparam RowType spanner::Row<Types...> that corresponds to the desired
-   * index definition.
-   */
-  template <typename RowType>
-  explicit KeySet(KeySetBuilder<RowType> const& builder) {
-    for (auto& key : builder.keys()) {
-      Append(proto_.add_keys(), std::move(key).values());
-    }
-    for (auto& range : builder.key_ranges()) {
-      auto* kr = proto_.add_ranges();
-      auto* start = range.start().IsClosed() ? kr->mutable_start_closed()
-                                             : kr->mutable_start_open();
-      Append(start, std::move(range).start().key().values());
-      auto* end = range.end().IsClosed() ? kr->mutable_end_closed()
-                                         : kr->mutable_end_open();
-      Append(end, std::move(range).end().key().values());
-    }
-  }
+  // Copy and move constructors and assignment operators.
+  KeySet(KeySet const& key_range) = default;
+  KeySet& operator=(KeySet const& rhs) = default;
+  KeySet(KeySet&& key_range) = default;
+  KeySet& operator=(KeySet&& rhs) = default;
 
   /// @name Equality
   /// Order of keys and key ranges in the `KeySet` is considered.
@@ -257,13 +247,6 @@ class KeySet {
 
   friend ::google::spanner::v1::KeySet internal::ToProto(KeySet keyset);
   friend KeySet internal::FromProto(::google::spanner::v1::KeySet keyset);
-
-  template <std::size_t N>
-  static void Append(google::protobuf::ListValue* lv, std::array<Value, N> a) {
-    for (auto& v : a) {
-      *lv->add_values() = internal::ToProto(std::move(v)).second;
-    }
-  }
 
   google::spanner::v1::KeySet proto_;
 };
@@ -362,12 +345,40 @@ class KeySetBuilder {
    * Builds a type-erased `KeySet` from the contents of the `KeySetBuilder`.
    *
    */
-  KeySet Build() const { return KeySet(*this); }
+  KeySet Build() && {
+    google::spanner::v1::KeySet ks;
+    for (auto& key : keys_) {
+      Append(ks.add_keys(), std::move(key).values());
+    }
+    for (auto& range : key_ranges_) {
+      auto* kr = ks.add_ranges();
+      auto* start = range.start().IsClosed() ? kr->mutable_start_closed()
+                                             : kr->mutable_start_open();
+      Append(start, std::move(range).start().key().values());
+      auto* end = range.end().IsClosed() ? kr->mutable_end_closed()
+                                         : kr->mutable_end_open();
+      Append(end, std::move(range).end().key().values());
+    }
+    return internal::FromProto(std::move(ks));
+  }
+
+  KeySet Build() const& {
+    auto copy = *this;
+    return std::move(copy).Build();
+  }
 
   // TODO(#322): Add methods to insert ranges of Keys and KeyRanges.
   // TODO(#323): Add methods to remove Keys or KeyRanges.
 
  private:
+  template <std::size_t N>
+  static void Append(google::protobuf::ListValue* lv,
+                     std::array<Value, N>&& a) {
+    for (auto& v : a) {
+      *lv->add_values() = internal::ToProto(std::move(v)).second;
+    }
+  }
+
   std::vector<RowType> keys_;
   std::vector<KeyRange<RowType>> key_ranges_;
 };

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -299,6 +299,12 @@ class KeySetBuilder {
    */
   KeySetBuilder() = default;
 
+  /// Copy and move constructors and assignment operators.
+  KeySetBuilder(KeySetBuilder const& key_range) = default;
+  KeySetBuilder& operator=(KeySetBuilder const& rhs) = default;
+  KeySetBuilder(KeySetBuilder&& key_range) = default;
+  KeySetBuilder& operator=(KeySetBuilder&& rhs) = default;
+
   /**
    * Constructs a `KeySetBuilder` with a single key `spanner::Row`.
    */

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -141,7 +141,6 @@ TEST(KeySetTest, EqualityKeys) {
   auto ksb0 = KeySetBuilder<Row<std::string, std::string>>();
   ksb0.Add(MakeRow("foo0", "bar0"));
   ksb0.Add(MakeRow("foo1", "bar1"));
-  auto ks0 = ksb0.Build();
 
   auto ksb1 = KeySetBuilder<Row<std::string, std::string>>();
   ksb1.Add(MakeRow("foo0", "bar0"));

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -18,12 +18,25 @@
 #include <google/spanner/v1/keys.pb.h>
 #include <gmock/gmock.h>
 #include <cstdint>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
+
+TEST(BoundTest, Accessors) {
+  auto row = MakeRow("test");
+  auto bound = MakeBoundClosed(row);
+  EXPECT_EQ(row, bound.key());
+  EXPECT_EQ(row, std::move(bound).key());
+
+  using RowType = decltype(row);
+  static_assert(std::is_same<RowType const&, decltype(bound.key())>::value, "");
+  static_assert(
+      std::is_same<RowType&&, decltype(std::move(bound).key())>::value, "");
+}
 
 TEST(BoundTest, MakeBoundClosed) {
   std::string key_value("key0");
@@ -39,6 +52,30 @@ TEST(BoundTest, MakeBoundOpen) {
   EXPECT_EQ(key_value_0, bound.key().get<0>());
   EXPECT_EQ(key_value_1, bound.key().get<1>());
   EXPECT_TRUE(bound.IsOpen());
+}
+
+TEST(KeyrangeTest, Accessors) {
+  auto start_row = MakeRow("a");
+  auto start_bound = MakeBoundClosed(start_row);
+
+  auto end_row = MakeRow("z");
+  auto end_bound = MakeBoundClosed(end_row);
+
+  auto range = MakeKeyRange(start_bound, end_bound);
+  EXPECT_EQ(start_bound, range.start());
+  EXPECT_EQ(end_bound, range.end());
+
+  EXPECT_EQ(start_bound, std::move(range).start());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  EXPECT_EQ(end_bound, std::move(range).end());
+
+  using StartType = decltype(start_bound);
+  static_assert(std::is_same<StartType const&, decltype(range.start())>::value,
+                "");
+
+  using EndType = decltype(end_bound);
+  static_assert(
+      std::is_same<EndType&&, decltype(std::move(range).start())>::value, "");
 }
 
 TEST(KeyRangeTest, ConstructorBoundModeUnspecified) {
@@ -165,20 +202,23 @@ TEST(KeySetTest, EqualityKeyRanges) {
 
 TEST(KeySetTest, RoundTripProtos) {
   auto test_cases = {
-      KeySetBuilder<Row<>>().Build(),                  //
-      KeySetBuilder<Row<std::int64_t>>()               //
-          .Add(MakeRow(42))                            //
-          .Build(),                                    //
-      KeySetBuilder<Row<std::int64_t>>()               //
-          .Add(MakeRow(42))                            //
-          .Add(MakeRow(123))                           //
-          .Build(),                                    //
-      KeySetBuilder<Row<std::int64_t, std::string>>()  //
-          .Build(),                                    //
-      KeySetBuilder<Row<std::int64_t, std::string>>()  //
-          .Add(MakeRow(42, "hi"))                      //
-          .Add(MakeRow(123, "bye"))                    //
-          .Build(),                                    //
+      KeySetBuilder<Row<>>().Build(),                                      //
+      KeySetBuilder<Row<std::int64_t>>()                                   //
+          .Add(MakeRow(42))                                                //
+          .Build(),                                                        //
+      KeySetBuilder<Row<std::int64_t>>()                                   //
+          .Add(MakeRow(42))                                                //
+          .Add(MakeRow(123))                                               //
+          .Build(),                                                        //
+      KeySetBuilder<Row<std::int64_t, std::string>>()                      //
+          .Build(),                                                        //
+      KeySetBuilder<Row<std::int64_t, std::string>>()                      //
+          .Add(MakeRow(42, "hi"))                                          //
+          .Add(MakeRow(123, "bye"))                                        //
+          .Build(),                                                        //
+      KeySetBuilder<Row<std::int64_t, std::string>>()                      //
+          .Add(MakeKeyRangeClosed(MakeRow(42, "hi"), MakeRow(43, "bye")))  //
+          .Build(),                                                        //
   };
 
   for (auto const& tc : test_cases) {

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -141,6 +141,7 @@ TEST(KeySetTest, EqualityKeys) {
   auto ksb0 = KeySetBuilder<Row<std::string, std::string>>();
   ksb0.Add(MakeRow("foo0", "bar0"));
   ksb0.Add(MakeRow("foo1", "bar1"));
+  auto ks0 = ksb0.Build();
 
   auto ksb1 = KeySetBuilder<Row<std::string, std::string>>();
   ksb1.Add(MakeRow("foo0", "bar0"));


### PR DESCRIPTION
Rvalue-ref qualifies the `KeySetBuilder<T>::Build()` method which will enable it to *move* all of its data into the protos in the resulting `KeySet`. I needed to add rvalue-qualified accessors to Bound and KeyRange as well.

I left the `KeySetBuilder<T>::Build() const&` overload, which is inefficient and will result in a copy of all the keys. We could remove this overload if we want to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/373)
<!-- Reviewable:end -->
