### PR TITLE
Handle a response with no values.

### DIFF
--- a/google/cloud/spanner/internal/partial_result_set_reader.cc
+++ b/google/cloud/spanner/internal/partial_result_set_reader.cc
@@ -46,7 +46,7 @@ StatusOr<optional<Value>> PartialResultSetReader::NextValue() {
   if (finished_) {
     return optional<Value>();
   }
-  if (next_value_index_ >= values_.size()) {
+  while (next_value_index_ >= values_.size()) {
     // Ran out of buffered values - try to read some more from gRPC.
     next_value_index_ = 0;
     auto status = ReadFromStream();
@@ -56,9 +56,8 @@ StatusOr<optional<Value>> PartialResultSetReader::NextValue() {
     if (finished_) {
       return optional<Value>();
     }
-    if (values_.empty()) {
-      return Status(StatusCode::kInternal, "response has no values");
-    }
+    // If the response contained any values, the loop will exit, otherwise
+    // continue reading until we do get at least one value.
   }
 
   if (metadata_->row_type().fields().empty()) {


### PR DESCRIPTION
I don't know if this is likely to happen in practice but I don't think
this is necessarily an error so we should be permissive.

Once place where I might envision it actually happening is at the end
of the stream -  maybe we could get a response with stats but no values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/375)
<!-- Reviewable:end -->
