### PR TITLE
feat: Add `Database` class to encapsulate project_id, instance_id, database_id

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,7 +16,6 @@ Checks: >
   -google-readability-namespace-comments,
   -google-runtime-references,
   -misc-non-private-member-variables-in-classes,
-  -modernize-avoid-c-arrays,
   -readability-named-parameter,
   -readability-braces-around-statements,
   -readability-magic-numbers

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: >
   -google-readability-namespace-comments,
   -google-runtime-references,
   -misc-non-private-member-variables-in-classes,
+  -modernize-avoid-c-arrays,
   -readability-named-parameter,
   -readability-braces-around-statements,
   -readability-magic-numbers

--- a/ci/test-install/spanner_install_test.cc
+++ b/ci/test-install/spanner_install_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_client.h"
 
 namespace spanner = google::cloud::spanner;
@@ -24,34 +25,34 @@ int main(int argc, char* argv[]) try {
         << " <project-id> <instance-id> <database-id>\n";
     return 1;
   }
-  std::string const project_id = argv[1];
-  std::string const instance_id = argv[2];
-  std::string const database_id = argv[3];
+
+  google::cloud::spanner::Database const database(argv[1], argv[2], argv[3]);
 
   using google::cloud::future;
   using google::cloud::StatusOr;
 
   google::cloud::spanner::DatabaseAdminClient client;
