### PR TITLE
test: Fix integration tests on Windows CMake builds

### DIFF
--- a/ci/kokoro/windows/CMakeLists.txt
+++ b/ci/kokoro/windows/CMakeLists.txt
@@ -21,7 +21,8 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(GOOGLE_CLOUD_CPP_SPANNER_ROOT "${PROJECT_SOURCE_DIR}/../../..")
-list(APPEND CMAKE_MODULE_PATH "${GOOGLE_CLOUD_CPP_SPANNER_ROOT}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${GOOGLE_CLOUD_CPP_SPANNER_ROOT}/cmake"
+            "${GOOGLE_CLOUD_CPP_SPANNER_ROOT}/ci/super")
 
 include(external/external-project-helpers)
 google_cloud_cpp_set_prefix_vars()

--- a/ci/kokoro/windows/build-project.ps1
+++ b/ci/kokoro/windows/build-project.ps1
@@ -17,13 +17,6 @@
 $ErrorActionPreference = "Stop"
 
 Write-Host "================================================================"
-Write-Host "Install Pscx module for current user $(Get-Date -Format o)."
-Install-Module Pscx -Force -AllowClobber -Scope CurrentUser
-if ($LastExitCode) {
-    throw "Error installing Pscx module $LastExitCode"
-}
-
-Write-Host "================================================================"
 Write-Host "Run CMake to create build scripts $(Get-Date -Format o)."
 
 # This script expects vcpkg to be installed in ..\vcpkg, discover the full

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -23,7 +23,7 @@ echo %date% %time%
 cmd /c gcloud auth activate-service-account --key-file "%KOKORO_GFILE_DIR%/build-results-service-account.json"
 
 call "%KOKORO_GFILE_DIR%/spanner-integration-tests-config.bat"
-set GOOGLE_APPLICATION_CREDENTIALS="%KOKORO_GFILE_DIR%/spanner-credentials.json"
+set GOOGLE_APPLICATION_CREDENTIALS=%KOKORO_GFILE_DIR%\spanner-credentials.json
 set GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=T:\src\github\vcpkg\packages\grpc_x64-windows-static\share\grpc\roots.pem
 

--- a/ci/kokoro/windows/common.cfg
+++ b/ci/kokoro/windows/common.cfg
@@ -24,3 +24,8 @@ env_vars {
   key: "BUILD_CACHE"
   value: "gs://cloud-cpp-kokoro-results/build-artifacts/spanner-vcpkg-installed.zip"
 }
+
+env_vars {
+  key: "RUN_INTEGRATION_TESTS"
+  value: "true"
+}


### PR DESCRIPTION
Also enable integration tests by default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/604)
<!-- Reviewable:end -->
