### PR TITLE
Wrap SessionHolder in a unique_ptr

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -27,13 +27,15 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
+using ::google::cloud::internal::make_unique;
+
 namespace spanner_proto = ::google::spanner::v1;
 
 StatusOr<ResultSet> ConnectionImpl::Read(ReadParams rp) {
   return internal::Visit(
       std::move(rp.transaction),
-      [this, &rp](SessionHolder& session, spanner_proto::TransactionSelector& s,
-                  std::int64_t) {
+      [this, &rp](std::unique_ptr<SessionHolder>& session,
+                  spanner_proto::TransactionSelector& s, std::int64_t) {
         return ReadImpl(session, s, std::move(rp));
       });
 }
@@ -42,7 +44,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionRead(
     PartitionReadParams prp) {
   return internal::Visit(
       std::move(prp.read_params.transaction),
-      [this, &prp](SessionHolder& session,
+      [this, &prp](std::unique_ptr<SessionHolder>& session,
                    spanner_proto::TransactionSelector& s, std::int64_t) {
         return PartitionReadImpl(session, s, prp.read_params,
                                  std::move(prp.partition_options));
@@ -52,7 +54,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionRead(
 StatusOr<ResultSet> ConnectionImpl::ExecuteSql(ExecuteSqlParams esp) {
   return internal::Visit(
       std::move(esp.transaction),
-      [this, &esp](SessionHolder& session,
+      [this, &esp](std::unique_ptr<SessionHolder>& session,
                    spanner_proto::TransactionSelector& s, std::int64_t seqno) {
         return ExecuteSqlImpl(session, s, seqno, std::move(esp));
       });
@@ -73,7 +75,7 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQuery(
     PartitionQueryParams pqp) {
   return internal::Visit(
       std::move(pqp.sql_params.transaction),
-      [this, &pqp](SessionHolder& session,
+      [this, &pqp](std::unique_ptr<SessionHolder>& session,
                    spanner_proto::TransactionSelector& s, std::int64_t) {
         return PartitionQueryImpl(session, s, pqp.sql_params,
                                   std::move(pqp.partition_options));
@@ -94,23 +96,24 @@ StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDml(
 StatusOr<CommitResult> ConnectionImpl::Commit(CommitParams cp) {
   return internal::Visit(
       std::move(cp.transaction),
-      [this, &cp](SessionHolder& session, spanner_proto::TransactionSelector& s,
-                  std::int64_t) {
-        return CommitImpl(session, s, std::move(cp));
+      [this, &cp](std::unique_ptr<SessionHolder>& session,
+                  spanner_proto::TransactionSelector& s, std::int64_t) {
+        return this->CommitImpl(session, s, std::move(cp));
       });
 }
 
 Status ConnectionImpl::Rollback(RollbackParams rp) {
   return internal::Visit(
       std::move(rp.transaction),
-      [this](SessionHolder& session, spanner_proto::TransactionSelector& s,
-             std::int64_t) { return RollbackImpl(session, s); });
+      [this](std::unique_ptr<SessionHolder>& session,
+             spanner_proto::TransactionSelector& s,
+             std::int64_t) { return this->RollbackImpl(session, s); });
 }
 
 StatusOr<ResultSet> ConnectionImpl::ReadImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
-    ReadParams rp) {
-  if (session.session_name().empty()) {
+    std::unique_ptr<SessionHolder>& session,
+    spanner_proto::TransactionSelector& s, ReadParams rp) {
+  if (!session) {
     auto session_or = GetSession();
     if (!session_or) {
       return std::move(session_or).status();
@@ -119,7 +122,7 @@ StatusOr<ResultSet> ConnectionImpl::ReadImpl(
   }
 
   spanner_proto::ReadRequest request;
-  request.set_session(session.session_name());
+  request.set_session(session->session_name());
   *request.mutable_transaction() = s;
   request.set_table(std::move(rp.table));
   request.set_index(std::move(rp.read_options.index_name));
@@ -152,12 +155,13 @@ StatusOr<ResultSet> ConnectionImpl::ReadImpl(
 }
 
 StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
-    ReadParams const& rp, PartitionOptions partition_options) {
-  if (session.session_name().empty()) {
+    std::unique_ptr<SessionHolder>& session,
+    spanner_proto::TransactionSelector& s, ReadParams const& rp,
+    PartitionOptions partition_options) {
+  if (!session) {
     // Since the session may be sent to other machines, it should not be
-    // returned to the pool when the Transaction is destroyed (release=true).
-    auto session_or = GetSession(/*release=*/true);
+    // returned to the pool when the Transaction is destroyed.
+    auto session_or = GetSession(/*dissociate_from_pool=*/true);
     if (!session_or) {
       return std::move(session_or).status();
     }
@@ -165,7 +169,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
   }
 
   spanner_proto::PartitionReadRequest request;
-  request.set_session(session.session_name());
+  request.set_session(session->session_name());
   *request.mutable_transaction() = s;
   request.set_table(rp.table);
   request.set_index(rp.read_options.index_name);
@@ -188,7 +192,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
   std::vector<ReadPartition> read_partitions;
   for (auto& partition : response->partitions()) {
     read_partitions.push_back(internal::MakeReadPartition(
-        response->transaction().id(), session.session_name(),
+        response->transaction().id(), session->session_name(),
         partition.partition_token(), rp.table, rp.keys, rp.columns,
         rp.read_options));
   }
@@ -197,9 +201,10 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
 }
 
 StatusOr<ResultSet> ConnectionImpl::ExecuteSqlImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, ExecuteSqlParams esp) {
-  if (session.session_name().empty()) {
+    std::unique_ptr<SessionHolder>& session,
+    spanner_proto::TransactionSelector& s, std::int64_t seqno,
+    ExecuteSqlParams esp) {
+  if (!session) {
     auto session_or = GetSession();
     if (!session_or) {
       return std::move(session_or).status();
@@ -208,7 +213,7 @@ StatusOr<ResultSet> ConnectionImpl::ExecuteSqlImpl(
   }
 
   spanner_proto::ExecuteSqlRequest request;
-  request.set_session(session.session_name());
+  request.set_session(session->session_name());
   *request.mutable_transaction() = s;
   auto sql_statement = internal::ToProto(std::move(esp.statement));
   request.set_sql(std::move(*sql_statement.mutable_sql()));
@@ -240,10 +245,13 @@ StatusOr<ResultSet> ConnectionImpl::ExecuteSqlImpl(
 }
 
 StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, ExecutePartitionedDmlParams epdp) {
-  if (session.session_name().empty()) {
-    auto session_or = GetSession();
+    std::unique_ptr<SessionHolder>& session,
+    spanner_proto::TransactionSelector& s, std::int64_t seqno,
+    ExecutePartitionedDmlParams epdp) {
+  if (!session) {
+    // Since the session may be sent to other machines, it should not be
+    // returned to the pool when the Transaction is destroyed (release=true).
+    auto session_or = GetSession(/*release=*/true);
     if (!session_or) {
       return std::move(session_or).status();
     }
@@ -252,7 +260,7 @@ StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
 
   grpc::ClientContext begin_context;
   spanner_proto::BeginTransactionRequest begin_request;
-  begin_request.set_session(session.session_name());
+  begin_request.set_session(session->session_name());
   *begin_request.mutable_options()->mutable_partitioned_dml() =
       spanner_proto::TransactionOptions_PartitionedDml();
 
@@ -263,7 +271,7 @@ StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
 
   grpc::ClientContext context;
   spanner_proto::ExecuteSqlRequest request;
-  request.set_session(session.session_name());
+  request.set_session(session->session_name());
   *request.mutable_transaction() = s;
   auto sql_statement = internal::ToProto(std::move(epdp.statement));
   request.set_sql(std::move(*sql_statement.mutable_sql()));
@@ -284,12 +292,13 @@ StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDmlImpl(
 }
 
 StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
-    ExecuteSqlParams const& esp, PartitionOptions partition_options) {
-  if (session.session_name().empty()) {
+    std::unique_ptr<SessionHolder>& session,
+    spanner_proto::TransactionSelector& s, ExecuteSqlParams const& esp,
+    PartitionOptions partition_options) {
+  if (!session) {
     // Since the session may be sent to other machines, it should not be
-    // returned to the pool when the Transaction is destroyed (release=true).
-    auto session_or = GetSession(/*release=*/true);
+    // returned to the pool when the Transaction is destroyed.
+    auto session_or = GetSession(/*dissociate_from_pool=*/true);
     if (!session_or) {
       return std::move(session_or).status();
     }
@@ -297,7 +306,7 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
   }
 
   spanner_proto::PartitionQueryRequest request;
-  request.set_session(session.session_name());
+  request.set_session(session->session_name());
   *request.mutable_transaction() = s;
   auto sql_statement = internal::ToProto(esp.statement);
   request.set_sql(std::move(*sql_statement.mutable_sql()));
@@ -320,7 +329,7 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
   std::vector<QueryPartition> query_partitions;
   for (auto& partition : response->partitions()) {
     query_partitions.push_back(internal::MakeQueryPartition(
-        response->transaction().id(), session.session_name(),
+        response->transaction().id(), session->session_name(),
         partition.partition_token(), esp.statement));
   }
 
@@ -328,17 +337,19 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
 }
 
 StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, BatchDmlParams params) {
-  if (session.session_name().empty()) {
+    std::unique_ptr<SessionHolder>& session,
+    spanner_proto::TransactionSelector& s, std::int64_t seqno,
+    BatchDmlParams params) {
+  if (!session) {
     auto session_or = GetSession();
     if (!session_or) {
       return std::move(session_or).status();
     }
     session = std::move(*session_or);
   }
+
   spanner_proto::ExecuteBatchDmlRequest request;
-  request.set_session(session.session_name());
+  request.set_session(session->session_name());
   request.set_seqno(seqno);
   *request.mutable_transaction() = s;
   for (auto& sql : params.statements) {
@@ -365,9 +376,9 @@ StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
 }
 
 StatusOr<CommitResult> ConnectionImpl::CommitImpl(
-    SessionHolder& session, spanner_proto::TransactionSelector& s,
-    CommitParams cp) {
-  if (session.session_name().empty()) {
+    std::unique_ptr<SessionHolder>& session,
+    spanner_proto::TransactionSelector& s, CommitParams cp) {
+  if (!session) {
     auto session_or = GetSession();
     if (!session_or) {
       return std::move(session_or).status();
@@ -376,7 +387,7 @@ StatusOr<CommitResult> ConnectionImpl::CommitImpl(
   }
 
   spanner_proto::CommitRequest request;
-  request.set_session(session.session_name());
+  request.set_session(session->session_name());
   for (auto&& m : cp.mutations) {
     *request.add_mutations() = std::move(m).as_proto();
   }
@@ -397,9 +408,9 @@ StatusOr<CommitResult> ConnectionImpl::CommitImpl(
   return r;
 }
 
-Status ConnectionImpl::RollbackImpl(SessionHolder& session,
-                                    spanner_proto::TransactionSelector& s) {
-  if (session.session_name().empty()) {
+Status ConnectionImpl::RollbackImpl(std::unique_ptr<SessionHolder>& session,
+                                spanner_proto::TransactionSelector& s) {
+  if (!session) {
     auto session_or = GetSession();
     if (!session_or) {
       return std::move(session_or).status();
@@ -417,7 +428,7 @@ Status ConnectionImpl::RollbackImpl(SessionHolder& session,
     return Status();
   }
   spanner_proto::RollbackRequest request;
-  request.set_session(session.session_name());
+  request.set_session(session->session_name());
   request.set_transaction_id(s.id());
   grpc::ClientContext context;
   return stub_->Rollback(context, request);
@@ -425,11 +436,16 @@ Status ConnectionImpl::RollbackImpl(SessionHolder& session,
 
 /**
  * Get a session from the pool, or create one if the pool is empty.
+ * @returns an error if session creation fails; always returns a valid
+ * `SessionHolder` (never `nullptr`) on success.
+ *
  * The `SessionHolder` usually returns the session to the pool when it is
- * destroyed, but if `release` is true the session will never be returned
- * to the pool.
+ * destroyed. However, if `dissociate_from_pool` is true the session will not
+ * be returned to the session pool. This is used in partitioned operations,
+ * since we don't know when all parties are done using the session.
  */
-StatusOr<SessionHolder> ConnectionImpl::GetSession(bool release) {
+StatusOr<std::unique_ptr<SessionHolder>> ConnectionImpl::GetSession(
+    bool dissociate_from_pool) {
   std::string session_name;
   std::unique_lock<std::mutex> lk(mu_);
   if (!sessions_.empty()) {
@@ -450,11 +466,14 @@ StatusOr<SessionHolder> ConnectionImpl::GetSession(bool release) {
     session_name = std::move(*response->mutable_name());
   }
 
-  return release ? SessionHolder(std::move(session_name), /*deleter=*/nullptr)
-                 : SessionHolder(std::move(session_name),
-                                 [this](std::string session) {
-                                   ReleaseSession(std::move(session));
-                                 });
+  // TODO(#409) take a (weak) reference to `this` to avoid use-after-free.
+  auto deleter = dissociate_from_pool
+                     ? std::function<void(std::string)>(nullptr)
+                     : [this](std::string session) {
+                         this->ReleaseSession(std::move(session));
+                       };
+  return make_unique<SessionHolder>(std::move(session_name),
+                                    std::move(deleter));
 }
 
 void ConnectionImpl::ReleaseSession(std::string session) {

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -464,7 +464,7 @@ StatusOr<std::unique_ptr<SessionHolder>> ConnectionImpl::GetSession(
 
   // TODO(#409) take a (weak) reference to `this` to avoid use-after-free.
   auto deleter = dissociate_from_pool
-                     ? std::function<void(std::string)>(nullptr)
+                     ? std::function<void(std::string)>()
                      : [this](std::string session) {
                          this->ReleaseSession(std::move(session));
                        };

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -27,8 +27,6 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-using ::google::cloud::internal::make_unique;
-
 namespace spanner_proto = ::google::spanner::v1;
 
 StatusOr<ResultSet> ConnectionImpl::Read(ReadParams rp) {
@@ -472,8 +470,8 @@ StatusOr<std::unique_ptr<SessionHolder>> ConnectionImpl::GetSession(
                      : [this](std::string session) {
                          this->ReleaseSession(std::move(session));
                        };
-  return make_unique<SessionHolder>(std::move(session_name),
-                                    std::move(deleter));
+  return ::google::cloud::internal::make_unique<SessionHolder>(
+      std::move(session_name), std::move(deleter));
 }
 
 void ConnectionImpl::ReleaseSession(std::string session) {

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -74,8 +74,9 @@ class ConnectionImpl : public Connection {
       ExecuteSqlParams esp);
 
   StatusOr<PartitionedDmlResult> ExecutePartitionedDmlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecutePartitionedDmlParams epdp);
+      std::unique_ptr<SessionHolder>& session,
+      google::spanner::v1::TransactionSelector& s, std::int64_t seqno,
+      ExecutePartitionedDmlParams epdp);
 
   StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
       std::unique_ptr<SessionHolder>& session,
@@ -83,15 +84,16 @@ class ConnectionImpl : public Connection {
       PartitionOptions partition_options);
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, BatchDmlParams params);
+      std::unique_ptr<SessionHolder>& session,
+      google::spanner::v1::TransactionSelector& s, std::int64_t seqno,
+      BatchDmlParams params);
 
   StatusOr<CommitResult> CommitImpl(std::unique_ptr<SessionHolder>& session,
                                     google::spanner::v1::TransactionSelector& s,
                                     CommitParams cp);
 
   Status RollbackImpl(std::unique_ptr<SessionHolder>& session,
-                  google::spanner::v1::TransactionSelector& s);
+                      google::spanner::v1::TransactionSelector& s);
 
   StatusOr<std::unique_ptr<SessionHolder>> GetSession(
       bool dissociate_from_pool = false);

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -59,38 +59,42 @@ class ConnectionImpl : public Connection {
   Status Rollback(RollbackParams) override;
 
  private:
-  StatusOr<ResultSet> ReadImpl(SessionHolder& session,
+  StatusOr<ResultSet> ReadImpl(std::unique_ptr<SessionHolder>& session,
                                google::spanner::v1::TransactionSelector& s,
                                ReadParams rp);
 
   StatusOr<std::vector<ReadPartition>> PartitionReadImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      ReadParams const& rp, PartitionOptions partition_options);
+      std::unique_ptr<SessionHolder>& session,
+      google::spanner::v1::TransactionSelector& s, ReadParams const& rp,
+      PartitionOptions partition_options);
 
   StatusOr<ResultSet> ExecuteSqlImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteSqlParams esp);
+      std::unique_ptr<SessionHolder>& session,
+      google::spanner::v1::TransactionSelector& s, std::int64_t seqno,
+      ExecuteSqlParams esp);
 
   StatusOr<PartitionedDmlResult> ExecutePartitionedDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
       std::int64_t seqno, ExecutePartitionedDmlParams epdp);
 
   StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
-      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      ExecuteSqlParams const& esp, PartitionOptions partition_options);
+      std::unique_ptr<SessionHolder>& session,
+      google::spanner::v1::TransactionSelector& s, ExecuteSqlParams const& esp,
+      PartitionOptions partition_options);
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
       std::int64_t seqno, BatchDmlParams params);
 
-  StatusOr<CommitResult> CommitImpl(SessionHolder& session,
+  StatusOr<CommitResult> CommitImpl(std::unique_ptr<SessionHolder>& session,
                                     google::spanner::v1::TransactionSelector& s,
                                     CommitParams cp);
 
-  Status RollbackImpl(SessionHolder& session,
-                      google::spanner::v1::TransactionSelector& s);
+  Status RollbackImpl(std::unique_ptr<SessionHolder>& session,
+                  google::spanner::v1::TransactionSelector& s);
 
-  StatusOr<SessionHolder> GetSession(bool release = false);
+  StatusOr<std::unique_ptr<SessionHolder>> GetSession(
+      bool dissociate_from_pool = false);
   void ReleaseSession(std::string session);
 
   Database db_;

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -526,8 +526,8 @@ TEST(ConnectionImplTest, CommitSuccessWithTransactionId) {
       }));
 
   auto txn = MakeReadWriteTransaction();
-  internal::Visit(txn, [](SessionHolder&, spanner_proto::TransactionSelector& s,
-                          std::int64_t) {
+  internal::Visit(txn, [](std::unique_ptr<SessionHolder>&,
+                          spanner_proto::TransactionSelector& s, std::int64_t) {
     s.set_id("test-txn-id");
     return 0;
   });
@@ -630,8 +630,8 @@ TEST(ConnectionImplTest, RollbackFailure) {
   ConnectionImpl conn(db, mock);
   auto txn = MakeReadWriteTransaction();
   auto begin_transaction =
-      [&transaction_id](SessionHolder&, spanner_proto::TransactionSelector& s,
-                        std::int64_t) {
+      [&transaction_id](std::unique_ptr<SessionHolder>&,
+                        spanner_proto::TransactionSelector& s, std::int64_t) {
         s.set_id(transaction_id);
         return 0;
       };
@@ -668,8 +668,8 @@ TEST(ConnectionImplTest, RollbackSuccess) {
   ConnectionImpl conn(db, mock);
   auto txn = MakeReadWriteTransaction();
   auto begin_transaction =
-      [&transaction_id](SessionHolder&, spanner_proto::TransactionSelector& s,
-                        std::int64_t) {
+      [&transaction_id](std::unique_ptr<SessionHolder>&,
+                        spanner_proto::TransactionSelector& s, std::int64_t) {
         s.set_id(transaction_id);
         return 0;
       };
@@ -891,7 +891,7 @@ TEST(ConnectionImplTest, MultipleThreads) {
     for (int i = 0; i != iterations; ++i) {
       auto txn = MakeReadWriteTransaction();
       auto begin_transaction = [thread_id, i](
-                                   SessionHolder&,
+                                   std::unique_ptr<SessionHolder>&,
                                    spanner_proto::TransactionSelector& s,
                                    std::int64_t) {
         s.set_id("txn-" + std::to_string(thread_id) + ":" + std::to_string(i));

--- a/google/cloud/spanner/internal/session_holder.h
+++ b/google/cloud/spanner/internal/session_holder.h
@@ -30,7 +30,6 @@ namespace internal {
  */
 class SessionHolder {
  public:
-  SessionHolder() = default;
   SessionHolder(std::string session,
                 std::function<void(std::string)> deleter) noexcept
       : session_(std::move(session)), deleter_(std::move(deleter)) {}

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/internal/time.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/transaction.h"
+#include "google/cloud/internal/make_unique.h"
 #include "google/cloud/internal/port_platform.h"
 #include <gmock/gmock.h>
 #include <chrono>
@@ -33,7 +34,10 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
-using TransactionSelector = google::spanner::v1::TransactionSelector;
+using ::google::cloud::internal::make_unique;
+using ::google::spanner::v1::TransactionSelector;
+using ::testing::IsNull;
+using ::testing::NotNull;
 
 class KeySet {};
 class ResultSet {};
@@ -70,9 +74,9 @@ class Client {
   // User-visible read operation.
   ResultSet Read(Transaction txn, std::string const& table, KeySet const& keys,
                  std::vector<std::string> const& columns) {
-    auto read = [this, &table, &keys, &columns](SessionHolder& session,
-                                                TransactionSelector& selector,
-                                                std::int64_t seqno) {
+    auto read = [this, &table, &keys, &columns](
+                    std::unique_ptr<SessionHolder>& session,
+                    TransactionSelector& selector, std::int64_t seqno) {
       return this->Read(session, selector, seqno, table, keys, columns);
     };
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
@@ -87,9 +91,10 @@ class Client {
   }
 
  private:
-  ResultSet Read(SessionHolder& session, TransactionSelector& selector,
-                 std::int64_t seqno, std::string const& table,
-                 KeySet const& keys, std::vector<std::string> const& columns);
+  ResultSet Read(std::unique_ptr<SessionHolder>& session,
+                 TransactionSelector& selector, std::int64_t seqno,
+                 std::string const& table, KeySet const& keys,
+                 std::vector<std::string> const& columns);
 
   Mode mode_;
   Timestamp read_timestamp_;
@@ -104,11 +109,12 @@ class Client {
 // to make a StreamingRead() RPC, and then, if the selector was a `begin`,
 // switch the selector to use the allocated transaction ID.  Here we use
 // the pre-assigned transaction ID after checking the read timestamp.
-ResultSet Client::Read(SessionHolder& session, TransactionSelector& selector,
-                       std::int64_t seqno, std::string const&, KeySet const&,
+ResultSet Client::Read(std::unique_ptr<SessionHolder>& session,
+                       TransactionSelector& selector, std::int64_t seqno,
+                       std::string const&, KeySet const&,
                        std::vector<std::string> const&) {
   if (selector.has_begin()) {
-    EXPECT_EQ("", session.session_name());
+    EXPECT_THAT(session, IsNull());
     bool fail_with_throw = false;
     if (selector.begin().has_read_only() &&
         selector.begin().read_only().has_read_timestamp()) {
@@ -129,7 +135,7 @@ ResultSet Client::Read(SessionHolder& session, TransactionSelector& selector,
     }
     switch (mode_) {
       case Mode::kReadSucceeds:  // `begin` -> `id`, calls now parallelized
-        session = SessionHolder(session_id_, /*deleter=*/nullptr);
+        session = make_unique<SessionHolder>(session_id_, /*deleter=*/nullptr);
         selector.set_id(txn_id_);
         break;
       case Mode::kReadFails:  // leave as `begin`, calls stay serialized
@@ -142,7 +148,8 @@ ResultSet Client::Read(SessionHolder& session, TransactionSelector& selector,
     }
   } else {
     if (selector.id() == txn_id_) {
-      EXPECT_EQ(session_id_, session.session_name());
+      EXPECT_THAT(session, NotNull());
+      EXPECT_EQ(session_id_, session->session_name());
       std::unique_lock<std::mutex> lock(mu_);
       switch (mode_) {
         case Mode::kReadSucceeds:  // non-initial visits valid

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -34,7 +34,6 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
-using ::google::cloud::internal::make_unique;
 using ::google::spanner::v1::TransactionSelector;
 using ::testing::IsNull;
 using ::testing::NotNull;
@@ -135,7 +134,8 @@ ResultSet Client::Read(std::unique_ptr<SessionHolder>& session,
     }
     switch (mode_) {
       case Mode::kReadSucceeds:  // `begin` -> `id`, calls now parallelized
-        session = make_unique<SessionHolder>(session_id_, /*deleter=*/nullptr);
+        session = ::google::cloud::internal::make_unique<SessionHolder>(
+            session_id_, /*deleter=*/nullptr);
         selector.set_id(txn_id_);
         break;
       case Mode::kReadFails:  // leave as `begin`, calls stay serialized

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/spanner/internal/session_holder.h"
 #include "google/cloud/spanner/internal/time.h"
 #include "google/cloud/spanner/internal/transaction_impl.h"
-#include "google/cloud//internal/make_unique.h"
+#include "google/cloud/internal/make_unique.h"
 
 namespace google {
 namespace cloud {
@@ -24,8 +24,6 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 namespace {
-
-using ::google::cloud::internal::make_unique;
 
 google::spanner::v1::TransactionOptions MakeOpts(
     google::spanner::v1::TransactionOptions_ReadOnly ro_opts) {
@@ -99,8 +97,9 @@ Transaction::Transaction(std::string session_id, std::string transaction_id) {
   google::spanner::v1::TransactionSelector selector;
   selector.set_id(std::move(transaction_id));
   impl_ = std::make_shared<internal::TransactionImpl>(
-      make_unique<internal::SessionHolder>(std::move(session_id),
-                                           /*deleter=*/nullptr),
+      ::google::cloud::internal::make_unique<internal::SessionHolder>(
+          std::move(session_id),
+          /*deleter=*/nullptr),
       std::move(selector));
 }
 

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/internal/session_holder.h"
 #include "google/cloud/spanner/internal/time.h"
 #include "google/cloud/spanner/internal/transaction_impl.h"
+#include "google/cloud//internal/make_unique.h"
 
 namespace google {
 namespace cloud {
@@ -23,6 +24,8 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 namespace {
+
+using ::google::cloud::internal::make_unique;
 
 google::spanner::v1::TransactionOptions MakeOpts(
     google::spanner::v1::TransactionOptions_ReadOnly ro_opts) {
@@ -96,7 +99,8 @@ Transaction::Transaction(std::string session_id, std::string transaction_id) {
   google::spanner::v1::TransactionSelector selector;
   selector.set_id(std::move(transaction_id));
   impl_ = std::make_shared<internal::TransactionImpl>(
-      internal::SessionHolder(std::move(session_id), /*deleter=*/nullptr),
+      make_unique<internal::SessionHolder>(std::move(session_id),
+                                           /*deleter=*/nullptr),
       std::move(selector));
 }
 

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -77,22 +77,24 @@ TEST(Transaction, RegularSemantics) {
 TEST(Transaction, Visit) {
   Transaction a = MakeReadOnlyTransaction();
   std::int64_t a_seqno;
-  internal::Visit(a, [&a_seqno](internal::SessionHolder& /*session*/,
-                                google::spanner::v1::TransactionSelector& s,
-                                std::int64_t seqno) {
-    EXPECT_TRUE(s.has_begin());
-    EXPECT_TRUE(s.begin().has_read_only());
-    s.set_id("test-txn-id");
-    a_seqno = seqno;
-    return 0;
-  });
-  internal::Visit(a, [a_seqno](internal::SessionHolder& /*session*/,
-                               google::spanner::v1::TransactionSelector& s,
-                               std::int64_t seqno) {
-    EXPECT_EQ("test-txn-id", s.id());
-    EXPECT_GT(seqno, a_seqno);
-    return 0;
-  });
+  internal::Visit(
+      a, [&a_seqno](std::unique_ptr<internal::SessionHolder>& /*session*/,
+                    google::spanner::v1::TransactionSelector& s,
+                    std::int64_t seqno) {
+        EXPECT_TRUE(s.has_begin());
+        EXPECT_TRUE(s.begin().has_read_only());
+        s.set_id("test-txn-id");
+        a_seqno = seqno;
+        return 0;
+      });
+  internal::Visit(
+      a, [a_seqno](std::unique_ptr<internal::SessionHolder>& /*session*/,
+                   google::spanner::v1::TransactionSelector& s,
+                   std::int64_t seqno) {
+        EXPECT_EQ("test-txn-id", s.id());
+        EXPECT_GT(seqno, a_seqno);
+        return 0;
+      });
 }
 
 }  // namespace


### PR DESCRIPTION
This makes "no session" a distinct case (nullptr) instead of being a
special case inside SessionHolder. Now if SessionHolder exists, the
session_name() is always valid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/507)
<!-- Reviewable:end -->
