### PR TITLE
A little RunTransaction() cleanup

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -165,8 +165,8 @@ StatusOr<CommitResult> RunTransaction(
     std::function<StatusOr<Mutations>(Client, Transaction)> const& f) {
   ExponentialBackoffPolicy backoff_policy(std::chrono::milliseconds(100),
                                           std::chrono::minutes(5), 2.0);
-  // TODO(#357): It is not a good idea to simply cap the number of retries.
-  // Instead, it is better to limit the total amount of time spent retrying.
+  // TODO(#357,#442): It is not a good idea to simply cap the number of
+  // retries. It is better to limit the total amount of time spent retrying.
   LimitedErrorCountRetryPolicy retry_policy(/*maximum_failures=*/2);
 
   Status last_status(

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -99,13 +99,9 @@ class ClientIntegrationTest : public ::testing::Test {
   }
 
   void SetUp() override {
-    auto commit_result = RunTransaction(
-        *client_, {},
-        [](Client client, Transaction txn) -> StatusOr<Mutations> {
-          auto deleter = client.ExecuteSql(
-              std::move(txn), SqlStatement("DELETE FROM Singers WHERE true;"));
-          if (!deleter) return deleter.status();
-          return Mutations{};
+    auto commit_result =
+        RunTransaction(*client_, {}, [](Client const&, Transaction const&) {
+          return Mutations{MakeDeleteMutation("Singers", KeySet::All())};
         });
     EXPECT_STATUS_OK(commit_result);
   }


### PR DESCRIPTION
- Move `RunTransactionImpl()` into an anonymous namespace.
- Move the `TODO(#357)` comment to a better location after #435.
- Allow the "DELETE FROM Singers" during intergration-test setup
  to abort and be retried by returning its status rather than
  expecting it is OK.
- Use more consistent naming in the test cases, and remove a
  redundant type alias.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/446)
<!-- Reviewable:end -->
