### PR TITLE
chore: run coverage tests sequentially.

### DIFF
--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -305,14 +305,14 @@ TEST(Row, ValuesMove) {
   EXPECT_EQ(Value("bar"), values[2]);
 }
 
-TEST(Row, PrinTo) {
+TEST(Row, PrintTo) {
   auto row = MakeRow(1234, "foo", 2345, "bar", "baz");
   std::ostringstream os;
   PrintTo(row, &os);
   auto actual = os.str();
   EXPECT_THAT(actual, HasSubstr("1234"));
-  EXPECT_THAT(actual, HasSubstr("2345"));
   EXPECT_THAT(actual, HasSubstr("foo"));
+  EXPECT_THAT(actual, HasSubstr("2345"));
   EXPECT_THAT(actual, HasSubstr("bar"));
   EXPECT_THAT(actual, HasSubstr("baz"));
 }

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -27,6 +27,9 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
+
+using ::testing::HasSubstr;
+
 template <typename... Ts>
 void VerifyRegularType(Ts&&... ts) {
   auto const row = MakeRow(std::forward<Ts>(ts)...);
@@ -282,6 +285,36 @@ TEST(Row, ValuesAccessorRvalue) {
   auto v = array[0].get<std::string>();
   EXPECT_TRUE(v.ok());
   EXPECT_EQ(kData, *v);
+}
+
+TEST(Row, ValuesConst) {
+  auto const row = MakeRow("foo", 12345, "bar");
+  auto values = row.values();
+  EXPECT_EQ(3, values.size());
+  EXPECT_EQ(Value("foo"), values[0]);
+  EXPECT_EQ(Value(12345), values[1]);
+  EXPECT_EQ(Value("bar"), values[2]);
+}
+
+TEST(Row, ValuesMove) {
+  auto row = MakeRow("foo", 12345, "bar");
+  auto values = std::move(row).values();
+  EXPECT_EQ(3, values.size());
+  EXPECT_EQ(Value("foo"), values[0]);
+  EXPECT_EQ(Value(12345), values[1]);
+  EXPECT_EQ(Value("bar"), values[2]);
+}
+
+TEST(Row, PrinTo) {
+  auto row = MakeRow(1234, "foo", 2345, "bar", "baz");
+  std::ostringstream os;
+  PrintTo(row, &os);
+  auto actual = os.str();
+  EXPECT_THAT(actual, HasSubstr("1234"));
+  EXPECT_THAT(actual, HasSubstr("2345"));
+  EXPECT_THAT(actual, HasSubstr("foo"));
+  EXPECT_THAT(actual, HasSubstr("bar"));
+  EXPECT_THAT(actual, HasSubstr("baz"));
 }
 
 }  // namespace


### PR DESCRIPTION
The gcov .gcda files for library files are shared across tests, and
written when the test finishes. If the tests are executed in parallel
some of the data may become lost (or the file corrupted). The easiest
fix is to run the tests sequentially. We could use a clever value for
GCOV_PREFIX and then aggregate the results, but that can be a future
improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/437)
<!-- Reviewable:end -->
