### PR TITLE
Add a configration file for bazelci

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,10 @@
+---
+tasks:
+  ubuntu1804:
+    platform: ubuntu1804
+    build_targets:
+    - "//google/cloud/spanner/..."
+    test_flags:
+    - "--test_tag_filters=-integration-tests"
+    test_targets:
+    - "//google/cloud/spanner/..."


### PR DESCRIPTION
Currently it will build and run unit tests on Ubuntu 18.04.

The configuration file is explained at:
https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/527)
<!-- Reviewable:end -->
