### PR TITLE
cleanup: remove ill-thought option.

### DIFF
--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/internal/compiler_info.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/log.h"
 #include <sstream>
 
 namespace google {
@@ -43,9 +44,11 @@ ConnectionOptions::ConnectionOptions(
       tracing_components_.insert(token);
     }
   }
-  clog_enabled_ =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_ENABLE_CLOG")
-          .has_value();
+
+  if (google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_ENABLE_CLOG")
+          .has_value()) {
+    google::cloud::LogSink::EnableStdClog();
+  }
 }
 
 ConnectionOptions::ConnectionOptions()

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -48,36 +48,12 @@ TEST(ConnectionOptionsTest, AdminEndpoint) {
   EXPECT_EQ("invalid-endpoint", options.endpoint());
 }
 
-TEST(ConnectionOptionsTest, Clog) {
-  ConnectionOptions options(grpc::InsecureChannelCredentials());
-  options.enable_clog();
-  EXPECT_TRUE(options.clog_enabled());
-  options.disable_clog();
-  EXPECT_FALSE(options.clog_enabled());
-}
-
 TEST(ConnectionOptionsTest, Tracing) {
   ConnectionOptions options(grpc::InsecureChannelCredentials());
   options.enable_tracing("fake-component");
   EXPECT_TRUE(options.tracing_enabled("fake-component"));
   options.disable_tracing("fake-component");
   EXPECT_FALSE(options.tracing_enabled("fake-component"));
-}
-
-TEST(ConnectionOptionsTest, DefaultClogUnset) {
-  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_ENABLE_CLOG");
-
-  google::cloud::internal::UnsetEnv("GOOGLE_CLOUD_CPP_ENABLE_CLOG");
-  ConnectionOptions options(grpc::InsecureChannelCredentials());
-  EXPECT_FALSE(options.clog_enabled());
-}
-
-TEST(ConnectionOptionsTest, DefaultClogSet) {
-  EnvironmentVariableRestore restore("GOOGLE_CLOUD_CPP_ENABLE_CLOG");
-
-  google::cloud::internal::SetEnv("GOOGLE_CLOUD_CPP_ENABLE_CLOG", "true");
-  ConnectionOptions options(grpc::InsecureChannelCredentials());
-  EXPECT_TRUE(options.clog_enabled());
 }
 
 TEST(ConnectionOptionsTest, DefaultTracingUnset) {

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -242,10 +242,6 @@ StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionRead(
 
 std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(
     ConnectionOptions const& options) {
-  if (options.clog_enabled()) {
-    google::cloud::LogSink::EnableStdClog();
-  }
-
   grpc::ChannelArguments channel_arguments = options.CreateChannelArguments();
 
   auto spanner_grpc_stub =


### PR DESCRIPTION
I did not think the `ConnectionOptions::clog_enabled()` option really
well. When I documented the other options I realized that this was out
of place.  Removed for now.

I did update the documentation of the other options too.

Fixes #561

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/579)
<!-- Reviewable:end -->
