### PR TITLE
Add `std::string` overloads for `Client::ExecuteSql()`

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -67,6 +67,10 @@ StatusOr<ResultSet> Client::ExecuteSql(SqlStatement statement) {
        std::move(statement)});
 }
 
+StatusOr<ResultSet> Client::ExecuteSql(std::string const& statement) {
+  return ExecuteSql(SqlStatement{statement});
+}
+
 StatusOr<ResultSet> Client::ExecuteSql(
     Transaction::SingleUseOptions transaction_options, SqlStatement statement) {
   return conn_->ExecuteSql(
@@ -74,9 +78,22 @@ StatusOr<ResultSet> Client::ExecuteSql(
        std::move(statement)});
 }
 
+StatusOr<ResultSet> Client::ExecuteSql(
+    Transaction::SingleUseOptions transaction_options,
+    std::string const& statement) {
+  return conn_->ExecuteSql(
+      {internal::MakeSingleUseTransaction(std::move(transaction_options)),
+       SqlStatement{statement}});
+}
+
 StatusOr<ResultSet> Client::ExecuteSql(Transaction transaction,
                                        SqlStatement statement) {
   return conn_->ExecuteSql({std::move(transaction), std::move(statement)});
+}
+
+StatusOr<ResultSet> Client::ExecuteSql(Transaction transaction,
+                                       std::string const& statement) {
+  return conn_->ExecuteSql({std::move(transaction), SqlStatement{statement}});
 }
 
 StatusOr<ResultSet> Client::ExecuteSql(SqlPartition const& /* partition */) {

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -81,9 +81,7 @@ StatusOr<ResultSet> Client::ExecuteSql(
 StatusOr<ResultSet> Client::ExecuteSql(
     Transaction::SingleUseOptions transaction_options,
     std::string const& statement) {
-  return conn_->ExecuteSql(
-      {internal::MakeSingleUseTransaction(std::move(transaction_options)),
-       SqlStatement{statement}});
+  return ExecuteSql(std::move(transaction_options), SqlStatement(statement));
 }
 
 StatusOr<ResultSet> Client::ExecuteSql(Transaction transaction,
@@ -93,7 +91,7 @@ StatusOr<ResultSet> Client::ExecuteSql(Transaction transaction,
 
 StatusOr<ResultSet> Client::ExecuteSql(Transaction transaction,
                                        std::string const& statement) {
-  return conn_->ExecuteSql({std::move(transaction), SqlStatement{statement}});
+  return ExecuteSql(std::move(transaction), SqlStatement{statement});
 }
 
 StatusOr<ResultSet> Client::ExecuteSql(SqlPartition const& /* partition */) {

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -235,6 +235,11 @@ class Client {
 
   /**
    * @copydoc ExecuteSql(SqlStatement)
+   */
+  StatusOr<ResultSet> ExecuteSql(std::string const& statement);
+
+  /**
+   * @copydoc ExecuteSql(SqlStatement)
    *
    * @param transaction_options Execute this query in a single-use transaction
    *     with these options.
@@ -244,12 +249,25 @@ class Client {
       SqlStatement statement);
 
   /**
+   * @copydoc ExecuteSql(Transaction::SingleUseOptions, SqlStatement)
+   */
+  StatusOr<ResultSet> ExecuteSql(
+      Transaction::SingleUseOptions transaction_options,
+      std::string const& statement);
+
+  /**
    * @copydoc ExecuteSql(SqlStatement)
    *
    * @param transaction Execute this query as part of an existing transaction.
    */
   StatusOr<ResultSet> ExecuteSql(Transaction transaction,
                                  SqlStatement statement);
+
+  /**
+   * @copydoc ExecuteSql(Transaction transaction, SqlStatement statement);
+   */
+  StatusOr<ResultSet> ExecuteSql(Transaction transaction,
+                                 std::string const& statement);
   //@}
 
   /**

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -234,6 +234,78 @@ TEST(ClientTest, ExecuteSqlSuccess) {
   EXPECT_EQ(row_number, 2);
 }
 
+TEST(ClientTest, ExecuteSqlStringOverload) {
+  auto conn = std::make_shared<MockConnection>();
+  Client client(conn);
+
+  auto source = make_unique<MockResultSetSource>();
+  ResultSet result_set(std::move(source));
+  EXPECT_CALL(*conn, ExecuteSql(_))
+      .WillOnce(Return(ByMove(std::move(result_set))));
+
+  auto result = client.ExecuteSql("select * from table;");
+  EXPECT_STATUS_OK(result);
+}
+
+TEST(ClientTest, ExecuteSqlWithTransaction) {
+  auto conn = std::make_shared<MockConnection>();
+  Client client(conn);
+
+  auto source = make_unique<MockResultSetSource>();
+  ResultSet result_set(std::move(source));
+  EXPECT_CALL(*conn, ExecuteSql(_))
+      .WillOnce(Return(ByMove(std::move(result_set))));
+
+  auto txn = MakeReadWriteTransaction();
+  auto result = client.ExecuteSql(txn, SqlStatement{"select * from table;"});
+  EXPECT_STATUS_OK(result);
+}
+
+TEST(ClientTest, ExecuteSqlWithTransactionStringOverload) {
+  auto conn = std::make_shared<MockConnection>();
+  Client client(conn);
+
+  auto source = make_unique<MockResultSetSource>();
+  ResultSet result_set(std::move(source));
+  EXPECT_CALL(*conn, ExecuteSql(_))
+      .WillOnce(Return(ByMove(std::move(result_set))));
+
+  auto txn = MakeReadWriteTransaction();
+  auto result = client.ExecuteSql(txn, "select * from table;");
+  EXPECT_STATUS_OK(result);
+}
+
+TEST(ClientTest, ExecuteSqlWithTransactionSingleOption) {
+  auto conn = std::make_shared<MockConnection>();
+  Client client(conn);
+
+  auto source = make_unique<MockResultSetSource>();
+  ResultSet result_set(std::move(source));
+  EXPECT_CALL(*conn, ExecuteSql(_))
+      .WillOnce(Return(ByMove(std::move(result_set))));
+
+  Transaction::ReadOnlyOptions strong;
+  Transaction::SingleUseOptions su_strong(strong);
+  auto result =
+      client.ExecuteSql(su_strong, SqlStatement{"select * from table;"});
+  EXPECT_STATUS_OK(result);
+}
+
+TEST(ClientTest, ExecuteSqlWithTransactionSingleOptionStringOverload) {
+  auto conn = std::make_shared<MockConnection>();
+  Client client(conn);
+
+  auto source = make_unique<MockResultSetSource>();
+  ResultSet result_set(std::move(source));
+  EXPECT_CALL(*conn, ExecuteSql(_))
+      .WillOnce(Return(ByMove(std::move(result_set))));
+
+  Transaction::ReadOnlyOptions strong;
+  Transaction::SingleUseOptions su_strong(strong);
+  auto result = client.ExecuteSql(su_strong, "select * from table;");
+  EXPECT_STATUS_OK(result);
+}
+
 TEST(ClientTest, ExecuteSqlFailure) {
   auto conn = std::make_shared<MockConnection>();
   Client client(conn);


### PR DESCRIPTION
Fixes #389

These are simple wrappers for their `SqlStatement` counterparts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/395)
<!-- Reviewable:end -->
