### PR TITLE
chore: run integration tests in random instance.

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -242,6 +242,8 @@ function (spanner_client_define_tests)
                 testing/mock_database_admin_stub.h
                 testing/mock_instance_admin_stub.h
                 testing/mock_spanner_stub.h
+                testing/pick_random_instance.cc
+                testing/pick_random_instance.h
                 testing/random_database_name.cc
                 testing/random_database_name.h
                 testing/validate_metadata.cc

--- a/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/mutations.h"
+#include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/make_unique.h"
@@ -36,16 +37,16 @@ class RpcFailureThresholdTest : public ::testing::Test {
     auto project_id =
         google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
     ASSERT_FALSE(project_id.empty());
-    auto instance_id =
-        google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_INSTANCE")
-            .value_or("");
-    ASSERT_FALSE(instance_id.empty());
 
     generator_ = google::cloud::internal::MakeDefaultPRNG();
+    auto instance_id =
+        spanner_testing::PickRandomInstance(generator_, project_id);
+    ASSERT_STATUS_OK(instance_id);
+
     auto database_id = spanner_testing::RandomDatabaseName(generator_);
 
     db_ = google::cloud::internal::make_unique<Database>(
-        project_id, instance_id, database_id);
+        project_id, *instance_id, database_id);
 
     std::cout << "Creating database [" << database_id << "] and table "
               << std::flush;

--- a/google/cloud/spanner/samples/BUILD
+++ b/google/cloud/spanner/samples/BUILD
@@ -26,6 +26,9 @@ load(":spanner_client_samples.bzl", "spanner_client_samples")
     tags = ["integration-tests"],
     deps = [
         "//google/cloud/spanner:spanner_client",
+        "//google/cloud/spanner:spanner_client_testing",
         "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+        "@com_google_googletest//:gtest",
     ],
 ) for test in spanner_client_samples]

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -45,16 +45,6 @@ function (spanner_client_define_samples)
         google_cloud_cpp_add_clang_tidy(${target})
         google_cloud_cpp_add_common_options(${target})
         add_test(NAME ${target} COMMAND ${target})
-    endforeach ()
-
-    foreach (fname ${spanner_client_integration_samples})
-        google_cloud_cpp_test_name_to_target(target "${fname}")
-        target_link_libraries(${target} PRIVATE googleapis-c++::spanner_client)
-        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
-    endforeach ()
-
-    foreach (fname ${spanner_client_unit_samples})
-        google_cloud_cpp_test_name_to_target(target "${fname}")
         target_link_libraries(${target}
                               PRIVATE googleapis-c++::spanner_client
                                       spanner_client_testing
@@ -62,7 +52,11 @@ function (spanner_client_define_samples)
                                       GTest::gmock_main
                                       GTest::gmock
                                       GTest::gtest)
+    endforeach ()
 
+    foreach (fname ${spanner_client_integration_samples})
+        google_cloud_cpp_test_name_to_target(target "${fname}")
+        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -22,12 +22,14 @@ spanner_client_testing_hdrs = [
     "testing/mock_database_admin_stub.h",
     "testing/mock_instance_admin_stub.h",
     "testing/mock_spanner_stub.h",
+    "testing/pick_random_instance.h",
     "testing/random_database_name.h",
     "testing/validate_metadata.h",
 ]
 
 spanner_client_testing_srcs = [
     "testing/database_environment.cc",
+    "testing/pick_random_instance.cc",
     "testing/random_database_name.cc",
     "testing/validate_metadata.cc",
 ]

--- a/google/cloud/spanner/testing/pick_random_instance.cc
+++ b/google/cloud/spanner/testing/pick_random_instance.cc
@@ -1,0 +1,52 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/testing/pick_random_instance.h"
+#include "google/cloud/spanner/instance_admin_client.h"
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+StatusOr<std::string> PickRandomInstance(
+    google::cloud::internal::DefaultPRNG& generator,
+    std::string const& project_id) {
+  spanner::InstanceAdminClient client(spanner::MakeInstanceAdminConnection());
+
+  std::vector<std::string> instance_ids;
+  for (auto instance : client.ListInstances(project_id, "")) {
+    if (!instance) return std::move(instance).status();
+    auto name = instance->name();
+    std::string const sep = "/instances/";
+    auto pos = name.rfind(sep);
+    if (pos == std::string::npos) {
+      return Status(StatusCode::kInternal, "Invalid instance name " + name);
+    }
+
+    instance_ids.push_back(name.substr(pos + sep.size()));
+  }
+
+  if (instance_ids.empty()) {
+    return Status(StatusCode::kInternal, "No available instances for test");
+  }
+
+  auto random_index =
+      std::uniform_int_distribution<std::size_t>(0, instance_ids.size() - 1);
+  return instance_ids[random_index(generator)];
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/testing/pick_random_instance.h
+++ b/google/cloud/spanner/testing/pick_random_instance.h
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_PICK_RANDOM_INSTANCE_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_PICK_RANDOM_INSTANCE_H_
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/status_or.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+/// Select one of the instances in @p project_id to run the tests on.
+StatusOr<std::string> PickRandomInstance(
+    google::cloud::internal::DefaultPRNG& generator,
+    std::string const& project_id);
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_PICK_RANDOM_INSTANCE_H_


### PR DESCRIPTION
The CI builds run in parallel, and we have about 10 builds that run the
integration tests. Inside each build the integration tests themselves
run in parallel, and about 4 of them create new databases. That is about
40 databases created more or less simultaneously. Meanwhile, the maximum
number of databases per instance is 100, so 3 pull requests at the same
time can exceed the limit.

With this change each integration test queries the list of instances for
the project, and then selects one of them at random to run the test. We
will configure several instances in the project used to run the CI
builds, giving us enough bandwidth to run multiple PRs simultaneously.

This is another mitigation for #329

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/585)
<!-- Reviewable:end -->
