### PR TITLE
chore: sanitizer builds should have debug symbols.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,8 +19,9 @@
 
 # --config asan: Address Sanitizer
 build:asan --strip=never
+build:asan --copt=-Og
+build:asan --copt=-g
 build:asan --copt=-fsanitize=address
-build:asan --copt=-O0
 build:asan --copt=-fno-omit-frame-pointer
 build:asan --linkopt=-fsanitize=address
 build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
@@ -28,6 +29,8 @@ build:asan --action_env=LSAN_OPTIONS=report_objects=1
 
 # --config tsan: Thread Sanitizer
 build:tsan --strip=never
+build:tsan --copt=-Og
+build:tsan --copt=-g
 build:tsan --copt=-fsanitize=thread
 build:tsan --copt=-fno-omit-frame-pointer
 build:tsan --linkopt=-fsanitize=thread
@@ -35,6 +38,8 @@ build:tsan --action_env=TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1
 
 # --config ubsan: Undefined Behavior Sanitizer
 build:ubsan --strip=never
+build:ubsan --copt=-Og
+build:ubsan --copt=-g
 build:ubsan --copt=-fsanitize=undefined
 build:ubsan --copt=-fno-omit-frame-pointer
 build:ubsan --linkopt=-fsanitize=undefined
@@ -43,8 +48,9 @@ build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 
 # --config msan: Memory Sanitizer
 build:msan --strip=never
+build:msan --copt=-Og
+build:msan --copt=-g
 build:msan --copt=-fsanitize=memory
-build:msan --copt=-O0
 build:msan --copt=-fno-omit-frame-pointer
 build:msan --copt=-fsanitize-memory-track-origins
 build:msan --copt=-fsanitize-memory-use-after-dtor


### PR DESCRIPTION
Without debug symbols the error messages are really hard to grok.
Compile with -Og -g for all sanitizer builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/434)
<!-- Reviewable:end -->
