### PR TITLE
bug: on Windows run integration tests serially

### DIFF
--- a/ci/kokoro/windows/bazel/build.bat
+++ b/ci/kokoro/windows/bazel/build.bat
@@ -57,6 +57,7 @@ del t:\bazel-info.txt
 
 echo %date% %time%
 bazel --output_user_root=C:\b test ^
+  --jobs=1 ^
   --keep_going ^
   --test_output=errors ^
   --verbose_failures=true ^


### PR DESCRIPTION
To workaround grpc/grpc#16872 we must run the integration tests serially
on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/578)
<!-- Reviewable:end -->
