### PR TITLE
cleanup: connection_impl function naming

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -46,61 +46,52 @@ class ConnectionImpl : public Connection {
                           std::shared_ptr<internal::SpannerStub> stub)
       : db_(std::move(db)), stub_(std::move(stub)) {}
 
-  StatusOr<ResultSet> Read(ReadParams rp) override;
+  StatusOr<ResultSet> Read(ReadParams) override;
   StatusOr<std::vector<ReadPartition>> PartitionRead(
-      PartitionReadParams prp) override;
-  StatusOr<ResultSet> ExecuteSql(ExecuteSqlParams esp) override;
+      PartitionReadParams) override;
+  StatusOr<ResultSet> ExecuteSql(ExecuteSqlParams) override;
   StatusOr<PartitionedDmlResult> ExecutePartitionedDml(
       ExecutePartitionedDmlParams) override;
-
   StatusOr<std::vector<QueryPartition>> PartitionQuery(
       PartitionQueryParams) override;
   StatusOr<BatchDmlResult> ExecuteBatchDml(BatchDmlParams) override;
-  StatusOr<CommitResult> Commit(CommitParams cp) override;
-  Status Rollback(RollbackParams rp) override;
+  StatusOr<CommitResult> Commit(CommitParams) override;
+  Status Rollback(RollbackParams) override;
 
  private:
-  StatusOr<SessionHolder> GetSession(bool release = false);
-  void ReleaseSession(std::string session);
+  StatusOr<ResultSet> ReadImpl(SessionHolder& session,
+                               google::spanner::v1::TransactionSelector& s,
+                               ReadParams rp);
 
-  /// Implementation details for Read.
-  StatusOr<ResultSet> Read(SessionHolder& session,
-                           google::spanner::v1::TransactionSelector& s,
-                           ReadParams rp);
-
-  /// Implementation details for PartitionRead.
-  StatusOr<std::vector<ReadPartition>> PartitionRead(
+  StatusOr<std::vector<ReadPartition>> PartitionReadImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
       ReadParams const& rp, PartitionOptions partition_options);
 
-  /// Implementation details for ExecuteSql
-  StatusOr<ResultSet> ExecuteSql(SessionHolder& session,
-                                 google::spanner::v1::TransactionSelector& s,
-                                 std::int64_t seqno, ExecuteSqlParams esp);
+  StatusOr<ResultSet> ExecuteSqlImpl(
+      SessionHolder& session, google::spanner::v1::TransactionSelector& s,
+      std::int64_t seqno, ExecuteSqlParams esp);
 
-  /// Implementation details for ExecutePartitionedDml
-  StatusOr<PartitionedDmlResult> ExecutePartitionedDml(
+  StatusOr<PartitionedDmlResult> ExecutePartitionedDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
       std::int64_t seqno, ExecutePartitionedDmlParams epdp);
 
-  /// Implementation details for PartitionQuery
-  StatusOr<std::vector<QueryPartition>> PartitionQuery(
+  StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
       ExecuteSqlParams const& esp, PartitionOptions partition_options);
 
-  /// Implementation details for ExecuteBatchDml
-  StatusOr<BatchDmlResult> ExecuteBatchDml(
+  StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
       std::int64_t seqno, BatchDmlParams params);
 
-  /// Implementation details for Commit.
-  StatusOr<CommitResult> Commit(SessionHolder& session,
-                                google::spanner::v1::TransactionSelector& s,
-                                CommitParams cp);
+  StatusOr<CommitResult> CommitImpl(SessionHolder& session,
+                                    google::spanner::v1::TransactionSelector& s,
+                                    CommitParams cp);
 
-  /// Implementation details for Rollback.
-  Status Rollback(SessionHolder& session,
-                  google::spanner::v1::TransactionSelector& s);
+  Status RollbackImpl(SessionHolder& session,
+                      google::spanner::v1::TransactionSelector& s);
+
+  StatusOr<SessionHolder> GetSession(bool release = false);
+  void ReleaseSession(std::string session);
 
   Database db_;
   std::shared_ptr<internal::SpannerStub> stub_;


### PR DESCRIPTION
This is a small cleanup with no behavioral change. The changes are:

1. The non-virtual methods that are called from Visit are now named like *FooImpl*, to distinguish them from the overridden virtual *Foo* function. I did this because it makes it easier to navigate between the two functions (via text search), and overloading virtual and non-virtual functions is weird on its own.

2. Removed the doxygen comments from the private functions because they seemed redundant and unnecessary.

3. Made the `override` declarations in the .h file consistent in whether they declare the parameter name or not. I chose to remove them, but I don't feel strongly about naming them all either. (If we do name them, I'd vote to name them all `params`.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/537)
<!-- Reviewable:end -->
