### PR TITLE
feat: populate the user-agent string.

### DIFF
--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/connection_options.h"
+#include "google/cloud/spanner/internal/compiler_info.h"
 #include "google/cloud/internal/getenv.h"
 #include <sstream>
 
@@ -20,10 +21,19 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+std::string BaseUserAgentPrefix() {
+  return "gcloud-cpp/" + google::cloud::spanner::VersionString() + " (" +
+         CompilerId() + "-" + CompilerVersion() + "; " + CompilerFeatures() +
+         ")";
+}
+}  // namespace internal
+
 ConnectionOptions::ConnectionOptions(
     std::shared_ptr<grpc::ChannelCredentials> credentials)
     : credentials_(std::move(credentials)),
-      endpoint_("spanner.googleapis.com") {
+      endpoint_("spanner.googleapis.com"),
+      user_agent_prefix_(internal::BaseUserAgentPrefix()) {
   auto tracing =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_ENABLE_TRACING");
   if (tracing.has_value()) {
@@ -40,6 +50,21 @@ ConnectionOptions::ConnectionOptions(
 
 ConnectionOptions::ConnectionOptions()
     : ConnectionOptions(grpc::GoogleDefaultCredentials()) {}
+
+grpc::ChannelArguments ConnectionOptions::CreateChannelArguments() const {
+  grpc::ChannelArguments channel_arguments;
+
+  if (!channel_pool_domain().empty()) {
+    // To get a different channel pool one just needs to set any channel
+    // parameter to a different value. Newer versions of gRPC include a macro
+    // for this purpose (GRPC_ARG_CHANNEL_POOL_DOMAIN). As we are compiling
+    // against older versions in some cases, we use the actual value.
+    channel_arguments.SetString("grpc.channel_pooling_domain",
+                                channel_pool_domain());
+  }
+  channel_arguments.SetUserAgentPrefix(user_agent_prefix());
+  return channel_arguments;
+}
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -86,6 +86,14 @@ class ConnectionOptions {
     return *this;
   }
 
+  /**
+   * Prepend @p prefix to the user-agent string.
+   *
+   * Libraries or services that use the Cloud Spanner C++ client may want to
+   * set their own user-agent prefix. This can help them develop telemetry
+   * information about number of users running particular versions of their
+   * system or library.
+   */
   ConnectionOptions& add_user_agent_prefix(std::string prefix) {
     prefix += " ";
     prefix += user_agent_prefix_;

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -28,6 +28,10 @@ namespace google {
 namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+std::string BaseUserAgentPrefix();
+}  // namespace internal
+
 /**
  * The configuration parameters for spanner connections.
  */
@@ -82,12 +86,24 @@ class ConnectionOptions {
     return *this;
   }
 
+  ConnectionOptions& add_user_agent_prefix(std::string prefix) {
+    prefix += " ";
+    prefix += user_agent_prefix_;
+    user_agent_prefix_ = std::move(prefix);
+    return *this;
+  }
+  std::string const& user_agent_prefix() const { return user_agent_prefix_; }
+
+  grpc::ChannelArguments CreateChannelArguments() const;
+
  private:
   std::shared_ptr<grpc::ChannelCredentials> credentials_;
   std::string endpoint_;
   bool clog_enabled_ = false;
   std::set<std::string> tracing_components_;
   std::string channel_pool_domain_;
+
+  std::string user_agent_prefix_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -246,15 +246,7 @@ std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(
     google::cloud::LogSink::EnableStdClog();
   }
 
-  grpc::ChannelArguments channel_arguments;
-  if (!options.channel_pool_domain().empty()) {
-    // To get a different channel pool one just needs to set any channel
-    // parameter to a different value. Newer versions of gRPC include a macro
-    // for this purpose (GRPC_ARG_CHANNEL_POOL_DOMAIN). As we are compiling
-    // against older versions in some cases, we use the actual value.
-    channel_arguments.SetString("grpc.channel_pooling_domain",
-                                options.channel_pool_domain());
-  }
+  grpc::ChannelArguments channel_arguments = options.CreateChannelArguments();
 
   auto spanner_grpc_stub =
       spanner_proto::Spanner::NewStub(grpc::CreateCustomChannel(


### PR DESCRIPTION
Populate the user-agent string with information about the library
version. Also allow applications to add their own user-agent string
prefixes.

This is part of the work for #224

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/535)
<!-- Reviewable:end -->
