### PR TITLE
feat: Implement a simple stress test.

### DIFF
--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -27,7 +27,9 @@ function (spanner_client_define_integration_tests)
     find_package(google_cloud_cpp_testing CONFIG REQUIRED)
 
     set(spanner_client_integration_tests
-        client_integration_test.cc database_admin_integration_test.cc
+        client_integration_test.cc
+        database_admin_integration_test.cc
+        client_stress_test.cc
         rpc_failure_threshold_integration_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -1,0 +1,248 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/client.h"
+#include "google/cloud/spanner/database.h"
+#include "google/cloud/spanner/testing/database_environment.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+#include <future>
+#include <random>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+
+constexpr std::int64_t kMillion = 1000 * 1000;
+std::int64_t flag_table_size = 10 * kMillion;
+std::int64_t flag_maximum_read_size = 10 * 1000;
+std::chrono::seconds flag_duration(30);
+int flag_threads = 0;  // 0 means use the threads_per_core setting.
+int flag_threads_per_core = 4;
+
+struct Result {
+  std::int64_t failure_count = 0;
+  std::int64_t success_count = 0;
+
+  void Update(Status const& s) {
+    if (!s.ok()) {
+      ++failure_count;
+    } else {
+      ++success_count;
+    }
+  }
+  void Update(Result const& r) {
+    failure_count += r.failure_count;
+    success_count += r.success_count;
+  }
+};
+
+int TaskCount() {
+  if (flag_threads != 0) return flag_threads;
+  auto cores = std::thread::hardware_concurrency();
+  return cores == 0 ? flag_threads_per_core
+                    : static_cast<int>(cores) * flag_threads_per_core;
+}
+
+/// @test Stress test the library using ExecuteSql calls.
+TEST(ClientSqlStressTest, UpsertAndSelect) {
+  int const task_count = TaskCount();
+
+  auto select_task = [](Client client) {
+    Result result{};
+
+    // Each thread needs its own random bits generator.
+    auto generator = google::cloud::internal::MakeDefaultPRNG();
+    std::uniform_int_distribution<std::int64_t> random_key(0, flag_table_size);
+    std::uniform_int_distribution<int> random_action(0, 1);
+    std::uniform_int_distribution<std::int64_t> random_limit(
+        0, flag_maximum_read_size);
+    enum Action {
+      kInsert = 0,
+      kSelect = 1,
+    };
+
+    auto deadline = std::chrono::steady_clock::now() + flag_duration;
+    for (auto start = std::chrono::steady_clock::now(); start < deadline;
+         start = std::chrono::steady_clock::now()) {
+      auto key = random_key(generator);
+      auto action = static_cast<Action>(random_action(generator));
+
+      if (action == kInsert) {
+        auto commit = spanner::RunTransaction(
+            client, {},
+            [key](Client const&,
+                  Transaction const&) -> StatusOr<spanner::Mutations> {
+              auto s = std::to_string(key);
+              return Mutations{spanner::MakeInsertOrUpdateMutation(
+                  "Singers", {"SingerId", "FirstName", "LastName"}, key,
+                  "fname-" + s, "lname-" + s)};
+            });
+        result.Update(commit.status());
+      } else {
+        auto size = random_limit(generator);
+        auto reader = client.ExecuteSql(
+            SqlStatement("SELECT SingerId, FirstName, LastName"
+                         "  FROM Singers"
+                         " WHERE SingerId >= @min"
+                         "   AND SingerId <= @max",
+                         {{"min", spanner::Value(key)},
+                          {"max", spanner::Value(key + size)}}));
+        result.Update(reader.status());
+        if (!reader) continue;
+        for (auto row :
+             reader->Rows<std::int64_t, std::string, std::string>()) {
+          result.Update(row.status());
+        }
+      }
+    }
+    return result;
+  };
+
+  Client client(
+      MakeConnection(spanner_testing::DatabaseEnvironment::GetDatabase()));
+
+  std::vector<std::future<Result>> tasks(task_count);
+  for (auto& t : tasks) {
+    t = std::async(std::launch::async, select_task, client);
+  }
+
+  Result total;
+  for (auto& t : tasks) {
+    total.Update(t.get());
+  }
+
+  auto experiments_count = total.failure_count + total.success_count;
+  EXPECT_LE(total.failure_count, experiments_count * 0.001);
+}
+
+/// @test Stress test the library using Read calls.
+TEST(ClientStressTest, UpsertAndRead) {
+  int const task_count = TaskCount();
+
+  auto read_task = [](Client client) {
+    Result result{};
+
+    // Each thread needs its own random bits generator.
+    auto generator = google::cloud::internal::MakeDefaultPRNG();
+    std::uniform_int_distribution<std::int64_t> random_key(0, flag_table_size);
+    std::uniform_int_distribution<int> random_action(0, 1);
+    std::uniform_int_distribution<std::int64_t> random_limit(
+        0, flag_maximum_read_size);
+    enum Action {
+      kInsert = 0,
+      kSelect = 1,
+    };
+
+    auto deadline = std::chrono::steady_clock::now() + flag_duration;
+    for (auto start = std::chrono::steady_clock::now(); start < deadline;
+         start = std::chrono::steady_clock::now()) {
+      auto key = random_key(generator);
+      auto action = static_cast<Action>(random_action(generator));
+
+      if (action == kInsert) {
+        auto commit = spanner::RunTransaction(
+            client, {},
+            [key](Client const&,
+                  Transaction const&) -> StatusOr<spanner::Mutations> {
+              auto s = std::to_string(key);
+              return Mutations{spanner::MakeInsertOrUpdateMutation(
+                  "Singers", {"SingerId", "FirstName", "LastName"}, key,
+                  "fname-" + s, "lname-" + s)};
+            });
+        result.Update(commit.status());
+      } else {
+        auto size = random_limit(generator);
+        using KeyType = Row<std::int64_t>;
+        auto range =
+            spanner::KeySetBuilder<KeyType>(
+                spanner::MakeKeyRangeClosed(KeyType(key), KeyType(key + size)))
+                .Build();
+
+        auto reader = client.Read("Singers", range,
+                                  {"SingerId", "FirstName", "LastName"});
+        result.Update(reader.status());
+        if (!reader) continue;
+        for (auto row :
+             reader->Rows<std::int64_t, std::string, std::string>()) {
+          result.Update(row.status());
+        }
+      }
+    }
+    return result;
+  };
+
+  Client client(
+      MakeConnection(spanner_testing::DatabaseEnvironment::GetDatabase()));
+
+  std::vector<std::future<Result>> tasks(task_count);
+  for (auto& t : tasks) {
+    t = std::async(std::launch::async, read_task, client);
+  }
+
+  Result total;
+  for (auto& t : tasks) {
+    total.Update(t.get());
+  }
+
+  auto experiments_count = total.failure_count + total.success_count;
+  EXPECT_LE(total.failure_count, experiments_count * 0.001);
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  ::google::cloud::testing_util::InitGoogleMock(argc, argv);
+
+  // TODO(#...) - refactor google-cloud-cpp code for command-line parsing.
+  std::string const table_size_arg = "--table-size=";
+  std::string const maximum_read_size_arg = "--maximum-read-size=";
+  std::string const duration_arg = "--duration=";
+  std::string const threads_arg = "--threads=";
+  std::string const threads_per_core_arg = "--threads-per-core=";
+  for (int i = 1; i != argc; ++i) {
+    std::string arg = argv[i];
+    if (arg.rfind(table_size_arg) == 0) {
+      google::cloud::spanner::flag_table_size =
+          std::stol(arg.substr(table_size_arg.size()));
+    } else if (arg.rfind(maximum_read_size_arg) == 0) {
+      google::cloud::spanner::flag_maximum_read_size =
+          std::stoi(arg.substr(maximum_read_size_arg.size()));
+    } else if (arg.rfind(threads_arg) == 0) {
+      google::cloud::spanner::flag_threads =
+          std::stoi(arg.substr(threads_arg.size()));
+    } else if (arg.rfind(threads_per_core_arg) == 0) {
+      google::cloud::spanner::flag_threads_per_core =
+          std::stoi(arg.substr(threads_per_core_arg.size()));
+    } else if (arg.rfind(duration_arg, 0) == 0) {
+      google::cloud::spanner::flag_duration =
+          std::chrono::seconds(std::stoi(arg.substr(duration_arg.size())));
+    } else if (arg.rfind("--", 0) == 0) {
+      std::cerr << "Unknown flag: " << arg << std::endl;
+    }
+  }
+
+  (void)::testing::AddGlobalTestEnvironment(
+      new google::cloud::spanner_testing::DatabaseEnvironment());
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/spanner/integration_tests/spanner_client_integration_tests.bzl
+++ b/google/cloud/spanner/integration_tests/spanner_client_integration_tests.bzl
@@ -19,5 +19,6 @@
 spanner_client_integration_tests = [
     "client_integration_test.cc",
     "database_admin_integration_test.cc",
+    "client_stress_test.cc",
     "rpc_failure_threshold_integration_test.cc",
 ]


### PR DESCRIPTION
This change introduces two tests, both work similarly: (1) they run
multiple threads, each thread runs for N seconds, (2) the thread picks
an action, row key, and query size at random, (3) if the action is
"insert" the thread inserts (or updates) the row with the given key, (4)
if the action is "select" the thread reads (or selects) the randomly
selected query size rows starting at the randomly selected key.

The test counts the number of successes and failures and expects less
than 0.1% failures.

This stress test is executed as part of the CI build, but it only runs
each test for 30 seconds. We should run it manually (or nightly) with a
much higher setting, maybe "24 hours" or something similar.

This (I think, but let me know if you disagree) fixes #455

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/471)
<!-- Reviewable:end -->
