### PR TITLE
fix: Harden SqlStatement against injection attacks

### DIFF
--- a/google/cloud/spanner/sql_partition.cc
+++ b/google/cloud/spanner/sql_partition.cc
@@ -80,9 +80,9 @@ StatusOr<SqlPartition> DeserializeSqlPartition(
     }
   }
 
-  SqlPartition sql_partition(proto.transaction().id(), proto.session(),
-                             proto.partition_token(),
-                             SqlStatement(proto.sql(), sql_parameters));
+  SqlPartition sql_partition(
+      proto.transaction().id(), proto.session(), proto.partition_token(),
+      MakeUntrustedSqlStatement(proto.sql(), sql_parameters));
   return sql_partition;
 }
 

--- a/google/cloud/spanner/sql_partition_test.cc
+++ b/google/cloud/spanner/sql_partition_test.cc
@@ -42,7 +42,7 @@ class SqlPartitionTester {
 namespace {
 
 TEST(SqlPartitionTest, MakeSqlPartition) {
-  std::string stmt("select * from foo where name = @name");
+  auto const& stmt = "select * from foo where name = @name";
   SqlStatement::ParamType params = {{"name", Value("Bob")}};
   std::string partition_token("token");
   std::string session_id("session");
@@ -58,7 +58,7 @@ TEST(SqlPartitionTest, MakeSqlPartition) {
 }
 
 TEST(SqlPartitionTest, Constructor) {
-  std::string stmt("select * from foo where name = @name");
+  auto const& stmt = "select * from foo where name = @name";
   SqlStatement::ParamType params = {{"name", Value("Bob")}};
   std::string partition_token("token");
   std::string session_id("session");
@@ -74,7 +74,7 @@ TEST(SqlPartitionTest, Constructor) {
 }
 
 TEST(SqlPartitionTester, RegularSemantics) {
-  std::string stmt("select * from foo where name = @name");
+  auto const& stmt = "select * from foo where name = @name";
   SqlStatement::ParamType params = {{"name", Value("Bob")}};
   std::string partition_token("token");
   std::string session_id("session");

--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -30,7 +30,7 @@ using ::testing::Eq;
 using ::testing::UnorderedPointwise;
 
 TEST(SqlStatementTest, SqlAccessor) {
-  const char* statement = "select * from foo";
+  auto const& statement = "select * from foo";
   SqlStatement stmt(statement);
   EXPECT_EQ(statement, stmt.sql());
 }
@@ -123,7 +123,7 @@ TEST(SqlStatementTest, ToProtoWithParams) {
                                     {"first", Value("Elwood")},
                                     {"destroyed_cars", Value(103)}};
 
-  auto sql =
+  auto const& sql =
       "SELECT * FROM foo WHERE last = @last AND first = @first AND "
       "destroyed_cars >= @destroyed_cars";
   SqlStatement stmt(sql, params);


### PR DESCRIPTION
# DO NOT APPROVE - JUST FOR DISCUSSION 

This change makes `SqlStatement` only be constructible by compile-time
string literals. In C++11, there's no 100% guaranteed way to ensure this
(that I know of), so this approximates it using a fairly common
technique of requiring the argument to be a statically sized array of
char. There's a TODO to add some compiler-specific hooks (hidden behind
a macro) to verify this "better" if we can.

There will be cases where users need to construct their SQL query as a
std::string at runtime. For these cases there is a
`MakeUntrustedSqlStatement()` factory function, which callers can use.
When this function is used it is the caller's responsibility to verify
that the string they are passing is safe.

Fixes: #400