### PR TITLE
Change one of the Commit tests to succeed.

### DIFF
--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -436,6 +436,7 @@ TEST(ConnectionImplTest, CommitSuccessWithTransactionId) {
 
   auto commit = conn.Commit({txn, {}});
   EXPECT_STATUS_OK(commit);
+  EXPECT_EQ(commit->commit_timestamp, Timestamp{std::chrono::seconds(123)});
 }
 
 TEST(ConnectionImplTest, RollbackGetSessionFailure) {


### PR DESCRIPTION
It seemed odd to me that all the Commit tests had failed Commits, and this
one seemed like it might as well succeed. (unless I'm misunderstanding
what this test was trying to do, in which case I can add a different test).

I also changed a few EXPECT_TRUE(foo.ok()) to EXPECT_STATUS_OK(foo);

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/449)
<!-- Reviewable:end -->
