### PR TITLE
Simplify Client::RunTransaction() functor interface

### DIFF
--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -347,8 +347,7 @@ class Client {
    * @return A `StatusOr` containing the result of the commit or error status
    *     on failure.
    */
-  StatusOr<CommitResult> Commit(Transaction transaction,
-                                std::vector<Mutation> mutations);
+  StatusOr<CommitResult> Commit(Transaction transaction, Mutations mutations);
 
   /**
    * Rolls back a read-write transaction, releasing any locks it holds.
@@ -397,19 +396,15 @@ std::shared_ptr<Connection> MakeConnection(
  * The caller-provided function will be passed the `Client` argument and a
  * newly created read-write `Transaction`. It should use these objects to
  * issue any `Read()`s, `ExecuteSql()`s, etc., and return the `Mutation`s to
- * commit or whether to rollback the transaction instead.
+ * commit, or an error (which causes the transaction to be rolled back).
  *
  * The lock priority of the transaction increases after each prior aborted
  * transaction, meaning that the next attempt has a slightly better chance
  * of success than before.
  */
-struct TransactionAction {
-  enum { kCommit, kRollback } action;
-  std::vector<Mutation> mutations;
-};
 StatusOr<CommitResult> RunTransaction(
     Client client, Transaction::ReadWriteOptions const& opts,
-    std::function<TransactionAction(Client, Transaction)> const& f);
+    std::function<StatusOr<Mutations>(Client, Transaction)> const& f);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -90,7 +90,7 @@ class Connection {
 
   struct CommitParams {
     Transaction transaction;
-    std::vector<Mutation> mutations;
+    Mutations mutations;
   };
   virtual StatusOr<CommitResult> Commit(CommitParams) = 0;
 

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -317,7 +317,7 @@ TEST_F(ClientIntegrationTest, RunTransaction) {
     isb.AddRow(MakeRow(100, "first-name-100", "last-name-100"));
     isb.AddRow(MakeRow(102, "first-name-102", "last-name-102"));
     isb.AddRow(MakeRow(199, "first-name-199", "last-name-199"));
-    return TransactionAction{TransactionAction::kCommit, {isb.Build()}};
+    return Mutations{isb.Build()};
   };
   auto insert_result = RunTransaction(*client_, rw_opts, insert);
   EXPECT_STATUS_OK(insert_result);
@@ -327,7 +327,7 @@ TEST_F(ClientIntegrationTest, RunTransaction) {
   auto dele = [](Client const&, Transaction const&) {
     auto ksb = KeySetBuilder<Row<std::int64_t>>().Add(MakeRow(102));
     auto mutation = MakeDeleteMutation("Singers", ksb.Build());
-    return TransactionAction{TransactionAction::kCommit, {mutation}};
+    return Mutations{mutation};
   };
   auto delete_result = RunTransaction(*client_, rw_opts, dele);
   EXPECT_STATUS_OK(delete_result);

--- a/google/cloud/spanner/mutations.h
+++ b/google/cloud/spanner/mutations.h
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/row.h"
 #include "google/cloud/spanner/value.h"
 #include <google/spanner/v1/mutation.pb.h>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -84,6 +85,12 @@ class Mutation {
 
   google::spanner::v1::Mutation m_;
 };
+
+/**
+ * An ordered sequence of mutations to pass to `Client::Commit()` or return
+ * from the `Client::RunTransaction()` functor.
+ */
+using Mutations = std::vector<Mutation>;
 
 // This namespace contains implementation details. It is not part of the public
 // API, and subject to change without notice.

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -323,18 +323,20 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
 
 //! [START spanner_dml_standard_insert]
 void DmlStandardInsert(google::cloud::spanner::Client client) {
+  using google::cloud::StatusOr;
   namespace spanner = google::cloud::spanner;
   auto commit_result = spanner::RunTransaction(
       std::move(client), spanner::Transaction::ReadWriteOptions{},
-      [](spanner::Client client, spanner::Transaction txn) {
-        client.ExecuteSql(
+      [](spanner::Client client,
+         spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
+        auto read = client.ExecuteSql(
             std::move(txn),
             spanner::SqlStatement(
                 "INSERT INTO Singers (SingerId, FirstName, LastName)"
                 "  VALUES (10, 'Virginia', 'Watson')",
                 {}));
-        return spanner::TransactionAction{spanner::TransactionAction::kCommit,
-                                          {}};
+        if (!read) return read.status();
+        return spanner::Mutations{};
       });
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());
@@ -345,18 +347,20 @@ void DmlStandardInsert(google::cloud::spanner::Client client) {
 
 //! [START spanner_dml_standard_update]
 void DmlStandardUpdate(google::cloud::spanner::Client client) {
+  using google::cloud::StatusOr;
   namespace spanner = google::cloud::spanner;
   auto commit_result = spanner::RunTransaction(
       std::move(client), spanner::Transaction::ReadWriteOptions{},
-      [](spanner::Client client, spanner::Transaction txn) {
-        client.ExecuteSql(
+      [](spanner::Client client,
+         spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
+        auto read = client.ExecuteSql(
             std::move(txn),
             spanner::SqlStatement(
                 "UPDATE Albums SET MarketingBudget = MarketingBudget * 2"
                 " WHERE SingerId = 1 AND AlbumId = 1",
                 {}));
-        return spanner::TransactionAction{spanner::TransactionAction::kCommit,
-                                          {}};
+        if (!read) return read.status();
+        return spanner::Mutations{};
       });
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -329,13 +329,13 @@ void DmlStandardInsert(google::cloud::spanner::Client client) {
       std::move(client), spanner::Transaction::ReadWriteOptions{},
       [](spanner::Client client,
          spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
-        auto read = client.ExecuteSql(
+        auto insert = client.ExecuteSql(
             std::move(txn),
             spanner::SqlStatement(
                 "INSERT INTO Singers (SingerId, FirstName, LastName)"
                 "  VALUES (10, 'Virginia', 'Watson')",
                 {}));
-        if (!read) return read.status();
+        if (!insert) return insert.status();
         return spanner::Mutations{};
       });
   if (!commit_result) {
@@ -353,13 +353,13 @@ void DmlStandardUpdate(google::cloud::spanner::Client client) {
       std::move(client), spanner::Transaction::ReadWriteOptions{},
       [](spanner::Client client,
          spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
-        auto read = client.ExecuteSql(
+        auto update = client.ExecuteSql(
             std::move(txn),
             spanner::SqlStatement(
                 "UPDATE Albums SET MarketingBudget = MarketingBudget * 2"
                 " WHERE SingerId = 1 AND AlbumId = 1",
                 {}));
-        if (!read) return read.status();
+        if (!update) return update.status();
         return spanner::Mutations{};
       });
   if (!commit_result) {
@@ -371,15 +371,18 @@ void DmlStandardUpdate(google::cloud::spanner::Client client) {
 
 //! [START spanner_dml_standard_delete]
 void DmlStandardDelete(google::cloud::spanner::Client client) {
+  using google::cloud::StatusOr;
   namespace spanner = google::cloud::spanner;
   auto commit_result = spanner::RunTransaction(
       std::move(client), spanner::Transaction::ReadWriteOptions{},
-      [](spanner::Client client, spanner::Transaction txn) {
-        client.ExecuteSql(std::move(txn),
-                          spanner::SqlStatement(
-                              "DELETE FROM Singers WHERE FirstName = 'Alice'"));
-        return spanner::TransactionAction{spanner::TransactionAction::kCommit,
-                                          {}};
+      [](spanner::Client client,
+         spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
+        auto dele = client.ExecuteSql(
+            std::move(txn),
+            spanner::SqlStatement(
+                "DELETE FROM Singers WHERE FirstName = 'Alice'"));
+        if (!dele) return dele.status();
+        return spanner::Mutations{};
       });
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());


### PR DESCRIPTION
DO NOT SUBMIT.  FOR DISCUSSION ONLY FOR NOW.

Replace `TransactionAction` with `StatusOr<Mutations>` as the return
type for the `Client::RunTransaction()` functor. This makes it easier
to write a functor (addressing #390), and makes it very clear what
`RunTransaction()` should return when the transaction will be rolled
back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/397)
<!-- Reviewable:end -->
