### PR TITLE
chore: upgrade google-cloud-cpp and googleapis

### DIFF
--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -31,11 +31,11 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_googleapis_google_cloud_cpp" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp",
-            strip_prefix = "google-cloud-cpp-7c4f218dbd9e1fbe08bc7187347d4da80198ec0a",
+            strip_prefix = "google-cloud-cpp-0.13.0",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp/archive/7c4f218dbd9e1fbe08bc7187347d4da80198ec0a.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz",
             ],
-            sha256 = "a0a0c46afb099d9c36f142ca812d8ef0e15b5ce6a0373fb7cb923683c56256dc",
+            sha256 = "35058ff14e4f9f49f78da2f1bbf1c03f27e8e40ec65c51f62720346e99803392",
         )
 
     # Load a newer version of google test than what gRPC does.

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -64,9 +64,9 @@ RUN cmake --build cmake-out/gtest --target install -- -j $(nproc)
 # Download and compile googleapis/cpp-cmakefiles:
 
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.4.tar.gz
-RUN tar -xf v0.1.4.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.4
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \
@@ -78,9 +78,9 @@ RUN cmake --build cmake-out --target install
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/7c4f218dbd9e1fbe08bc7187347d4da80198ec0a.tar.gz
-RUN tar -xf 7c4f218dbd9e1fbe08bc7187347d4da80198ec0a.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-7c4f218dbd9e1fbe08bc7187347d4da80198ec0a
+RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz
+RUN tar -xf v0.13.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-0.13.0
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -50,9 +50,9 @@ RUN cmake --build cmake-out/gtest --target install -- -j $(nproc)
 # Download and compile googleapis/cpp-cmakefiles:
 
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.4.tar.gz
-RUN tar -xf v0.1.4.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.4
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz
+RUN tar -xf v0.1.5.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.1.5
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \
@@ -64,9 +64,9 @@ RUN cmake --build cmake-out --target install
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/7c4f218dbd9e1fbe08bc7187347d4da80198ec0a.tar.gz
-RUN tar -xf 7c4f218dbd9e1fbe08bc7187347d4da80198ec0a.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-7c4f218dbd9e1fbe08bc7187347d4da80198ec0a
+RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz
+RUN tar -xf v0.13.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-0.13.0
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/windows/CMakeLists.txt
+++ b/ci/kokoro/windows/CMakeLists.txt
@@ -27,12 +27,9 @@ include(external/external-project-helpers)
 google_cloud_cpp_set_prefix_vars()
 
 include(ExternalProject)
-set(
-    GOOGLE_CLOUD_CPP_URL
-    "https://github.com/googleapis/google-cloud-cpp/archive/84772e182e5a82c9f839a9073cef88b9962c48cf.tar.gz"
-    )
+set(GOOGLE_CLOUD_CPP_URL "https://github.com/googleapis/archive/v0.13.0.tar.gz")
 set(GOOGLE_CLOUD_CPP_SHA256
-    "3bdf9266cd16c935f2c62bf6d151df8a15a307d612e966be0f340398785b9d31")
+    "35058ff14e4f9f49f78da2f1bbf1c03f27e8e40ec65c51f62720346e99803392")
 google_cloud_cpp_set_prefix_vars()
 
 ExternalProject_Add(

--- a/ci/super/external/google-cloud-cpp.cmake
+++ b/ci/super/external/google-cloud-cpp.cmake
@@ -20,16 +20,15 @@ include(external/curl)
 include(external/crc32c)
 include(external/grpc)
 include(external/googleapis)
+include(external/googletest)
 
 if (NOT TARGET google-cloud-cpp-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
-    set(
-        GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp/archive/7c4f218dbd9e1fbe08bc7187347d4da80198ec0a.tar.gz"
-        )
+    set(GOOGLE_CLOUD_CPP_URL
+        "https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz")
     set(GOOGLE_CLOUD_CPP_SHA256
-        "a0a0c46afb099d9c36f142ca812d8ef0e15b5ce6a0373fb7cb923683c56256dc")
+        "35058ff14e4f9f49f78da2f1bbf1c03f27e8e40ec65c51f62720346e99803392")
 
     google_cloud_cpp_set_prefix_vars()
 
@@ -38,6 +37,7 @@ if (NOT TARGET google-cloud-cpp-project)
     ExternalProject_Add(
         google-cloud-cpp-project
         DEPENDS googleapis-project
+                googletest-project
                 grpc-project
                 curl-project
                 crc32c-project

--- a/ci/super/external/googleapis.cmake
+++ b/ci/super/external/googleapis.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET googleapis-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
-        "https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.4.tar.gz")
+        "https://github.com/googleapis/cpp-cmakefiles/archive/v0.1.5.tar.gz")
     set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
-        "53266f7d30852ead4bf375d9244fa67fd41eb6adadc511e9a2a3de47f3b68d49")
+        "f1443a10c545114b19fe9dc352568cb03b588813b12cc5db8780b64ae9a09ce1")
 
     google_cloud_cpp_set_prefix_vars()
 


### PR DESCRIPTION
Upgrade googleapis to 0.1.5 and google-cloud-cpp to 0.13.0. Those versions
support CMake 3.15, which is starting to appear in more places (e.g. my
macOS laptop :grin: )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/605)
<!-- Reviewable:end -->
