### PR TITLE
chore: mitigate flakiness in integration tests.

### DIFF
--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -20,6 +20,7 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
 
 [cc_test(
     name = "spanner_client_" + test.replace("/", "_").replace(".cc", ""),
+    timeout = "long",
     srcs = [test],
     tags = ["integration-tests"],
     deps = [


### PR DESCRIPTION
The CI builds that run integration tests sometime fail with a timeout.
The default timeout is 300s, this changes that timeout to 900s. Some of
the tests take about 90s to run (average, observed max is about 120s),
so 10x seems like a safe margin.

This is part of the work for #329, I do not believe it fixes it, but probably
makes it so unlikely that we won't care anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/542)
<!-- Reviewable:end -->
