### PR TITLE
Reset expected rows during each RunTransaction() iteration

### DIFF
--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -358,6 +358,7 @@ TEST_F(ClientIntegrationTest, ExecuteSql) {
       *client_, {},
       [&expected_rows](Client client,
                        Transaction const& txn) -> StatusOr<Mutations> {
+        expected_rows.clear();
         for (int i = 2; i != 10; ++i) {
           auto s = std::to_string(i);
           auto insert = client.ExecuteSql(
@@ -396,7 +397,6 @@ TEST_F(ClientIntegrationTest, ExecuteSql) {
       actual_rows.push_back(*std::move(row));
     }
   }
-
   EXPECT_THAT(actual_rows, UnorderedElementsAreArray(expected_rows));
 }
 
@@ -406,11 +406,11 @@ void CheckReadWithOptions(
         options_generator) {
   using RowType = Row<std::int64_t, std::string, std::string>;
   std::vector<RowType> expected_rows;
-
   auto commit = RunTransaction(
       client, Transaction::ReadWriteOptions{},
       [&expected_rows](Client const&,
                        Transaction const&) -> StatusOr<Mutations> {
+        expected_rows.clear();
         InsertMutationBuilder insert("Singers",
                                      {"SingerId", "FirstName", "LastName"});
         for (int i = 1; i != 10; ++i) {
@@ -438,7 +438,6 @@ void CheckReadWithOptions(
       actual_rows.push_back(*std::move(row));
     }
   }
-
   EXPECT_THAT(actual_rows, UnorderedElementsAreArray(expected_rows));
 }
 


### PR DESCRIPTION
The `RunTransaction()` functor may run multiple times (after the
previous transaction was aborted), so it is important that any
value accumulator is cleared at the beginning of each invocation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/450)
<!-- Reviewable:end -->
