### PR TITLE
cleanup: rename client_options* files.

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -88,10 +88,10 @@ add_library(spanner_client
             backoff_policy.h
             client.cc
             client.h
-            client_options.cc
-            client_options.h
             commit_result.h
             connection.h
+            connection_options.cc
+            connection_options.h
             database.cc
             database.h
             database_admin_client.cc
@@ -136,6 +136,7 @@ add_library(spanner_client
             polling_policy.h
             query_partition.cc
             query_partition.h
+            read_options.h
             read_partition.cc
             read_partition.h
             result_set.h
@@ -207,7 +208,7 @@ function (spanner_client_define_tests)
                            PUBLIC ${GOOGLE_CLOUD_CPP_SPANNER_EXCEPTIONS_FLAG})
 
     set(spanner_client_unit_tests
-        client_options_test.cc
+        connection_options_test.cc
         client_test.cc
         database_test.cc
         database_admin_client_test.cc
@@ -229,6 +230,7 @@ function (spanner_client_define_tests)
         internal/tuple_utils_test.cc
         keys_test.cc
         mutations_test.cc
+        read_options_test.cc
         read_partition_test.cc
         result_set_test.cc
         retry_policy_test.cc

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -15,9 +15,9 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CLIENT_H_
 
-#include "google/cloud/spanner/client_options.h"
 #include "google/cloud/spanner/commit_result.h"
 #include "google/cloud/spanner/connection.h"
+#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/keys.h"
 #include "google/cloud/spanner/mutations.h"

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -15,10 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_H_
 
-#include "google/cloud/spanner/client_options.h"
 #include "google/cloud/spanner/commit_result.h"
+#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/keys.h"
 #include "google/cloud/spanner/mutations.h"
+#include "google/cloud/spanner/read_options.h"
 #include "google/cloud/spanner/result_set.h"
 #include "google/cloud/spanner/sql_statement.h"
 #include "google/cloud/spanner/transaction.h"

--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -1,0 +1,47 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/connection_options.h"
+#include "google/cloud/internal/getenv.h"
+#include <sstream>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+ConnectionOptions::ConnectionOptions(
+    std::shared_ptr<grpc::ChannelCredentials> credentials)
+    : credentials_(std::move(credentials)),
+      endpoint_("spanner.googleapis.com") {
+  auto tracing =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
+  if (tracing.has_value()) {
+    std::istringstream is{*tracing};
+    std::string token;
+    while (std::getline(is, token, ',')) {
+      tracing_components_.insert(token);
+    }
+  }
+  clog_enabled_ =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_ENABLE_CLOG")
+          .has_value();
+}
+
+ConnectionOptions::ConnectionOptions()
+    : ConnectionOptions(grpc::GoogleDefaultCredentials()) {}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CLIENT_OPTIONS_H_
-#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CLIENT_OPTIONS_H_
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_OPTIONS_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_OPTIONS_H_
 
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
@@ -83,36 +83,9 @@ class ConnectionOptions {
   std::set<std::string> tracing_components_;
 };
 
-/// Options passed to `Client::Read` or `Client::PartitionRead`.
-struct ReadOptions {
-  /**
-   * If non-empty, the name of an index on a database table. This index is used
-   * instead of the table primary key when interpreting the `KeySet`and sorting
-   * result rows.
-   */
-  std::string index_name;
-
-  /**
-   * Limit on the number of rows to yield, or 0 for no limit.
-   * A limit cannot be specified when calling`PartitionRead`.
-   */
-  std::int64_t limit = 0;
-};
-
-inline bool operator==(ReadOptions const& lhs, ReadOptions const& rhs) {
-  return lhs.limit == rhs.limit && lhs.index_name == rhs.index_name;
-}
-
-inline bool operator!=(ReadOptions const& lhs, ReadOptions const& rhs) {
-  return !(lhs == rhs);
-}
-
-/// Options passed to `Client::PartitionRead` or `Client::PartitionQuery`
-using PartitionOptions = google::spanner::v1::PartitionOptions;
-
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CLIENT_OPTIONS_H_
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_OPTIONS_H_

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/spanner/client_options.h"
+#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/environment_variable_restore.h"
 #include <gmock/gmock.h>
@@ -95,22 +95,6 @@ TEST(ClientOptionsTest, DefaultTracingSet) {
   EXPECT_TRUE(options.tracing_enabled("foo"));
   EXPECT_TRUE(options.tracing_enabled("bar"));
   EXPECT_TRUE(options.tracing_enabled("baz"));
-}
-
-TEST(ReadOptionsTest, Equality) {
-  ReadOptions test_options_0;
-  ReadOptions test_options_1;
-  EXPECT_EQ(test_options_0, test_options_1);
-  test_options_0.index_name = "secondary";
-  EXPECT_NE(test_options_0, test_options_1);
-  test_options_1.index_name = "secondary";
-  EXPECT_EQ(test_options_0, test_options_1);
-  test_options_0.limit = 42;
-  EXPECT_NE(test_options_0, test_options_1);
-  test_options_1.limit = 42;
-  EXPECT_EQ(test_options_0, test_options_1);
-  test_options_1 = test_options_0;
-  EXPECT_EQ(test_options_0, test_options_1);
 }
 
 }  // namespace

--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_DATABASE_ADMIN_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_DATABASE_ADMIN_CLIENT_H_
 
