### PR TITLE
feat: implement user-agent string for admin stubs.

### DIFF
--- a/google/cloud/spanner/internal/database_admin_stub.cc
+++ b/google/cloud/spanner/internal/database_admin_stub.cc
@@ -103,7 +103,9 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
 
 std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
     ConnectionOptions const& options) {
-  auto channel = grpc::CreateChannel(options.endpoint(), options.credentials());
+  auto channel =
+      grpc::CreateCustomChannel(options.endpoint(), options.credentials(),
+                                options.CreateChannelArguments());
   auto spanner_grpc_stub = gcsa::DatabaseAdmin::NewStub(channel);
   auto longrunning_grpc_stub =
       google::longrunning::Operations::NewStub(channel);

--- a/google/cloud/spanner/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/internal/instance_admin_stub.cc
@@ -54,7 +54,9 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
 
 std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
     ConnectionOptions const& options) {
-  auto channel = grpc::CreateChannel(options.endpoint(), options.credentials());
+  auto channel =
+      grpc::CreateCustomChannel(options.endpoint(), options.credentials(),
+                                options.CreateChannelArguments());
   auto spanner_grpc_stub = gcsa::InstanceAdmin::NewStub(channel);
   auto longrunning_grpc_stub =
       google::longrunning::Operations::NewStub(channel);


### PR DESCRIPTION
This fixes #224.  Unfortunately I do not know of any way to write a unit or integration test for this, the state of the `grpc::Channel` or a gRPC-generated `FooStub` are not accessible in any way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/538)
<!-- Reviewable:end -->
