### PR TITLE
Fix a reversed comparison that causes Session leaks

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -109,11 +109,11 @@ StatusOr<SessionHolder> ConnectionImpl::GetSession(bool release) {
     session_name = std::move(*response->mutable_name());
   }
 
-  return release ? SessionHolder(std::move(session_name), /*deleter=*/nullptr)
-                 : SessionHolder(std::move(session_name),
+  return release ? SessionHolder(std::move(session_name),
                                  [this](std::string session) {
                                    this->ReleaseSession(std::move(session));
-                                 });
+                                 })
+                 : SessionHolder(std::move(session_name), /*deleter=*/nullptr);
 }
 
 void ConnectionImpl::ReleaseSession(std::string session) {


### PR DESCRIPTION
I'm somewhat disturbed no tests failed, so I'll plan to write something
to detect session leaks... but in the meantime I think we should fix
this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/505)
<!-- Reviewable:end -->
