### PR TITLE
feat: implement a mocking example.

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -149,7 +149,6 @@ add_library(spanner_client
             row_parser.h
             sql_statement.cc
             sql_statement.h
-            testing/mock_spanner_stub.h
             timestamp.h
             transaction.cc
             transaction.h
@@ -197,6 +196,8 @@ function (spanner_client_define_tests)
                 testing/database_environment.cc
                 testing/database_environment.h
                 testing/matchers.h
+                testing/mock_spanner_connection.h
+                testing/mock_spanner_stub.h
                 testing/random_database_name.cc
                 testing/random_database_name.h
                 testing/validate_metadata.cc

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/spanner/internal/time.h"
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/result_set.h"
+#include "google/cloud/spanner/testing/mock_spanner_connection.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/internal/make_unique.h"
@@ -37,6 +38,8 @@ namespace {
 namespace spanner_proto = ::google::spanner::v1;
 
 using ::google::cloud::internal::make_unique;
+using ::google::cloud::spanner_testing::MockConnection;
+using ::google::cloud::spanner_testing::MockResultSetSource;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
 using ::testing::ByMove;
@@ -46,26 +49,6 @@ using ::testing::HasSubstr;
 using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::SaveArg;
-
-class MockConnection : public Connection {
- public:
-  MOCK_METHOD1(Read, StatusOr<ResultSet>(ReadParams));
-  MOCK_METHOD1(PartitionRead,
-               StatusOr<std::vector<ReadPartition>>(PartitionReadParams));
-  MOCK_METHOD1(ExecuteSql, StatusOr<ResultSet>(ExecuteSqlParams));
-  MOCK_METHOD1(PartitionQuery,
-               StatusOr<std::vector<QueryPartition>>(PartitionQueryParams));
-  MOCK_METHOD1(ExecuteBatchDml, StatusOr<BatchDmlResult>(BatchDmlParams));
-  MOCK_METHOD1(Commit, StatusOr<CommitResult>(CommitParams));
-  MOCK_METHOD1(Rollback, Status(RollbackParams));
-};
-
-class MockResultSetSource : public internal::ResultSetSource {
- public:
-  MOCK_METHOD0(NextValue, StatusOr<optional<Value>>());
-  MOCK_METHOD0(Metadata, optional<spanner_proto::ResultSetMetadata>());
-  MOCK_METHOD0(Stats, optional<spanner_proto::ResultSetStats>());
-};
 
 TEST(ClientTest, CopyAndMove) {
   auto conn1 = std::make_shared<MockConnection>();

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -203,6 +203,10 @@ period between retries.
 @see [ExponentialBackoffPolicy](@ref google::cloud::spanner::v0::ExponentialBackoffPolicy)
    to configure different parameters for the exponential backoff policy.
 
+## Next Steps
+
+* @ref spanner-mocking
+
 [sql-overview-link]: https://cloud.google.com/spanner/docs/query-syntax
 
 [spanner-quickstart]: https://cloud.google.com/spanner/docs/tutorials 'Spanner Tutorials'

--- a/google/cloud/spanner/doc/spanner-mocking.dox
+++ b/google/cloud/spanner/doc/spanner-mocking.dox
@@ -1,0 +1,71 @@
+/*!
+
+@page spanner-mocking Mocking the Cloud Spanner C++ Client with Google Mock.
+
+In this document we describe how to write unit tests that mock
+`google::cloud::spanner::Client` using Google Mock. This document assumes the
+reader is familiar with the Google Test and Google Mock frameworks and with
+the Cloud Spanner C++ Client.
+
+## Mocking a successful `ExecuteSql`
+
+First include the headers for the Cloud Spanner Client, the mocking class, and
+the Google Mock framework.
+
+@snippet mock_execute_sql.cc required-includes
+
+The example uses a number of aliases to save typing and improve readability:
+
+@snippet mock_execute_sql.cc helper-aliases
+
+Create a mocking object for `google::cloud::spanner::Connection`:
+
+@snippet mock_execute_sql.cc create-mock
+
+We will setup this mock in a second, but first let's look at how it is used to
+create a `google::cloud::spanner::Client` object:
+
+@snippet mock_execute_sql.cc create-client
+
+Once the client is created you can make calls on the client as usual:
+
+@snippet mock_execute_sql.cc client-call
+
+And then verify the results meet your expectations:
+
+@snippet mock_execute_sql.cc expected-results
+
+All of this depends on creating a `google::cloud::spanner::ResultSet` that
+simulates the stream of results you want. To do so, you need to mock a source
+that streams `google::cloud::spanner::Values`:
+
+@snippet mock_execute_sql.cc create-streaming-source
+
+The source must define the names and types of the columns returned by the query:
+
+@snippet mock_execute_sql.cc return-metadata
+
+And then setup the mock to return the results. Note that the results are
+returned one value at a time, even if a row contains multiple values.
+
+@snippet mock_execute_sql.cc simulate-streaming-results
+
+Note that the last value in the stream is indicated by an optional without a
+value:
+
+@snippet mock_execute_sql.cc simulate-streaming-end
+
+
+Once the `source` has been created and its behavior mocked, you mock the
+behavior for `ExecuteSql`:
+
+@snippet mock_execute_sql.cc mock-execute-sql
+
+
+## Full Listing
+
+Finally we present the full code for this example:
+
+@snippet mock_execute_sql.cc all
+
+*/

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -17,29 +17,52 @@
 include(EnableClangTidy)
 include(EnableWerror)
 
+function (google_cloud_cpp_test_name_to_target var fname)
+    string(REPLACE "/"
+                   "_"
+                   target
+                   ${fname})
+    string(REPLACE ".cc"
+                   ""
+                   target
+                   ${target})
+    set("${var}" "${target}" PARENT_SCOPE)
+endfunction ()
+
 function (spanner_client_define_samples)
-    set(spanner_client_samples samples.cc)
+    set(spanner_client_integration_samples samples.cc)
+    set(spanner_client_unit_samples mock_execute_sql.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
     # the list in two places.
     export_list_to_bazel("spanner_client_samples.bzl" "spanner_client_samples")
 
     # Generate a target for each unit test.
-    foreach (fname ${spanner_client_samples})
-        string(REPLACE "/"
-                       "_"
-                       target
-                       ${fname})
-        string(REPLACE ".cc"
-                       ""
-                       target
-                       ${target})
+    foreach (fname ${spanner_client_integration_samples}
+             ${spanner_client_unit_samples})
+        google_cloud_cpp_test_name_to_target(target "${fname}")
         add_executable(${target} ${fname})
-        target_link_libraries(${target} PRIVATE googleapis-c++::spanner_client)
         google_cloud_cpp_add_clang_tidy(${target})
         google_cloud_cpp_add_common_options(${target})
         add_test(NAME ${target} COMMAND ${target})
+    endforeach ()
+
+    foreach (fname ${spanner_client_integration_samples})
+        google_cloud_cpp_test_name_to_target(target "${fname}")
+        target_link_libraries(${target} PRIVATE googleapis-c++::spanner_client)
         set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
+    endforeach ()
+
+    foreach (fname ${spanner_client_unit_samples})
+        google_cloud_cpp_test_name_to_target(target "${fname}")
+        target_link_libraries(${target}
+                              PRIVATE googleapis-c++::spanner_client
+                                      spanner_client_testing
+                                      google_cloud_cpp_testing
+                                      GTest::gmock_main
+                                      GTest::gmock
+                                      GTest::gtest)
+
     endforeach ()
 endfunction ()
 

--- a/google/cloud/spanner/samples/mock_execute_sql.cc
+++ b/google/cloud/spanner/samples/mock_execute_sql.cc
@@ -1,0 +1,112 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! [all]
+
+//! [required-includes]
+#include "google/cloud/spanner/client.h"
+#include "google/cloud/spanner/testing/mock_spanner_connection.h"
+#include <google/protobuf/text_format.h>
+#include <gmock/gmock.h>
+//! [required-includes]
+
+namespace {
+
+//! [helper-aliases]
+using ::testing::_;
+using ::testing::Return;
+namespace spanner = google::cloud::spanner;
+//! [helper-aliases]
+
+TEST(MockSpannerClient, SuccessfulExecuteSql) {
+  // Create a mock object to stream the results of a ExecuteSql query.
+  //! [create-streaming-source]
+  auto source =
+      std::unique_ptr<google::cloud::spanner_testing::MockResultSetSource>(
+          new google::cloud::spanner_testing::MockResultSetSource);
+  //! [create-streaming-source]
+
+  // Setup the return type of the ExecuteSql results:
+  //! [return-metadata]
+  google::spanner::v1::ResultSetMetadata metadata;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        row_type: {
+          fields: {
+            name: "Id",
+            type: { code: INT64 }
+          }
+          fields: {
+            name: "Greeting",
+            type: { code: STRING }
+          }
+        }
+      )pb",
+      &metadata));
+  EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
+  //! [return-metadata]
+
+  // Setup the mock source to return some values:
+  //! [simulate-streaming-results]
+  EXPECT_CALL(*source, NextValue())
+      .WillOnce(Return(google::cloud::optional<spanner::Value>(1)))
+      .WillOnce(Return(google::cloud::optional<spanner::Value>("Hello World")))
+      .WillOnce(Return(google::cloud::optional<spanner::Value>(2)))
+      .WillOnce(Return(google::cloud::optional<spanner::Value>("Hello World")))
+      //! [simulate-streaming-results]
+      //! [simulate-streaming-end]
+      .WillOnce(Return(google::cloud::optional<spanner::Value>()));
+  //! [simulate-streaming-end]
+
+  // Create a mock for `spanner::Connection`:
+  //! [create-mock]
+  auto conn =
+      std::make_shared<google::cloud::spanner_testing::MockConnection>();
+  //! [create-mock]
+
+  // Setup the connection mock to return the results previously setup:
+  //! [mock-execute-sql]
+  EXPECT_CALL(*conn, ExecuteSql(_))
+      .WillOnce([&source](spanner::Connection::ExecuteSqlParams const&)
+                    -> google::cloud::StatusOr<spanner::ResultSet> {
+        return spanner::ResultSet(std::move(source));
+      });
+  //! [mock-execute-sql]
+
+  // Create a client with the mocked connection:
+  //! [create-client]
+  spanner::Client client(conn);
+  //! [create-client]
+
+  // Make the request and verify the expected results:
+  //! [client-call]
+  auto reader = client.ExecuteSql(
+      spanner::SqlStatement("SELECT Id, Greeting FROM Greetings"));
+  ASSERT_TRUE(reader);
+  //! [client-call]
+
+  //! [expected-results]
+  int count = 0;
+  for (auto row : reader->Rows<std::int64_t, std::string>()) {
+    ASSERT_TRUE(row);
+    auto expected_id = ++count;
+    EXPECT_EQ(expected_id, row->get<0>());
+    EXPECT_EQ("Hello World", row->get<1>());
+  }
+  //! [expected-results]
+}
+
+}  // namespace
+
+//! [all]

--- a/google/cloud/spanner/samples/spanner_client_samples.bzl
+++ b/google/cloud/spanner/samples/spanner_client_samples.bzl
@@ -17,5 +17,4 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 spanner_client_samples = [
-    "samples.cc",
 ]

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -56,7 +56,6 @@ spanner_client_hdrs = [
     "row.h",
     "row_parser.h",
     "sql_statement.h",
-    "testing/mock_spanner_stub.h",
     "timestamp.h",
     "transaction.h",
     "value.h",

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -19,6 +19,8 @@
 spanner_client_testing_hdrs = [
     "testing/database_environment.h",
     "testing/matchers.h",
+    "testing/mock_spanner_connection.h",
+    "testing/mock_spanner_stub.h",
     "testing/random_database_name.h",
     "testing/validate_metadata.h",
 ]

--- a/google/cloud/spanner/testing/mock_spanner_connection.h
+++ b/google/cloud/spanner/testing/mock_spanner_connection.h
@@ -1,0 +1,52 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_SPANNER_CONNECTION_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_SPANNER_CONNECTION_H_
+
+#include "google/cloud/spanner/connection.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+
+class MockConnection : public spanner::Connection {
+ public:
+  MOCK_METHOD1(Read, StatusOr<spanner::ResultSet>(ReadParams));
+  MOCK_METHOD1(PartitionRead, StatusOr<std::vector<spanner::ReadPartition>>(
+                                  PartitionReadParams));
+  MOCK_METHOD1(ExecuteSql, StatusOr<spanner::ResultSet>(ExecuteSqlParams));
+  MOCK_METHOD1(PartitionQuery, StatusOr<std::vector<spanner::QueryPartition>>(
+                                   PartitionQueryParams));
+  MOCK_METHOD1(ExecuteBatchDml,
+               StatusOr<spanner::BatchDmlResult>(BatchDmlParams));
+  MOCK_METHOD1(Commit, StatusOr<spanner::CommitResult>(CommitParams));
+  MOCK_METHOD1(Rollback, Status(RollbackParams));
+};
+
+class MockResultSetSource : public spanner::internal::ResultSetSource {
+ public:
+  MOCK_METHOD0(NextValue, StatusOr<optional<spanner::Value>>());
+  MOCK_METHOD0(Metadata, optional<google::spanner::v1::ResultSetMetadata>());
+  MOCK_METHOD0(Stats, optional<google::spanner::v1::ResultSetStats>());
+};
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_SPANNER_CONNECTION_H_


### PR DESCRIPTION
Add a new sample showing how to mock a `spanner::Client`, because this
is a fairly difficult example to understand this change also adds a new
page to explain the example step-by-step.

This fixes #196

If you are interested in the rendered output from the docs, I manually uploaded them to this location:

https://coryan.github.io/google-cloud-cpp-spanner/pr530/spanner-mocking.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/530)
<!-- Reviewable:end -->
