### PR TITLE
chore: Removed ExecutePartitionedDml

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -105,12 +105,6 @@ std::vector<StatusOr<spanner_proto::ResultSetStats>> Client::ExecuteBatchDml(
   return {Status(StatusCode::kUnimplemented, "not implemented")};
 }
 
-// returns a lower bound on the number of modified rows
-StatusOr<std::int64_t> Client::ExecutePartitionedDml(
-    SqlStatement const& /*statement*/) {
-  return Status(StatusCode::kUnimplemented, "not implemented");
-}
-
 StatusOr<CommitResult> Client::Commit(Transaction transaction,
                                       Mutations mutations) {
   return conn_->Commit({std::move(transaction), std::move(mutations)});

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -317,18 +317,6 @@ class Client {
       std::vector<SqlStatement> const& statements);
 
   /**
-   * Executes single Partitioned DML statement. Partitions the key space and
-   * runs the DML statement over each partition in parallel using separate,
-   * internal transactions that commit independently.
-   *
-   * @param statement The SQL DML statement to execute.
-   *
-   * @return A `StatusOr` containing a lower bound on the number of modified
-   *     rows or error status on failure.
-   */
-  StatusOr<std::int64_t> ExecutePartitionedDml(SqlStatement const& statement);
-
-  /**
    * Commits a read-write transaction.
    *
    * The commit might return an `ABORTED` error. This can occur at any time;


### PR DESCRIPTION
"PartitionedDml" is a type of transaction, so we don't think we want to expose it as a separate method on Client. Instead see #287 for how we'll handle PartitionedDml using the existing `Client::ExecuteSql` method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/467)
<!-- Reviewable:end -->