-#include "google/cloud/spanner/client_options.h"
+#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/internal/database_admin_stub.h"
 #include "google/cloud/future.h"

--- a/google/cloud/spanner/internal/database_admin_stub.h
+++ b/google/cloud/spanner/internal/database_admin_stub.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_STUB_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_DATABASE_ADMIN_STUB_H_
 
-#include "google/cloud/spanner/client_options.h"
+#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_SPANNER_STUB_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_SPANNER_STUB_H_
 
-#include "google/cloud/spanner/client_options.h"
+#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"

--- a/google/cloud/spanner/read_options.h
+++ b/google/cloud/spanner/read_options.h
@@ -1,0 +1,59 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_READ_OPTIONS_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_READ_OPTIONS_H_
+
+#include "google/cloud/spanner/version.h"
+#include <google/spanner/v1/spanner.pb.h>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+/// Options passed to `Client::Read` or `Client::PartitionRead`.
+struct ReadOptions {
+  /**
+   * If non-empty, the name of an index on a database table. This index is used
+   * instead of the table primary key when interpreting the `KeySet`and sorting
+   * result rows.
+   */
+  std::string index_name;
+
+  /**
+   * Limit on the number of rows to yield, or 0 for no limit.
+   * A limit cannot be specified when calling `PartitionRead`.
+   */
+  std::int64_t limit = 0;
+};
+
+inline bool operator==(ReadOptions const& lhs, ReadOptions const& rhs) {
+  return lhs.limit == rhs.limit && lhs.index_name == rhs.index_name;
+}
+
+inline bool operator!=(ReadOptions const& lhs, ReadOptions const& rhs) {
+  return !(lhs == rhs);
+}
+
+/// Options passed to `Client::PartitionRead` or `Client::PartitionQuery`
+using PartitionOptions = google::spanner::v1::PartitionOptions;
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_READ_OPTIONS_H_

--- a/google/cloud/spanner/read_options_test.cc
+++ b/google/cloud/spanner/read_options_test.cc
@@ -12,35 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/spanner/client_options.h"
-#include "google/cloud/internal/getenv.h"
-#include <sstream>
+#include "google/cloud/spanner/read_options.h"
+#include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
-ConnectionOptions::ConnectionOptions(
-    std::shared_ptr<grpc::ChannelCredentials> credentials)
-    : credentials_(std::move(credentials)),
-      endpoint_("spanner.googleapis.com") {
-  auto tracing =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
-  if (tracing.has_value()) {
-    std::istringstream is{*tracing};
-    std::string token;
-    while (std::getline(is, token, ',')) {
-      tracing_components_.insert(token);
-    }
-  }
-  clog_enabled_ =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_ENABLE_CLOG")
-          .has_value();
+namespace {
+
+TEST(ReadOptionsTest, Equality) {
+  ReadOptions test_options_0{};
+  ReadOptions test_options_1{};
+  EXPECT_EQ(test_options_0, test_options_1);
+  test_options_0.index_name = "secondary";
+  EXPECT_NE(test_options_0, test_options_1);
+  test_options_1.index_name = "secondary";
+  EXPECT_EQ(test_options_0, test_options_1);
+  test_options_0.limit = 42;
+  EXPECT_NE(test_options_0, test_options_1);
+  test_options_1.limit = 42;
+  EXPECT_EQ(test_options_0, test_options_1);
+  test_options_1 = test_options_0;
+  EXPECT_EQ(test_options_0, test_options_1);
 }
 
-ConnectionOptions::ConnectionOptions()
-    : ConnectionOptions(grpc::GoogleDefaultCredentials()) {}
-
+}  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -15,7 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_READ_PARTITION_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_READ_PARTITION_H_
 
-#include "google/cloud/spanner/client_options.h"
 #include "google/cloud/spanner/connection.h"
 #include "google/cloud/spanner/keys.h"
 #include "google/cloud/spanner/version.h"

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -19,9 +19,9 @@
 spanner_client_hdrs = [
     "backoff_policy.h",
     "client.h",
-    "client_options.h",
     "commit_result.h",
     "connection.h",
+    "connection_options.h",
     "database.h",
     "database_admin_client.h",
     "date.h",
@@ -46,6 +46,7 @@ spanner_client_hdrs = [
     "mutations.h",
     "polling_policy.h",
     "query_partition.h",
+    "read_options.h",
     "read_partition.h",
     "result_set.h",
     "retry_policy.h",
@@ -62,7 +63,7 @@ spanner_client_hdrs = [
 
 spanner_client_srcs = [
     "client.cc",
-    "client_options.cc",
+    "connection_options.cc",
     "database.cc",
     "database_admin_client.cc",
     "date.cc",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -17,7 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 spanner_client_unit_tests = [
-    "client_options_test.cc",
+    "connection_options_test.cc",
     "client_test.cc",
     "database_test.cc",
     "database_admin_client_test.cc",
@@ -39,6 +39,7 @@ spanner_client_unit_tests = [
     "internal/tuple_utils_test.cc",
     "keys_test.cc",
     "mutations_test.cc",
+    "read_options_test.cc",
     "read_partition_test.cc",
     "result_set_test.cc",
     "retry_policy_test.cc",


### PR DESCRIPTION
The main class in them is ConnectionOptions, so the file should match.
This change also moves the other classes in that header to (a new file)
called `read_options.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/453)
<!-- Reviewable:end -->