-  future<StatusOr<google::spanner::admin::database::v1::Database>> created_database =
-      client.CreateDatabase(project_id, instance_id, database_id,
-              {R"""(
+  future<StatusOr<google::spanner::admin::database::v1::Database>>
+      created_database =
+          client.CreateDatabase(database, {R"""(
                         CREATE TABLE Singers (
                                 SingerId   INT64 NOT NULL,
                                 FirstName  STRING(1024),
                                 LastName   STRING(1024),
                                 SingerInfo BYTES(MAX)
                         ) PRIMARY KEY (SingerId))""",
-              R"""(CREATE TABLE Albums (
+                                           R"""(CREATE TABLE Albums (
                                 SingerId     INT64 NOT NULL,
                                 AlbumId      INT64 NOT NULL,
                                 AlbumTitle   STRING(MAX)
                         ) PRIMARY KEY (SingerId, AlbumId),
                         INTERLEAVE IN PARENT Singers ON DELETE CASCADE)"""});
-      StatusOr<google::spanner::admin::database::v1::Database> db = created_database.get();
+  StatusOr<google::spanner::admin::database::v1::Database> db =
+      created_database.get();
   if (!db) {
       throw std::runtime_error(db.status().message());
   }
-  std::cout << "Created database [" << database_id << "]\n";
+  std::cout << "Created database [" << database << "]\n";
 
   return 0;
 } catch (std::exception const& ex) {

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -92,6 +92,8 @@ add_library(spanner_client
             client_options.h
             commit_result.h
             connection.h
+            database.cc
+            database.h
             database_admin_client.cc
             database_admin_client.h
             date.cc
@@ -205,6 +207,7 @@ function (spanner_client_define_tests)
     set(spanner_client_unit_tests
         client_options_test.cc
         client_test.cc
+        database_test.cc
         database_admin_client_test.cc
         date_test.cc
         internal/base64_test.cc

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -112,19 +112,11 @@ Status Client::Rollback(Transaction transaction) {
   return conn_->Rollback({std::move(transaction)});
 }
 
-std::string MakeDatabaseName(std::string const& project,
-                             std::string const& instance,
-                             std::string const& database_id) {
-  return std::string("projects/") + project + "/instances/" + instance +
-         "/databases/" + database_id;
-}
-
 std::shared_ptr<Connection> MakeConnection(
-    std::string database,
-    std::shared_ptr<grpc::ChannelCredentials> const& creds,
+    Database db, std::shared_ptr<grpc::ChannelCredentials> const& creds,
     std::string const& endpoint) {
   auto stub = internal::CreateDefaultSpannerStub(creds, endpoint);
-  return std::make_shared<internal::ConnectionImpl>(std::move(database),
+  return std::make_shared<internal::ConnectionImpl>(std::move(db),
                                                     std::move(stub));
 }
 

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -113,11 +113,10 @@ Status Client::Rollback(Transaction transaction) {
 }
 
 std::shared_ptr<Connection> MakeConnection(
-    Database db, std::shared_ptr<grpc::ChannelCredentials> const& creds,
+    Database const& db, std::shared_ptr<grpc::ChannelCredentials> const& creds,
     std::string const& endpoint) {
   auto stub = internal::CreateDefaultSpannerStub(creds, endpoint);
-  return std::make_shared<internal::ConnectionImpl>(std::move(db),
-                                                    std::move(stub));
+  return std::make_shared<internal::ConnectionImpl>(db, std::move(stub));
 }
 
 StatusOr<CommitResult> RunTransaction(

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/client_options.h"
 #include "google/cloud/spanner/commit_result.h"
 #include "google/cloud/spanner/connection.h"
+#include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/keys.h"
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/result_set.h"
@@ -72,7 +73,7 @@ inline namespace SPANNER_CLIENT_NS {
  * namespace cs = ::google::cloud::spanner;
  * using ::google::cloud::StatusOr;
  *
- * auto db = cs::MakeDatabaseName("my_project", "my_instance", "my_db_id"));
+ * auto db = cs::Database("my_project", "my_instance", "my_db_id"));
  * auto conn = cs::MakeConnection(std::move(db));
  * auto client = cs::Client(conn);
  *
@@ -368,11 +369,6 @@ class Client {
   std::shared_ptr<Connection> conn_;
 };
 
-/// Format a database name given the `project`, `instance`, and `database_id`.
-std::string MakeDatabaseName(std::string const& project,
-                             std::string const& instance,
-                             std::string const& database_id);
-
 /**
  * Returns a Connection object that can be used for interacting with Spanner.
  *
@@ -383,12 +379,12 @@ std::string MakeDatabaseName(std::string const& project,
  *
  * @see `Connection`
  *
- * @param database the name of the database. See `MakeDatabaesName`.
+ * @param db See `Database`.
  * @param creds (optional) the gRPC credentials to use.
  * @param endpoint (optional) the Spanner service to connect to.
  */
 std::shared_ptr<Connection> MakeConnection(
-    std::string database,
+    Database db,
     std::shared_ptr<grpc::ChannelCredentials> const& creds =
         grpc::GoogleDefaultCredentials(),
     std::string const& endpoint = "spanner.googleapis.com");

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -74,7 +74,7 @@ inline namespace SPANNER_CLIENT_NS {
  * using ::google::cloud::StatusOr;
  *
  * auto db = cs::Database("my_project", "my_instance", "my_db_id"));
- * auto conn = cs::MakeConnection(std::move(db));
+ * auto conn = cs::MakeConnection(db);
  * auto client = cs::Client(conn);
  *
  * StatusOr<cs::ResultSet> result = client.Read(...);
@@ -384,7 +384,7 @@ class Client {
  * @param endpoint (optional) the Spanner service to connect to.
  */
 std::shared_ptr<Connection> MakeConnection(
-    Database db,
+    Database const& db,
     std::shared_ptr<grpc::ChannelCredentials> const& creds =
         grpc::GoogleDefaultCredentials(),
     std::string const& endpoint = "spanner.googleapis.com");

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -334,21 +334,15 @@ TEST(ClientTest, RollbackError) {
   EXPECT_EQ(StatusCode::kInvalidArgument, rollback.code());
 }
 
-TEST(ClientTest, MakeDatabaseName) {
-  EXPECT_EQ(
-      "projects/dummy_project/instances/dummy_instance/databases/"
-      "dummy_database_id",
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id"));
-}
-
 TEST(ClientTest, MakeConnectionOptionalArguments) {
-  auto conn = MakeConnection("foo");
+  Database db("foo", "bar", "baz");
+  auto conn = MakeConnection(db);
   EXPECT_NE(conn, nullptr);
 
-  conn = MakeConnection("foo", grpc::GoogleDefaultCredentials());
+  conn = MakeConnection(db, grpc::GoogleDefaultCredentials());
   EXPECT_NE(conn, nullptr);
 
-  conn = MakeConnection("foo", grpc::GoogleDefaultCredentials(), "localhost");
+  conn = MakeConnection(db, grpc::GoogleDefaultCredentials(), "localhost");
   EXPECT_NE(conn, nullptr);
 }
 

--- a/google/cloud/spanner/database.cc
+++ b/google/cloud/spanner/database.cc
@@ -1,0 +1,61 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/database.h"
+#include <array>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+Database::Database(std::string project_id, std::string instance_id,
+                   std::string database_id)
+    : project_id_(std::move(project_id)),
+      instance_id_(std::move(instance_id)),
+      database_id_(std::move(database_id)) {}
+
+std::string Database::FullName() const {
+  // "projects/<project-id>/instances/<instance-id>/databases/<database-id>"
+  constexpr char kProjects[] = "projects/";
+  constexpr char kInstances[] = "/instances/";
+  constexpr char kDatabases[] = "/databases/";
+  std::string name;
+  name.reserve(sizeof(kProjects) + sizeof(kInstances) + sizeof(kDatabases) - 3 +
+               project_id().size() + instance_id().size() +
+               database_id().size());
+  name += kProjects;
+  name += project_id();
+  name += kInstances;
+  name += instance_id();
+  name += kDatabases;
+  name += database_id();
+  return name;
+}
+
+bool operator==(Database const& a, Database const& b) {
+  return std::tie(a.project_id(), a.instance_id(), a.database_id()) ==
+         std::tie(b.project_id(), b.instance_id(), b.database_id());
+}
+
+bool operator!=(Database const& a, Database const& b) { return !(a == b); }
+
+std::ostream& operator<<(std::ostream& os, Database const& dn) {
+  return os << dn.FullName();
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/database.cc
+++ b/google/cloud/spanner/database.cc
@@ -20,42 +20,32 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-Database::Database(std::string project_id, std::string instance_id,
-                   std::string database_id)
-    : project_id_(std::move(project_id)),
-      instance_id_(std::move(instance_id)),
-      database_id_(std::move(database_id)) {}
+Database::Database(std::string const& project_id,
+                   std::string const& instance_id,
+                   std::string const& database_id)
+    : full_name_("projects/" + project_id + "/instances/" + instance_id +
+                 "/databases/" + database_id) {}
 
-std::string Database::FullName() const {
-  // "projects/<project-id>/instances/<instance-id>/databases/<database-id>"
-  constexpr char kDatabases[] = "/databases/";
-  std::string parent = ParentName();
-  return parent + kDatabases + database_id();
+std::string Database::FullName() const { return full_name_; }
+
+std::string Database::DatabaseId() const {
+  auto pos = full_name_.rfind('/');
+  return full_name_.substr(pos + 1);
 }
 
 std::string Database::ParentName() const {
-  // "projects/<project-id>/instances/<instance-id>"
-  constexpr char kProjects[] = "projects/";
-  constexpr char kInstances[] = "/instances/";
-  std::string name;
-  name.reserve(sizeof(kProjects) + sizeof(kInstances) - 2 +
-               project_id().size() + instance_id().size());
-  name += kProjects;
-  name += project_id();
-  name += kInstances;
-  name += instance_id();
-  return name;
+  auto pos = full_name_.rfind("/databases/");
+  return full_name_.substr(0, pos);
 }
 
 bool operator==(Database const& a, Database const& b) {
-  return std::tie(a.project_id(), a.instance_id(), a.database_id()) ==
-         std::tie(b.project_id(), b.instance_id(), b.database_id());
+  return a.full_name_ == b.full_name_;
 }
 
 bool operator!=(Database const& a, Database const& b) { return !(a == b); }
 
 std::ostream& operator<<(std::ostream& os, Database const& dn) {
-  return os << dn.FullName();
+  return os << dn.full_name_;
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/database.cc
+++ b/google/cloud/spanner/database.cc
@@ -28,19 +28,22 @@ Database::Database(std::string project_id, std::string instance_id,
 
 std::string Database::FullName() const {
   // "projects/<project-id>/instances/<instance-id>/databases/<database-id>"
+  constexpr char kDatabases[] = "/databases/";
+  std::string parent = ParentName();
+  return parent + kDatabases + database_id();
+}
+
+std::string Database::ParentName() const {
+  // "projects/<project-id>/instances/<instance-id>"
   constexpr char kProjects[] = "projects/";
   constexpr char kInstances[] = "/instances/";
-  constexpr char kDatabases[] = "/databases/";
   std::string name;
-  name.reserve(sizeof(kProjects) + sizeof(kInstances) + sizeof(kDatabases) - 3 +
-               project_id().size() + instance_id().size() +
-               database_id().size());
+  name.reserve(sizeof(kProjects) + sizeof(kInstances) - 2 +
+               project_id().size() + instance_id().size());
   name += kProjects;
   name += project_id();
   name += kInstances;
   name += instance_id();
-  name += kDatabases;
-  name += database_id();
   return name;
 }
 

--- a/google/cloud/spanner/database.cc
+++ b/google/cloud/spanner/database.cc
@@ -29,8 +29,8 @@ Database::Database(std::string const& project_id,
 std::string Database::FullName() const { return full_name_; }
 
 std::string Database::DatabaseId() const {
-  auto pos = full_name_.rfind('/');
-  return full_name_.substr(pos + 1);
+  auto pos = full_name_.rfind("/databases/");
+  return full_name_.substr(pos + sizeof("/databases/") - 1);
 }
 
 std::string Database::ParentName() const {

--- a/google/cloud/spanner/database.h
+++ b/google/cloud/spanner/database.h
@@ -26,7 +26,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 /**
- * This class identifies a Spanner Database 
+ * This class identifies a Spanner Database
  *
  * A Spanner database is identified by its `project_id`, `instance_id`, and
  * `database_id`.
@@ -55,6 +55,10 @@ class Database {
   // Returns the fully qualified database name as a string of the form:
   // "projects/<project-id>/instances/<instance-id>/databases/<database-id>"
   std::string FullName() const;
+
+  // Returns the fully qualified name of the database's parent of the form:
+  // "projects/<project-id>/instances/<instance-id>"
+  std::string ParentName() const;
 
  private:
   std::string project_id_;

--- a/google/cloud/spanner/database.h
+++ b/google/cloud/spanner/database.h
@@ -33,7 +33,7 @@ inline namespace SPANNER_CLIENT_NS {
  */
 class Database {
  public:
-  /// Constructs a Spanner Database identified by the given IDs.
+  /// Constructs a Database object identified by the given IDs.
   Database(std::string const& project_id, std::string const& instance_id,
            std::string const& database_id);
 

--- a/google/cloud/spanner/database.h
+++ b/google/cloud/spanner/database.h
@@ -34,8 +34,8 @@ inline namespace SPANNER_CLIENT_NS {
 class Database {
  public:
   /// Constructs a Spanner Database identified by the given IDs.
-  Database(std::string project_id, std::string instance_id,
-           std::string database_id);
+  Database(std::string const& project_id, std::string const& instance_id,
+           std::string const& database_id);
 
   /// @name Copy and move
   //@{
@@ -45,35 +45,33 @@ class Database {
   Database& operator=(Database&&) = default;
   //@}
 
-  /// @name Accessors
-  //@{
-  std::string const& project_id() const { return project_id_; }
-  std::string const& instance_id() const { return instance_id_; }
-  std::string const& database_id() const { return database_id_; }
-  //@}
+  /// Returns the database ID.
+  std::string DatabaseId() const;
 
-  // Returns the fully qualified database name as a string of the form:
-  // "projects/<project-id>/instances/<instance-id>/databases/<database-id>"
+  /**
+   * Returns the fully qualified database name as a string of the form:
+   * "projects/<project-id>/instances/<instance-id>/databases/<database-id>"
+   */
   std::string FullName() const;
 
-  // Returns the fully qualified name of the database's parent of the form:
-  // "projects/<project-id>/instances/<instance-id>"
+  /**
+   * Returns the fully qualified name of the database's parent of the form:
+   * "projects/<project-id>/instances/<instance-id>"
+   */
   std::string ParentName() const;
 
+  /// @name Equality operators
+  //@{
+  friend bool operator==(Database const& a, Database const& b);
+  friend bool operator!=(Database const& a, Database const& b);
+  //@}
+
+  /// Output the `FullName()` format.
+  friend std::ostream& operator<<(std::ostream& os, Database const& dn);
+
  private:
-  std::string project_id_;
-  std::string instance_id_;
-  std::string database_id_;
+  std::string full_name_;
 };
-
-/// @name Equality operators
-//@{
-bool operator==(Database const& a, Database const& b);
-bool operator!=(Database const& a, Database const& b);
-//@}
-
-/// Output the `FullName()` format.
-std::ostream& operator<<(std::ostream& os, Database const& dn);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/database.h
+++ b/google/cloud/spanner/database.h
@@ -1,0 +1,79 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_DATABASE_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_DATABASE_H_
+
+#include "google/cloud/spanner/version.h"
+#include <ostream>
+#include <string>
+#include <tuple>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+/**
+ * This class identifies a Spanner Database 
+ *
+ * A Spanner database is identified by its `project_id`, `instance_id`, and
+ * `database_id`.
+ */
+class Database {
+ public:
+  /// Constructs a Spanner Database identified by the given IDs.
+  Database(std::string project_id, std::string instance_id,
+           std::string database_id);
+
+  /// @name Copy and move
+  //@{
+  Database(Database const&) = default;
+  Database& operator=(Database const&) = default;
+  Database(Database&&) = default;
+  Database& operator=(Database&&) = default;
+  //@}
+
+  /// @name Accessors
+  //@{
+  std::string const& project_id() const { return project_id_; }
+  std::string const& instance_id() const { return instance_id_; }
+  std::string const& database_id() const { return database_id_; }
+  //@}
+
+  // Returns the fully qualified database name as a string of the form:
+  // "projects/<project-id>/instances/<instance-id>/databases/<database-id>"
+  std::string FullName() const;
+
+ private:
+  std::string project_id_;
+  std::string instance_id_;
+  std::string database_id_;
+};
+
+/// @name Equality operators
+//@{
+bool operator==(Database const& a, Database const& b);
+bool operator!=(Database const& a, Database const& b);
+//@}
+
+/// Output the `FullName()` format.
+std::ostream& operator<<(std::ostream& os, Database const& dn);
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_DATABASE_H_

--- a/google/cloud/spanner/database.h
+++ b/google/cloud/spanner/database.h
@@ -26,10 +26,18 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 /**
- * This class identifies a Spanner Database
+ * This class identifies a Cloud Spanner Database
  *
- * A Spanner database is identified by its `project_id`, `instance_id`, and
- * `database_id`.
+ * A Cloud Spanner database is identified by its `project_id`, `instance_id`,
+ * and `database_id`.
+ *
+ * @note this class makes no effort to validate the components of the
+ *     database name. It is the application's responsibility to provide valid
+ *     project, instance, and database ids. Passing invalid values will not be
+ *     checked until the database name is used in a RPC to spanner.
+ *
+ * For more info about the `database_id` format, see
+ * https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.CreateDatabaseRequest
  */
 class Database {
  public:

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -33,7 +33,7 @@ future<StatusOr<gcsa::Database>> DatabaseAdminClient::CreateDatabase(
   grpc::ClientContext context;
   gcsa::CreateDatabaseRequest request;
   request.set_parent(db.ParentName());
-  request.set_create_statement("CREATE DATABASE `" + db.database_id() + "`");
+  request.set_create_statement("CREATE DATABASE `" + db.DatabaseId() + "`");
   for (auto const& s : extra_statements) {
     *request.add_extra_statements() = s;
   }

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -29,13 +29,11 @@ DatabaseAdminClient::DatabaseAdminClient(ClientOptions const& client_options)
           internal::CreateDefaultDatabaseAdminStub(client_options))) {}
 
 future<StatusOr<gcsa::Database>> DatabaseAdminClient::CreateDatabase(
-    std::string const& project_id, std::string const& instance_id,
-    std::string const& database_id,
-    std::vector<std::string> const& extra_statements) {
+    Database const& db, std::vector<std::string> const& extra_statements) {
   grpc::ClientContext context;
   gcsa::CreateDatabaseRequest request;
-  request.set_parent("projects/" + project_id + "/instances/" + instance_id);
-  request.set_create_statement("CREATE DATABASE `" + database_id + "`");
+  request.set_parent(db.ParentName());
+  request.set_create_statement("CREATE DATABASE `" + db.database_id() + "`");
   for (auto const& s : extra_statements) {
     *request.add_extra_statements() = s;
   }
@@ -50,13 +48,10 @@ future<StatusOr<gcsa::Database>> DatabaseAdminClient::CreateDatabase(
 
 future<StatusOr<gcsa::UpdateDatabaseDdlMetadata>>
 DatabaseAdminClient::UpdateDatabase(
-    std::string const& project_id, std::string const& instance_id,
-    std::string const& database_id,
-    std::vector<std::string> const& statements) {
+    Database const& db, std::vector<std::string> const& statements) {
   grpc::ClientContext context;
   gcsa::UpdateDatabaseDdlRequest request;
-  request.set_database("projects/" + project_id + "/instances/" + instance_id +
-                       "/databases/" + database_id);
+  request.set_database(db.FullName());
   for (auto const& s : statements) {
     *request.add_statements() = s;
   }
@@ -69,14 +64,10 @@ DatabaseAdminClient::UpdateDatabase(
   return stub_->AwaitUpdateDatabase(*std::move(operation));
 }
 
-Status DatabaseAdminClient::DropDatabase(std::string const& project_id,
-                                         std::string const& instance_id,
-                                         std::string const& database_id) {
+Status DatabaseAdminClient::DropDatabase(Database const& db) {
   grpc::ClientContext context;
   google::spanner::admin::database::v1::DropDatabaseRequest request;
-  request.set_database("projects/" + project_id + "/instances/" + instance_id +
-                       "/databases/" + database_id);
-
+  request.set_database(db.FullName());
   return stub_->DropDatabase(context, request);
 }
 

--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_DATABASE_ADMIN_CLIENT_H_
 
 #include "google/cloud/spanner/client_options.h"
+#include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/internal/database_admin_stub.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
@@ -137,8 +138,7 @@ class DatabaseAdminClient {
    *     for the regular expression that must be satisfied by the database id.
    */
   future<StatusOr<google::spanner::admin::database::v1::Database>>
-  CreateDatabase(std::string const& project_id, std::string const& instance_id,
-                 std::string const& database_id,
+  CreateDatabase(Database const& db,
                  std::vector<std::string> const& extra_statements = {});
 
   /**
@@ -159,8 +159,7 @@ class DatabaseAdminClient {
    */
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabase(std::string const& project_id, std::string const& instance_id,
-                 std::string const& database_id,
+  UpdateDatabase(Database const& db,
                  std::vector<std::string> const& statements);
 
   /**
@@ -172,9 +171,7 @@ class DatabaseAdminClient {
    * @par Example
    * @snippet samples.cc drop-database
    */
-  Status DropDatabase(std::string const& project_id,
-                      std::string const& instance_id,
-                      std::string const& database_id);
+  Status DropDatabase(Database const& db);
 
   /// Create a new client with the given stub. For testing only.
   explicit DatabaseAdminClient(std::shared_ptr<internal::DatabaseAdminStub> s)

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -78,7 +78,8 @@ TEST(DatabaseAdminClientTest, CreateDatabaseSuccess) {
       }));
 
   DatabaseAdminClient client(mock);
-  auto fut = client.CreateDatabase("test-project", "test-instance", "test-db");
+  Database dbase("test-project", "test-instance", "test-db");
+  auto fut = client.CreateDatabase(dbase);
   EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
   EXPECT_STATUS_OK(db);
@@ -99,7 +100,8 @@ TEST(DatabaseAdminClientTest, HandleCreateDatabaseError) {
           }));
 
   DatabaseAdminClient client(mock);
-  auto fut = client.CreateDatabase("test-project", "test-instance", "test-db");
+  Database dbase("test-project", "test-instance", "test-db");
+  auto fut = client.CreateDatabase(dbase);
   EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
@@ -131,9 +133,9 @@ TEST(DatabaseAdminClientTest, UpdateDatabaseSuccess) {
       }));
 
   DatabaseAdminClient client(mock);
+  Database dbase("test-project", "test-instance", "test-db");
   auto fut = client.UpdateDatabase(
-      "test-project", "test-instance", "test-db",
-      {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"});
+      dbase, {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"});
   EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto metadata = fut.get();
   EXPECT_STATUS_OK(metadata);
@@ -154,9 +156,9 @@ TEST(DatabaseAdminClientTest, HandleUpdateDatabaseError) {
           }));
 
   DatabaseAdminClient client(mock);
+  Database dbase("test-project", "test-instance", "test-db");
   auto fut = client.UpdateDatabase(
-      "test-project", "test-instance", "test-db",
-      {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"});
+      dbase, {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"});
   EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto db = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, db.status().code());
@@ -183,7 +185,9 @@ TEST(DatabaseAdminClientTest, HandleAwaitCreateDatabaseError) {
 
   DatabaseAdminClient client(mock);
   auto db =
-      client.CreateDatabase("test-project", "test-instance", "test-db").get();
+      client
+          .CreateDatabase(Database("test-project", "test-instance", "test-db"))
+          .get();
   EXPECT_EQ(StatusCode::kAborted, db.status().code());
 }
 
@@ -209,7 +213,7 @@ TEST(DatabaseAdminClientTest, HandleAwaitUpdateDatabaseError) {
   DatabaseAdminClient client(mock);
   auto db = client
                 .UpdateDatabase(
-                    "test-project", "test-instance", "test-db",
+                    Database("test-project", "test-instance", "test-db"),
                     {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"})
                 .get();
   EXPECT_EQ(StatusCode::kAborted, db.status().code());

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -184,10 +184,8 @@ TEST(DatabaseAdminClientTest, HandleAwaitCreateDatabaseError) {
       }));
 
   DatabaseAdminClient client(mock);
-  auto db =
-      client
-          .CreateDatabase(Database("test-project", "test-instance", "test-db"))
-          .get();
+  Database dbase("test-project", "test-instance", "test-db");
+  auto db = client.CreateDatabase(dbase).get();
   EXPECT_EQ(StatusCode::kAborted, db.status().code());
 }
 
@@ -211,11 +209,12 @@ TEST(DatabaseAdminClientTest, HandleAwaitUpdateDatabaseError) {
       }));
 
   DatabaseAdminClient client(mock);
-  auto db = client
-                .UpdateDatabase(
-                    Database("test-project", "test-instance", "test-db"),
-                    {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"})
-                .get();
+  Database dbase("test-project", "test-instance", "test-db");
+  auto db =
+      client
+          .UpdateDatabase(
+              dbase, {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"})
+          .get();
   EXPECT_EQ(StatusCode::kAborted, db.status().code());
 }
 

--- a/google/cloud/spanner/database_test.cc
+++ b/google/cloud/spanner/database_test.cc
@@ -25,9 +25,7 @@ namespace {
 
 TEST(Database, Basics) {
   Database db("p1", "i1", "d1");
-  EXPECT_EQ("p1", db.project_id());
-  EXPECT_EQ("i1", db.instance_id());
-  EXPECT_EQ("d1", db.database_id());
+  EXPECT_EQ("d1", db.DatabaseId());
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", db.FullName());
   EXPECT_EQ("projects/p1/instances/i1", db.ParentName());
 

--- a/google/cloud/spanner/database_test.cc
+++ b/google/cloud/spanner/database_test.cc
@@ -29,18 +29,22 @@ TEST(Database, Basics) {
   EXPECT_EQ("i1", db.instance_id());
   EXPECT_EQ("d1", db.database_id());
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", db.FullName());
+  EXPECT_EQ("projects/p1/instances/i1", db.ParentName());
 
   auto copy = db;
   EXPECT_EQ(copy, db);
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", copy.FullName());
+  EXPECT_EQ("projects/p1/instances/i1", db.ParentName());
 
   auto moved = std::move(copy);
   EXPECT_EQ(moved, db);
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", moved.FullName());
+  EXPECT_EQ("projects/p1/instances/i1", db.ParentName());
 
   Database db2("p2", "i2", "d2");
   EXPECT_NE(db2, db);
   EXPECT_EQ("projects/p2/instances/i2/databases/d2", db2.FullName());
+  EXPECT_EQ("projects/p2/instances/i2", db2.ParentName());
 }
 
 TEST(Database, OutputStream) {

--- a/google/cloud/spanner/database_test.cc
+++ b/google/cloud/spanner/database_test.cc
@@ -1,0 +1,57 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/database.h"
+#include "google/cloud/spanner/testing/matchers.h"
+#include <gmock/gmock.h>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+
+TEST(Database, Basics) {
+  Database db("p1", "i1", "d1");
+  EXPECT_EQ("p1", db.project_id());
+  EXPECT_EQ("i1", db.instance_id());
+  EXPECT_EQ("d1", db.database_id());
+  EXPECT_EQ("projects/p1/instances/i1/databases/d1", db.FullName());
+
+  auto copy = db;
+  EXPECT_EQ(copy, db);
+  EXPECT_EQ("projects/p1/instances/i1/databases/d1", copy.FullName());
+
+  auto moved = std::move(copy);
+  EXPECT_EQ(moved, db);
+  EXPECT_EQ("projects/p1/instances/i1/databases/d1", moved.FullName());
+
+  Database db2("p2", "i2", "d2");
+  EXPECT_NE(db2, db);
+  EXPECT_EQ("projects/p2/instances/i2/databases/d2", db2.FullName());
+}
+
+TEST(Database, OutputStream) {
+  Database db("p1", "i1", "d1");
+  std::ostringstream os;
+  os << db;
+  EXPECT_EQ("projects/p1/instances/i1/databases/d1", os.str());
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/database_test.cc
+++ b/google/cloud/spanner/database_test.cc
@@ -31,16 +31,19 @@ TEST(Database, Basics) {
 
   auto copy = db;
   EXPECT_EQ(copy, db);
+  EXPECT_EQ("d1", copy.DatabaseId());
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", copy.FullName());
   EXPECT_EQ("projects/p1/instances/i1", db.ParentName());
 
   auto moved = std::move(copy);
   EXPECT_EQ(moved, db);
+  EXPECT_EQ("d1", moved.DatabaseId());
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", moved.FullName());
   EXPECT_EQ("projects/p1/instances/i1", db.ParentName());
 
   Database db2("p2", "i2", "d2");
   EXPECT_NE(db2, db);
+  EXPECT_EQ("d2", db2.DatabaseId());
   EXPECT_EQ("projects/p2/instances/i2/databases/d2", db2.FullName());
   EXPECT_EQ("projects/p2/instances/i2", db2.ParentName());
 }

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -40,11 +40,11 @@ class IntegrationTestEnvironment : public ::testing::Environment {
  protected:
   void SetUp() override {
     auto project_id =
-        google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
+        google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
     ASSERT_FALSE(project_id.empty());
     auto instance_id =
         google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_INSTANCE")
-            .value();
+            .value_or("");
     ASSERT_FALSE(instance_id.empty());
 
     generator_ = new google::cloud::internal::DefaultPRNG(

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -41,9 +41,11 @@ class IntegrationTestEnvironment : public ::testing::Environment {
   void SetUp() override {
     auto project_id =
         google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
+    ASSERT_FALSE(project_id.empty());
     auto instance_id =
         google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_INSTANCE")
             .value();
+    ASSERT_FALSE(instance_id.empty());
 
     generator_ = new google::cloud::internal::DefaultPRNG(
         google::cloud::internal::MakeDefaultPRNG());

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/client.h"
+#include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
@@ -34,8 +35,8 @@ using ::testing::UnorderedElementsAreArray;
 // Use a ::testing::Environment to create the database once.
 class IntegrationTestEnvironment : public ::testing::Environment {
  public:
-  static std::string DatabaseName() {
-    return MakeDatabaseName(*project_id_, *instance_id_, *database_id_);
+  static Database DatabaseName() {
+    return Database(*project_id_, *instance_id_, *database_id_);
   }
 
   static std::string RandomTableName() {
@@ -60,8 +61,8 @@ class IntegrationTestEnvironment : public ::testing::Environment {
 
     std::cout << "Creating database and table " << std::flush;
     DatabaseAdminClient admin_client;
-    auto database_future = admin_client.CreateDatabase(
-        *project_id_, *instance_id_, *database_id_, {R"""(CREATE TABLE Singers (
+    auto database_future =
+        admin_client.CreateDatabase(DatabaseName(), {R"""(CREATE TABLE Singers (
                                 SingerId   INT64 NOT NULL,
                                 FirstName  STRING(1024),
                                 LastName   STRING(1024)
@@ -84,8 +85,7 @@ class IntegrationTestEnvironment : public ::testing::Environment {
 
   void TearDown() override {
     DatabaseAdminClient admin_client;
-    auto drop_status =
-        admin_client.DropDatabase(*project_id_, *instance_id_, *database_id_);
+    auto drop_status = admin_client.DropDatabase(DatabaseName());
     EXPECT_STATUS_OK(drop_status);
   }
 

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -35,34 +35,26 @@ using ::testing::UnorderedElementsAreArray;
 // Use a ::testing::Environment to create the database once.
 class IntegrationTestEnvironment : public ::testing::Environment {
  public:
-  static Database DatabaseName() {
-    return Database(*project_id_, *instance_id_, *database_id_);
-  }
-
-  static std::string RandomTableName() {
-    return google::cloud::internal::Sample(*generator_, 16,
-                                           "abcdefghijklmnopqrstuvwxyz");
-  }
+  static Database const& GetDatabase() { return *db_; }
 
  protected:
   void SetUp() override {
-    project_id_ = new std::string(
-        google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or(""));
-    ASSERT_FALSE(project_id_->empty());
-    instance_id_ = new std::string(
+    auto project_id =
+        google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value();
+    auto instance_id =
         google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_INSTANCE")
-            .value_or(""));
-    ASSERT_FALSE(instance_id_->empty());
+            .value();
 
     generator_ = new google::cloud::internal::DefaultPRNG(
         google::cloud::internal::MakeDefaultPRNG());
-    database_id_ =
-        new std::string(spanner_testing::RandomDatabaseName(*generator_));
+    auto database_id = spanner_testing::RandomDatabaseName(*generator_);
+
+    db_ = new Database(project_id, instance_id, database_id);
 
     std::cout << "Creating database and table " << std::flush;
     DatabaseAdminClient admin_client;
     auto database_future =
-        admin_client.CreateDatabase(DatabaseName(), {R"""(CREATE TABLE Singers (
+        admin_client.CreateDatabase(*db_, {R"""(CREATE TABLE Singers (
                                 SingerId   INT64 NOT NULL,
                                 FirstName  STRING(1024),
                                 LastName   STRING(1024)
@@ -85,27 +77,23 @@ class IntegrationTestEnvironment : public ::testing::Environment {
 
   void TearDown() override {
     DatabaseAdminClient admin_client;
-    auto drop_status = admin_client.DropDatabase(DatabaseName());
+    auto drop_status = admin_client.DropDatabase(*db_);
     EXPECT_STATUS_OK(drop_status);
   }
 
  private:
-  static std::string* project_id_;
-  static std::string* instance_id_;
-  static std::string* database_id_;
+  static Database* db_;
   static google::cloud::internal::DefaultPRNG* generator_;
 };
 
-std::string* IntegrationTestEnvironment::project_id_;
-std::string* IntegrationTestEnvironment::instance_id_;
-std::string* IntegrationTestEnvironment::database_id_;
+Database* IntegrationTestEnvironment::db_;
 google::cloud::internal::DefaultPRNG* IntegrationTestEnvironment::generator_;
 
 class ClientIntegrationTest : public ::testing::Test {
  public:
   static void SetUpTestSuite() {
     client_ = google::cloud::internal::make_unique<Client>(
-        MakeConnection(IntegrationTestEnvironment::DatabaseName()));
+        MakeConnection(IntegrationTestEnvironment::GetDatabase()));
   }
 
   void SetUp() override {

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/getenv.h"
@@ -41,8 +42,8 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
   std::string database_id = spanner_testing::RandomDatabaseName(generator);
 
   DatabaseAdminClient client;
-  auto database_future =
-      client.CreateDatabase(project_id, instance_id, database_id);
+  Database db(project_id, instance_id, database_id);
+  auto database_future = client.CreateDatabase(db);
   auto database = database_future.get();
   ASSERT_STATUS_OK(database);
 
@@ -57,8 +58,7 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
                              ) PRIMARY KEY (SingerId)
                             )""";
 
-  auto update_future = client.UpdateDatabase(
-      project_id, instance_id, database_id, {create_table_statement});
+  auto update_future = client.UpdateDatabase(db, {create_table_statement});
   auto metadata = update_future.get();
   EXPECT_STATUS_OK(metadata);
   EXPECT_THAT(metadata->database(), EndsWith(database_id));
@@ -68,7 +68,7 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
     EXPECT_EQ(create_table_statement, metadata->statements(0));
   }
 
-  auto drop_status = client.DropDatabase(project_id, instance_id, database_id);
+  auto drop_status = client.DropDatabase(db);
   EXPECT_STATUS_OK(drop_status);
 }
 

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -64,7 +64,7 @@ StatusOr<ConnectionImpl::SessionHolder> ConnectionImpl::GetSession() {
   }
   grpc::ClientContext context;
   spanner_proto::CreateSessionRequest request;
-  request.set_database(database_);
+  request.set_database(db_.FullName());
   auto response = stub_->CreateSession(context, request);
   if (!response) {
     return response.status();

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_CONNECTION_IMPL_H_
 
 #include "google/cloud/spanner/connection.h"
+#include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status.h"
@@ -37,11 +38,11 @@ namespace internal {
  */
 class ConnectionImpl : public Connection {
  public:
-  // Creates a ConnectionImpl that will talk to the specified `database` using
-  // the given `stub`. We can test this class by injecting in a mock `stub`.
-  explicit ConnectionImpl(std::string database,
+  // Creates a ConnectionImpl that will talk to the specified `db` using the
+  // given `stub`. We can test this class by injecting in a mock `stub`.
+  explicit ConnectionImpl(Database db,
                           std::shared_ptr<internal::SpannerStub> stub)
-      : database_(std::move(database)), stub_(std::move(stub)) {}
+      : db_(std::move(db)), stub_(std::move(stub)) {}
 
   StatusOr<ResultSet> Read(ReadParams rp) override;
   StatusOr<ResultSet> ExecuteSql(ExecuteSqlParams esp) override;
@@ -79,7 +80,7 @@ class ConnectionImpl : public Connection {
   /// Implementation details for Rollback.
   Status Rollback(google::spanner::v1::TransactionSelector& s);
 
-  std::string database_;
+  Database db_;
   std::shared_ptr<internal::SpannerStub> stub_;
 
   // The current session pool.

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -52,14 +52,13 @@ class MockGrpcReader
 TEST(ConnectionImplTest, ReadGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  auto database_name =
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id");
-  ConnectionImpl conn(database_name, mock);
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  ConnectionImpl conn(db, mock);
   EXPECT_CALL(*mock, CreateSession(_, _))
       .WillOnce(::testing::Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+          [&db](grpc::ClientContext&,
+                spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
           }));
 
@@ -76,14 +75,13 @@ TEST(ConnectionImplTest, ReadGetSessionFailure) {
 TEST(ConnectionImplTest, ReadStreamingReadFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  auto database_name =
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id");
-  ConnectionImpl conn(database_name, mock);
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  ConnectionImpl conn(db, mock);
   EXPECT_CALL(*mock, CreateSession(_, _))
       .WillOnce(::testing::Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+          [&db](grpc::ClientContext&,
+                spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             spanner_proto::Session session;
             session.set_name("test-session-name");
             return session;
@@ -111,14 +109,13 @@ TEST(ConnectionImplTest, ReadStreamingReadFailure) {
 TEST(ConnectionImplTest, ReadSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  auto database_name =
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id");
-  ConnectionImpl conn(database_name, mock);
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  ConnectionImpl conn(db, mock);
   EXPECT_CALL(*mock, CreateSession(_, _))
       .WillOnce(::testing::Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+          [&db](grpc::ClientContext&,
+                spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             spanner_proto::Session session;
             session.set_name("test-session-name");
             return session;
@@ -176,14 +173,13 @@ TEST(ConnectionImplTest, ReadSuccess) {
 TEST(ConnectionImplTest, ExecuteSqlGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  auto database_name =
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id");
-  ConnectionImpl conn(database_name, mock);
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  ConnectionImpl conn(db, mock);
   EXPECT_CALL(*mock, CreateSession(_, _))
       .WillOnce(::testing::Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+          [&db](grpc::ClientContext&,
+                spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
           }));
 
@@ -197,14 +193,13 @@ TEST(ConnectionImplTest, ExecuteSqlGetSessionFailure) {
 TEST(ConnectionImplTest, ExecuteSqlStreamingReadFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  auto database_name =
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id");
-  ConnectionImpl conn(database_name, mock);
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  ConnectionImpl conn(db, mock);
   EXPECT_CALL(*mock, CreateSession(_, _))
       .WillOnce(::testing::Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+          [&db](grpc::ClientContext&,
+                spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             spanner_proto::Session session;
             session.set_name("test-session-name");
             return session;
@@ -229,14 +224,13 @@ TEST(ConnectionImplTest, ExecuteSqlStreamingReadFailure) {
 TEST(ConnectionImplTest, ExecuteSqlReadSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  auto database_name =
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id");
-  ConnectionImpl conn(database_name, mock);
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  ConnectionImpl conn(db, mock);
   EXPECT_CALL(*mock, CreateSession(_, _))
       .WillOnce(::testing::Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+          [&db](grpc::ClientContext&,
+                spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             spanner_proto::Session session;
             session.set_name("test-session-name");
             return session;
@@ -291,14 +285,13 @@ TEST(ConnectionImplTest, ExecuteSqlReadSuccess) {
 TEST(ConnectionImplTest, CommitGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  auto database_name =
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id");
-  ConnectionImpl conn(database_name, mock);
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  ConnectionImpl conn(db, mock);
   EXPECT_CALL(*mock, CreateSession(_, _))
-      .WillOnce(Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+      .WillOnce(
+          Invoke([&db](grpc::ClientContext&,
+                       spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
           }));
 
@@ -310,14 +303,13 @@ TEST(ConnectionImplTest, CommitGetSessionFailure) {
 TEST(ConnectionImplTest, CommitCommitFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  auto database_name =
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id");
-  ConnectionImpl conn(database_name, mock);
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  ConnectionImpl conn(db, mock);
   EXPECT_CALL(*mock, CreateSession(_, _))
-      .WillOnce(Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+      .WillOnce(
+          Invoke([&db](grpc::ClientContext&,
+                       spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             spanner_proto::Session session;
             session.set_name("test-session-name");
             return session;
@@ -336,14 +328,13 @@ TEST(ConnectionImplTest, CommitCommitFailure) {
 TEST(ConnectionImplTest, CommitTransactionId) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
-  auto database_name =
-      MakeDatabaseName("dummy_project", "dummy_instance", "dummy_database_id");
-  ConnectionImpl conn(database_name, mock);
+  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
+  ConnectionImpl conn(db, mock);
   EXPECT_CALL(*mock, CreateSession(_, _))
-      .WillOnce(Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+      .WillOnce(
+          Invoke([&db](grpc::ClientContext&,
+                       spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             spanner_proto::Session session;
             session.set_name("test-session-name");
             return session;
@@ -368,19 +359,19 @@ TEST(ConnectionImplTest, CommitTransactionId) {
 }
 
 TEST(ConnectionImplTest, RollbackGetSessionFailure) {
-  auto database_name = MakeDatabaseName("project", "instance", "database");
+  auto db = Database("project", "instance", "database");
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   EXPECT_CALL(*mock, CreateSession(_, _))
-      .WillOnce(Invoke(
-          [&database_name](grpc::ClientContext&,
-                           spanner_proto::CreateSessionRequest const& request) {
-            EXPECT_EQ(database_name, request.database());
+      .WillOnce(
+          Invoke([&db](grpc::ClientContext&,
+                       spanner_proto::CreateSessionRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
             return Status(StatusCode::kPermissionDenied, "uh-oh in GetSession");
           }));
   EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
 
-  ConnectionImpl conn(database_name, mock);
+  ConnectionImpl conn(db, mock);
   auto txn = MakeReadWriteTransaction();
   auto rollback = conn.Rollback({txn});
   EXPECT_EQ(StatusCode::kPermissionDenied, rollback.code());
@@ -388,44 +379,44 @@ TEST(ConnectionImplTest, RollbackGetSessionFailure) {
 }
 
 TEST(ConnectionImplTest, RollbackBeginTransaction) {
-  auto database_name = MakeDatabaseName("project", "instance", "database");
+  auto db = Database("project", "instance", "database");
   std::string const session_name = "test-session-name";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   EXPECT_CALL(*mock, CreateSession(_, _))
-      .WillOnce(Invoke([&database_name, &session_name](
+      .WillOnce(Invoke([&db, &session_name](
                            grpc::ClientContext&,
                            spanner_proto::CreateSessionRequest const& request) {
-        EXPECT_EQ(database_name, request.database());
+        EXPECT_EQ(db.FullName(), request.database());
         spanner_proto::Session session;
         session.set_name(session_name);
         return session;
       }));
   EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
 
-  ConnectionImpl conn(database_name, mock);
+  ConnectionImpl conn(db, mock);
   auto txn = MakeReadWriteTransaction();
   auto rollback = conn.Rollback({txn});
   EXPECT_TRUE(rollback.ok());
 }
 
 TEST(ConnectionImplTest, RollbackSingleUseTransaction) {
-  auto database_name = MakeDatabaseName("project", "instance", "database");
+  auto db = Database("project", "instance", "database");
   std::string const session_name = "test-session-name";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   EXPECT_CALL(*mock, CreateSession(_, _))
-      .WillOnce(Invoke([&database_name, &session_name](
+      .WillOnce(Invoke([&db, &session_name](
                            grpc::ClientContext&,
                            spanner_proto::CreateSessionRequest const& request) {
-        EXPECT_EQ(database_name, request.database());
+        EXPECT_EQ(db.FullName(), request.database());
         spanner_proto::Session session;
         session.set_name(session_name);
         return session;
       }));
   EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
 
-  ConnectionImpl conn(database_name, mock);
+  ConnectionImpl conn(db, mock);
   auto txn = internal::MakeSingleUseTransaction(
       Transaction::SingleUseOptions{Transaction::ReadOnlyOptions{}});
   auto rollback = conn.Rollback({txn});
@@ -434,16 +425,16 @@ TEST(ConnectionImplTest, RollbackSingleUseTransaction) {
 }
 
 TEST(ConnectionImplTest, RollbackFailure) {
-  auto database_name = MakeDatabaseName("project", "instance", "database");
+  auto db = Database("project", "instance", "database");
   std::string const session_name = "test-session-name";
   std::string const transaction_id = "test-txn-id";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   EXPECT_CALL(*mock, CreateSession(_, _))
-      .WillOnce(Invoke([&database_name, &session_name](
+      .WillOnce(Invoke([&db, &session_name](
                            grpc::ClientContext&,
                            spanner_proto::CreateSessionRequest const& request) {
-        EXPECT_EQ(database_name, request.database());
+        EXPECT_EQ(db.FullName(), request.database());
         spanner_proto::Session session;
         session.set_name(session_name);
         return session;
@@ -457,7 +448,7 @@ TEST(ConnectionImplTest, RollbackFailure) {
         return Status(StatusCode::kPermissionDenied, "uh-oh in Rollback");
       }));
 
-  ConnectionImpl conn(database_name, mock);
+  ConnectionImpl conn(db, mock);
   auto txn = MakeReadWriteTransaction();
   auto begin_transaction =
       [&transaction_id](spanner_proto::TransactionSelector& s, std::int64_t) {
@@ -471,16 +462,16 @@ TEST(ConnectionImplTest, RollbackFailure) {
 }
 
 TEST(ConnectionImplTest, RollbackSuccess) {
-  auto database_name = MakeDatabaseName("project", "instance", "database");
+  auto db = Database("project", "instance", "database");
   std::string const session_name = "test-session-name";
   std::string const transaction_id = "test-txn-id";
 
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   EXPECT_CALL(*mock, CreateSession(_, _))
-      .WillOnce(Invoke([&database_name, &session_name](
+      .WillOnce(Invoke([&db, &session_name](
                            grpc::ClientContext&,
                            spanner_proto::CreateSessionRequest const& request) {
-        EXPECT_EQ(database_name, request.database());
+        EXPECT_EQ(db.FullName(), request.database());
         spanner_proto::Session session;
         session.set_name(session_name);
         return session;
@@ -494,7 +485,7 @@ TEST(ConnectionImplTest, RollbackSuccess) {
         return Status();
       }));
 
-  ConnectionImpl conn(database_name, mock);
+  ConnectionImpl conn(db, mock);
   auto txn = MakeReadWriteTransaction();
   auto begin_transaction =
       [&transaction_id](spanner_proto::TransactionSelector& s, std::int64_t) {

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -68,7 +68,7 @@ void CreateDatabase(std::vector<std::string> const& argv) {
     if (!db) {
       throw std::runtime_error(db.status().message());
     }
-    std::cout << "Created database [" << database_id << "]\n";
+    std::cout << "Created database [" << database << "]\n";
   }
   //! [create-database] [END spanner_create_database]
   (argv[0], argv[1], argv[2]);
@@ -136,7 +136,7 @@ void DropDatabase(std::vector<std::string> const& argv) {
     if (!status.ok()) {
       throw std::runtime_error(status.message());
     }
-    std::cout << "Database " << database_id << " successfully dropped\n";
+    std::cout << "Database " << database << " successfully dropped\n";
   }
   //! [drop-database] [END spanner_drop_database]
   (argv[0], argv[1], argv[2]);

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -58,7 +58,8 @@ void CreateDatabase(std::vector<std::string> const& argv) {
                                 LastName   STRING(1024),
                                 SingerInfo BYTES(MAX)
                         ) PRIMARY KEY (SingerId))""",
-                                         R"""(CREATE TABLE Albums (
+                                         R"""(
+                        CREATE TABLE Albums (
                                 SingerId     INT64 NOT NULL,
                                 AlbumId      INT64 NOT NULL,
                                 AlbumTitle   STRING(MAX)
@@ -150,8 +151,9 @@ void InsertData(std::vector<std::string> const& argv) {
 
   // TODO(#377) - cache the client across sample functions.
   namespace spanner = google::cloud::spanner;
-  spanner::Client client(spanner::MakeConnection(
-      spanner::MakeDatabaseName(argv[0], argv[1], argv[2])));
+
+  spanner::Database db(argv[0], argv[1], argv[2]);
+  spanner::Client client(spanner::MakeConnection(db));
 
   //! [START spanner_insert_data]
   namespace spanner = google::cloud::spanner;
@@ -194,8 +196,8 @@ void DmlStandardInsert(std::vector<std::string> const& argv) {
 
   // TODO(#377) - cache the client across sample functions.
   namespace spanner = google::cloud::spanner;
-  spanner::Client client(spanner::MakeConnection(
-      spanner::MakeDatabaseName(argv[0], argv[1], argv[2])));
+  spanner::Database db(argv[0], argv[1], argv[2]);
+  spanner::Client client(spanner::MakeConnection(db));
 
   //! [START spanner_dml_standard_insert]
   namespace spanner = google::cloud::spanner;

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -48,16 +48,17 @@ void CreateDatabase(std::vector<std::string> const& argv) {
   [](std::string const& project_id, std::string const& instance_id,
      std::string const& database_id) {
     google::cloud::spanner::DatabaseAdminClient client;
+    google::cloud::spanner::Database database(project_id, instance_id,
+                                              database_id);
     future<StatusOr<google::spanner::admin::database::v1::Database>> future =
-        client.CreateDatabase(project_id, instance_id, database_id,
-                              {R"""(
+        client.CreateDatabase(database, {R"""(
                         CREATE TABLE Singers (
                                 SingerId   INT64 NOT NULL,
                                 FirstName  STRING(1024),
                                 LastName   STRING(1024),
                                 SingerInfo BYTES(MAX)
                         ) PRIMARY KEY (SingerId))""",
-                               R"""(CREATE TABLE Albums (
+                                         R"""(CREATE TABLE Albums (
                                 SingerId     INT64 NOT NULL,
                                 AlbumId      INT64 NOT NULL,
                                 AlbumTitle   STRING(MAX)
@@ -85,11 +86,12 @@ void AddColumn(std::vector<std::string> const& argv) {
   [](std::string const& project_id, std::string const& instance_id,
      std::string const& database_id) {
     google::cloud::spanner::DatabaseAdminClient client;
+    google::cloud::spanner::Database database(project_id, instance_id,
+                                              database_id);
     future<StatusOr<
         google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
         future = client.UpdateDatabase(
-            project_id, instance_id, database_id,
-            {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"});
+            database, {"ALTER TABLE Albums ADD COLUMN MarketingBudget INT64"});
     StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>
         metadata = future.get();
     if (!metadata) {
@@ -128,8 +130,9 @@ void DropDatabase(std::vector<std::string> const& argv) {
   [](std::string const& project_id, std::string const& instance_id,
      std::string const& database_id) {
     google::cloud::spanner::DatabaseAdminClient client;
-    google::cloud::Status status =
-        client.DropDatabase(project_id, instance_id, database_id);
+    google::cloud::spanner::Database database(project_id, instance_id,
+                                              database_id);
+    google::cloud::Status status = client.DropDatabase(database);
     if (!status.ok()) {
       throw std::runtime_error(status.message());
     }

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -22,6 +22,7 @@ spanner_client_hdrs = [
     "client_options.h",
     "commit_result.h",
     "connection.h",
+    "database.h",
     "database_admin_client.h",
     "date.h",
     "internal/base64.h",
@@ -61,6 +62,7 @@ spanner_client_hdrs = [
 spanner_client_srcs = [
     "client.cc",
     "client_options.cc",
+    "database.cc",
     "database_admin_client.cc",
     "date.cc",
     "internal/base64.cc",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -19,6 +19,7 @@
 spanner_client_unit_tests = [
     "client_options_test.cc",
     "client_test.cc",
+    "database_test.cc",
     "database_admin_client_test.cc",
     "date_test.cc",
     "internal/base64_test.cc",


### PR DESCRIPTION
Fixes #369 

This PR adds the `Database` class, which identifies a Spanner database. It is constructed with a `project_id`, `instance_id`, and `database_id`.

All functions that need these fields now accept a `Database` argument instead of a `std::string` or 3-separate `std::string`s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/382)
<!-- Reviewable:end -->
