### PR TITLE
feat: Implement more Cloud Spanner STRUCT samples.

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -487,17 +487,22 @@ void FieldAccessOnStructParameters(google::cloud::spanner::Client client) {
 //! [START spanner_field_access_on_nested_struct]
 void FieldAccessOnNestedStruct(google::cloud::spanner::Client client) {
   namespace spanner = google::cloud::spanner;
-  using SingerFullName = std::tuple<std::string, std::string>;
 
   // Cloud Spanner STRUCT<> with named fields is represented as
   // tuple<pair<string, T>...>. Create a type alias for this example:
+  using SingerFullName = std::tuple<std::pair<std::string, std::string>,
+                                    std::pair<std::string, std::string>>;
+  auto make_name = [](std::string fname, std::string lname) {
+    return SingerFullName({"FirstName", std::move(fname)},
+                          {"LastName", std::move(lname)});
+  };
   using SongInfo =
       std::tuple<std::pair<std::string, std::string>,
                  std::pair<std::string, std::vector<SingerFullName>>>;
-  auto songinfo = SongInfo({"SongName", "Imagination"},
-                           {"ArtistNames",
-                            {SingerFullName{"Elena", "Campbell"},
-                             SingerFullName{"Hannah", "Harris"}}});
+  auto songinfo = SongInfo(
+      {"SongName", "Imagination"},
+      {"ArtistNames",
+       {make_name("Elena", "Campbell"), make_name("Hannah", "Harris")}});
 
   auto reader = client.ExecuteSql(spanner::SqlStatement(
       "SELECT SingerId, @songinfo.SongName FROM Singers"

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -468,7 +468,7 @@ void FieldAccessOnStructParameters(google::cloud::spanner::Client client) {
   // tuple<pair<string, T>...>. Create a type alias for this example:
   using SingerName = std::tuple<std::pair<std::string, std::string>,
                                 std::pair<std::string, std::string>>;
-  SingerName name({"FirtName", "Elena"}, {"LastName", "Campbell"});
+  SingerName name({"FirstName", "Elena"}, {"LastName", "Campbell"});
 
   auto reader = client.ExecuteSql(spanner::SqlStatement(
       "SELECT SingerId FROM Singers WHERE FirstName = @name.FirstName",
@@ -494,9 +494,10 @@ void FieldAccessOnNestedStruct(google::cloud::spanner::Client client) {
   using SongInfo =
       std::tuple<std::pair<std::string, std::string>,
                  std::pair<std::string, std::vector<SingerFullName>>>;
-  auto songinfo =
-      SongInfo({"SongName", "Imagination"},
-               {"ArtistNames", {{"Elena", "Campbell"}, {"Hannah", "Harris"}}});
+  auto songinfo = SongInfo({"SongName", "Imagination"},
+                           {"ArtistNames",
+                            {SingerFullName{"Elena", "Campbell"},
+                             SingerFullName{"Hannah", "Harris"}}});
 
   auto reader = client.ExecuteSql(spanner::SqlStatement(
       "SELECT SingerId, @songinfo.SongName FROM Singers"


### PR DESCRIPTION
Add the `spanner_field_access_on_struct_parameters` and the
`spanner_field_access_on_nested_struct` samples.

Fixes #191 and fixes #192.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/411)
<!-- Reviewable:end -->
