### PR TITLE
feat: Rename Bound -> KeyBound

### DIFF
--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -335,8 +335,8 @@ TEST_F(ClientIntegrationTest, RunTransaction) {
 
   // Read SingerIds [100 ... 200).
   std::vector<std::int64_t> ids;
-  auto ksb = KeySetBuilder<Row<std::int64_t>>().Add(
-      MakeKeyRange(MakeBoundClosed(MakeRow(100)), MakeBoundOpen(MakeRow(200))));
+  auto ksb = KeySetBuilder<Row<std::int64_t>>().Add(MakeKeyRange(
+      MakeKeyBoundClosed(MakeRow(100)), MakeKeyBoundOpen(MakeRow(200))));
   auto results = client_->Read("Singers", ksb.Build(), {"SingerId"});
   EXPECT_STATUS_OK(results);
   if (results) {

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -45,31 +45,31 @@ struct IsRow<Row<Ts...>> : std::true_type {};
 }  // namespace internal
 
 /**
- * The `Bound` class is a regular type that represents one endpoint of an
+ * The `KeyBound` class is a regular type that represents one endpoint of an
  * interval of keys.
  *
- * `Bound`s can be "open", meaning the matching row will be excluded from the
- * results, or "closed" meaning the matching row will be included. `Bound`
- * instances should be created with the `MakeBoundOpen()` or
- * `MakeBoundClosed()` factory functions.
+ * `KeyBound`s can be "open", meaning the matching row will be excluded from
+ * the results, or "closed" meaning the matching row will be included.
+ * `KeyBound` instances should be created with the `MakeKeyBoundOpen()` or
+ * `MakeKeyBoundClosed()` factory functions.
  *
  * @tparam KeyType spanner::Row<Types...> that corresponds to the desired index
  * definition.
  */
 template <typename RowType>
-class Bound {
+class KeyBound {
  public:
   static_assert(internal::IsRow<RowType>::value,
                 "KeyType must be of type spanner::Row<>.");
 
   // Not default constructible
-  Bound() = delete;
+  KeyBound() = delete;
 
   // Copy and move constructors and assignment operators.
-  Bound(Bound const& key_range) = default;
-  Bound& operator=(Bound const& rhs) = default;
-  Bound(Bound&& key_range) = default;
-  Bound& operator=(Bound&& rhs) = default;
+  KeyBound(KeyBound const& key_range) = default;
+  KeyBound& operator=(KeyBound const& rhs) = default;
+  KeyBound(KeyBound&& key_range) = default;
+  KeyBound& operator=(KeyBound&& rhs) = default;
 
   RowType const& key() const& { return key_; }
   RowType&& key() && { return std::move(key_); }
@@ -77,59 +77,60 @@ class Bound {
   bool IsClosed() const { return mode_ == Mode::kClosed; }
   bool IsOpen() const { return mode_ == Mode::kOpen; }
 
-  friend bool operator==(Bound const& lhs, Bound const& rhs) {
+  friend bool operator==(KeyBound const& lhs, KeyBound const& rhs) {
     return lhs.key_ == rhs.key_ && lhs.mode_ == rhs.mode_;
   }
-  friend bool operator!=(Bound const& lhs, Bound const& rhs) {
+  friend bool operator!=(KeyBound const& lhs, KeyBound const& rhs) {
     return !(lhs == rhs);
   }
 
  private:
   enum class Mode { kClosed, kOpen };
 
-  Bound(RowType key, Mode mode) : key_(std::move(key)), mode_(mode) {}
+  KeyBound(RowType key, Mode mode) : key_(std::move(key)), mode_(mode) {}
 
   template <typename T>
-  friend Bound<T> MakeBoundClosed(T key);
+  friend KeyBound<T> MakeKeyBoundClosed(T key);
 
   template <typename T>
-  friend Bound<T> MakeBoundOpen(T key);
+  friend KeyBound<T> MakeKeyBoundOpen(T key);
 
   RowType key_;
   Mode mode_;
 };
 
 /**
- * Helper function to create a closed `Bound` on the key `spanner::Row`
+ * Helper function to create a closed `KeyBound` on the key `spanner::Row`
  * provided.
  *
  * @tparam RowType spanner::Row<Types...> that corresponds to the desired index
  * definition.
  * @param key spanner::Row<Types...>
- * @return Bound<RowType>
+ * @return KeyBound<RowType>
  */
 template <typename RowType>
-Bound<RowType> MakeBoundClosed(RowType key) {
-  return Bound<RowType>(std::move(key), Bound<RowType>::Mode::kClosed);
+KeyBound<RowType> MakeKeyBoundClosed(RowType key) {
+  return KeyBound<RowType>(std::move(key), KeyBound<RowType>::Mode::kClosed);
 }
 
 /**
- * Helper function to create an open `Bound` on the key `spanner::Row` provided.
+ * Helper function to create an open `KeyBound` on the key `spanner::Row`
+ * provided.
  *
  * @tparam RowType spanner::Row<Types...> that corresponds to the desired index
  * definition.
  * @param key spanner::Row<Types...>
- * @return Bound<RowType>
+ * @return KeyBound<RowType>
  */
 template <typename RowType>
-Bound<RowType> MakeBoundOpen(RowType key) {
-  return Bound<RowType>(std::move(key), Bound<RowType>::Mode::kOpen);
+KeyBound<RowType> MakeKeyBoundOpen(RowType key) {
+  return KeyBound<RowType>(std::move(key), KeyBound<RowType>::Mode::kOpen);
 }
 
 /**
- * The `KeyRange` class is a regular type that represents the pair of `Bound`s
- * necessary to uniquely identify a contiguous group of key `spanner::Row`s in
- * its index.
+ * The `KeyRange` class is a regular type that represents the pair of
+ * `KeyBound`s necessary to uniquely identify a contiguous group of key
+ * `spanner::Row`s in its index.
  *
  * @tparam KeyType spanner::Row<Types...> that corresponds to the desired index
  * definition.
@@ -144,9 +145,9 @@ class KeyRange {
   KeyRange() = delete;
 
   /**
-   * Constructs a `KeyRange` with the given `Bound`s.
+   * Constructs a `KeyRange` with the given `KeyBound`s.
    */
-  explicit KeyRange(Bound<RowType> start, Bound<RowType> end)
+  explicit KeyRange(KeyBound<RowType> start, KeyBound<RowType> end)
       : start_(std::move(start)), end_(std::move(end)) {}
 
   // Copy and move constructors and assignment operators.
@@ -155,11 +156,11 @@ class KeyRange {
   KeyRange(KeyRange&& key_range) = default;
   KeyRange& operator=(KeyRange&& rhs) = default;
 
-  Bound<RowType> const& start() const& { return start_; }
-  Bound<RowType>&& start() && { return std::move(start_); }
+  KeyBound<RowType> const& start() const& { return start_; }
+  KeyBound<RowType>&& start() && { return std::move(start_); }
 
-  Bound<RowType> const& end() const& { return end_; }
-  Bound<RowType>&& end() && { return std::move(end_); }
+  KeyBound<RowType> const& end() const& { return end_; }
+  KeyBound<RowType>&& end() && { return std::move(end_); }
 
   friend bool operator==(KeyRange const& lhs, KeyRange const& rhs) {
     return lhs.start_ == rhs.start_ && lhs.end_ == rhs.end_;
@@ -169,13 +170,13 @@ class KeyRange {
   }
 
  private:
-  Bound<RowType> start_;
-  Bound<RowType> end_;
+  KeyBound<RowType> start_;
+  KeyBound<RowType> end_;
 };
 
 /**
  * Helper function to create a `KeyRange` between two keys `spanner::Row`s with
- * both `Bound`s closed.
+ * both `KeyBound`s closed.
  *
  * @tparam RowType spanner::Row<Types...> that corresponds to the desired index
  * definition.
@@ -185,12 +186,12 @@ class KeyRange {
  */
 template <typename RowType>
 KeyRange<RowType> MakeKeyRangeClosed(RowType start, RowType end) {
-  return MakeKeyRange(MakeBoundClosed(std::move(start)),
-                      MakeBoundClosed(std::move(end)));
+  return MakeKeyRange(MakeKeyBoundClosed(std::move(start)),
+                      MakeKeyBoundClosed(std::move(end)));
 }
 
 /**
- * Helper function to create a `KeyRange` between the `Bound`s provided.
+ * Helper function to create a `KeyRange` between the `KeyBound`s provided.
  *
  * @tparam RowType spanner::Row<Types...> that corresponds to the desired index
  * definition.
@@ -199,7 +200,7 @@ KeyRange<RowType> MakeKeyRangeClosed(RowType start, RowType end) {
  * @return KeyRange<RowType>
  */
 template <typename RowType>
-KeyRange<RowType> MakeKeyRange(Bound<RowType> start, Bound<RowType> end) {
+KeyRange<RowType> MakeKeyRange(KeyBound<RowType> start, KeyBound<RowType> end) {
   return KeyRange<RowType>(std::move(start), std::move(end));
 }
 

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -26,9 +26,9 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-TEST(BoundTest, Accessors) {
+TEST(KeyBoundTest, Accessors) {
   auto row = MakeRow("test");
-  auto bound = MakeBoundClosed(row);
+  auto bound = MakeKeyBoundClosed(row);
   EXPECT_EQ(row, bound.key());
   EXPECT_EQ(row, std::move(bound).key());
 
@@ -38,17 +38,17 @@ TEST(BoundTest, Accessors) {
       std::is_same<RowType&&, decltype(std::move(bound).key())>::value, "");
 }
 
-TEST(BoundTest, MakeBoundClosed) {
+TEST(KeyBoundTest, MakeKeyBoundClosed) {
   std::string key_value("key0");
-  auto bound = MakeBoundClosed(MakeRow(key_value));
+  auto bound = MakeKeyBoundClosed(MakeRow(key_value));
   EXPECT_EQ(key_value, bound.key().get<0>());
   EXPECT_TRUE(bound.IsClosed());
 }
 
-TEST(BoundTest, MakeBoundOpen) {
+TEST(KeyBoundTest, MakeKeyBoundOpen) {
   std::string key_value_0("key0");
   std::int64_t key_value_1(42);
-  auto bound = MakeBoundOpen(MakeRow(key_value_0, key_value_1));
+  auto bound = MakeKeyBoundOpen(MakeRow(key_value_0, key_value_1));
   EXPECT_EQ(key_value_0, bound.key().get<0>());
   EXPECT_EQ(key_value_1, bound.key().get<1>());
   EXPECT_TRUE(bound.IsOpen());
@@ -56,10 +56,10 @@ TEST(BoundTest, MakeBoundOpen) {
 
 TEST(KeyrangeTest, Accessors) {
   auto start_row = MakeRow("a");
-  auto start_bound = MakeBoundClosed(start_row);
+  auto start_bound = MakeKeyBoundClosed(start_row);
 
   auto end_row = MakeRow("z");
-  auto end_bound = MakeBoundClosed(end_row);
+  auto end_bound = MakeKeyBoundClosed(end_row);
 
   auto range = MakeKeyRange(start_bound, end_bound);
   EXPECT_EQ(start_bound, range.start());
@@ -78,7 +78,7 @@ TEST(KeyrangeTest, Accessors) {
       std::is_same<EndType&&, decltype(std::move(range).start())>::value, "");
 }
 
-TEST(KeyRangeTest, ConstructorBoundModeUnspecified) {
+TEST(KeyRangeTest, ConstructorKeyBoundModeUnspecified) {
   std::string start_value("key0");
   std::string end_value("key1");
   KeyRange<Row<std::string>> closed_range =
@@ -93,8 +93,8 @@ TEST(KeyRangeTest, ConstructorBoundModeUnspecified) {
 TEST(KeyRangeTest, ConstructorClosedClosed) {
   std::string start_value("key0");
   std::string end_value("key1");
-  auto start_bound = MakeBoundClosed(MakeRow(start_value));
-  auto end_bound = MakeBoundClosed(MakeRow(end_value));
+  auto start_bound = MakeKeyBoundClosed(MakeRow(start_value));
+  auto end_bound = MakeKeyBoundClosed(MakeRow(end_value));
   auto closed_range = MakeKeyRange(start_bound, end_bound);
   EXPECT_EQ(start_value, closed_range.start().key().get<0>());
   EXPECT_TRUE(closed_range.start().IsClosed());
@@ -105,8 +105,9 @@ TEST(KeyRangeTest, ConstructorClosedClosed) {
 TEST(KeyRangeTest, ConstructorClosedOpen) {
   std::string start_value("key0");
   std::string end_value("key1");
-  auto range = KeyRange<Row<std::string>>(MakeBoundClosed(MakeRow(start_value)),
-                                          MakeBoundOpen(MakeRow(end_value)));
+  auto range =
+      KeyRange<Row<std::string>>(MakeKeyBoundClosed(MakeRow(start_value)),
+                                 MakeKeyBoundOpen(MakeRow(end_value)));
   EXPECT_EQ(start_value, range.start().key().get<0>());
   EXPECT_TRUE(range.start().IsClosed());
   EXPECT_EQ(end_value, range.end().key().get<0>());
@@ -116,8 +117,9 @@ TEST(KeyRangeTest, ConstructorClosedOpen) {
 TEST(KeyRangeTest, ConstructorOpenClosed) {
   std::string start_value("key0");
   std::string end_value("key1");
-  auto range = KeyRange<Row<std::string>>(MakeBoundOpen(MakeRow(start_value)),
-                                          MakeBoundClosed(MakeRow(end_value)));
+  auto range =
+      KeyRange<Row<std::string>>(MakeKeyBoundOpen(MakeRow(start_value)),
+                                 MakeKeyBoundClosed(MakeRow(end_value)));
   EXPECT_EQ(start_value, range.start().key().get<0>());
   EXPECT_TRUE(range.start().IsOpen());
   EXPECT_EQ(end_value, range.end().key().get<0>());
@@ -127,8 +129,9 @@ TEST(KeyRangeTest, ConstructorOpenClosed) {
 TEST(KeyRangeTest, ConstructorOpenOpen) {
   std::string start_value("key0");
   std::string end_value("key1");
-  auto range = KeyRange<Row<std::string>>(MakeBoundOpen(MakeRow(start_value)),
-                                          MakeBoundOpen(MakeRow(end_value)));
+  auto range =
+      KeyRange<Row<std::string>>(MakeKeyBoundOpen(MakeRow(start_value)),
+                                 MakeKeyBoundOpen(MakeRow(end_value)));
   EXPECT_EQ(start_value, range.start().key().get<0>());
   EXPECT_TRUE(range.start().IsOpen());
   EXPECT_EQ(end_value, range.end().key().get<0>());
@@ -189,8 +192,8 @@ TEST(KeySetTest, EqualityKeys) {
 TEST(KeySetTest, EqualityKeyRanges) {
   auto range0 = MakeKeyRangeClosed(MakeRow("start00", "start01"),
                                    MakeRow("end00", "end01"));
-  auto range1 = MakeKeyRange(MakeBoundOpen(MakeRow("start10", "start11")),
-                             MakeBoundOpen(MakeRow("end10", "end11")));
+  auto range1 = MakeKeyRange(MakeKeyBoundOpen(MakeRow("start10", "start11")),
+                             MakeKeyBoundOpen(MakeRow("end10", "end11")));
   auto ksb0 = KeySetBuilder<Row<std::string, std::string>>();
   ksb0.Add(range0).Add(range1);
   auto ksb1 = KeySetBuilder<Row<std::string, std::string>>();
@@ -237,8 +240,8 @@ TEST(KeySetBuilderTest, ConstructorKeyRange) {
   std::string start_value("key0");
   std::string end_value("key1");
   auto ks = KeySetBuilder<Row<std::string>>(
-      KeyRange<Row<std::string>>(MakeBoundClosed(MakeRow(start_value)),
-                                 MakeBoundClosed(MakeRow(end_value))));
+      KeyRange<Row<std::string>>(MakeKeyBoundClosed(MakeRow(start_value)),
+                                 MakeKeyBoundClosed(MakeRow(end_value))));
   EXPECT_EQ(start_value, ks.key_ranges()[0].start().key().get<0>());
   EXPECT_TRUE(ks.key_ranges()[0].start().IsClosed());
   EXPECT_EQ(end_value, ks.key_ranges()[0].end().key().get<0>());
@@ -264,8 +267,8 @@ TEST(KeySetBuilderTest, AddKeyToNonEmptyKeySetBuilder) {
 TEST(KeySetBuilderTest, AddKeyRangeToEmptyKeySetBuilder) {
   auto ks = KeySetBuilder<Row<std::string, std::string>>();
   auto range = KeyRange<Row<std::string, std::string>>(
-      MakeBoundClosed(MakeRow("start00", "start01")),
-      MakeBoundClosed(MakeRow("end00", "end01")));
+      MakeKeyBoundClosed(MakeRow("start00", "start01")),
+      MakeKeyBoundClosed(MakeRow("end00", "end01")));
   ks.Add(range);
   EXPECT_EQ("start00", ks.key_ranges()[0].start().key().get<0>());
   EXPECT_EQ("start01", ks.key_ranges()[0].start().key().get<1>());
@@ -278,8 +281,8 @@ TEST(KeySetBuilderTest, AddKeyRangeToEmptyKeySetBuilder) {
 TEST(KeySetBuilderTest, AddKeyRangeToNonEmptyKeySetBuilder) {
   auto ks = KeySetBuilder<Row<std::string, std::string>>(MakeKeyRangeClosed(
       MakeRow("start00", "start01"), MakeRow("end00", "end01")));
-  auto range = MakeKeyRange(MakeBoundOpen(MakeRow("start10", "start11")),
-                            MakeBoundOpen(MakeRow("end10", "end11")));
+  auto range = MakeKeyRange(MakeKeyBoundOpen(MakeRow("start10", "start11")),
+                            MakeKeyBoundOpen(MakeRow("end10", "end11")));
   ks.Add(range);
   EXPECT_EQ("start00", ks.key_ranges()[0].start().key().get<0>());
   EXPECT_EQ("start01", ks.key_ranges()[0].start().key().get<1>());
@@ -337,8 +340,8 @@ TEST(InternalKeySetTest, BuildToProtoTwoKeys) {
 TEST(InternalKeySetTest, BuildToProtoTwoRanges) {
   auto ksb = KeySetBuilder<Row<std::string, std::string>>(MakeKeyRangeClosed(
       MakeRow("start00", "start01"), MakeRow("end00", "end01")));
-  auto range = MakeKeyRange(MakeBoundOpen(MakeRow("start10", "start11")),
-                            MakeBoundOpen(MakeRow("end10", "end11")));
+  auto range = MakeKeyRange(MakeKeyBoundOpen(MakeRow("start10", "start11")),
+                            MakeKeyBoundOpen(MakeRow("end10", "end11")));
   ksb.Add(range);
 
   ::google::spanner::v1::KeySet expected;


### PR DESCRIPTION
This naming seems to fit better with our existing names of KeySet,
KeyRange, and KeyBuilder, all of which have that "Key" prefix. I think
the "Key" prefix on the name is also important because these objects are
where we cross over from the concept of "Rows" to the concept of a
"Key".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/439)
<!-- Reviewable:end -->
