### PR TITLE
doc: Remove spurious quote in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ this library for experimental code, nor for production workloads.
 [windows/cmake-shield]: https://storage.googleapis.com/cloud-cpp-kokoro-status/spanner-windows-cmake.svg
 [windows/cmake-link]:   https://storage.googleapis.com/cloud-cpp-kokoro-status/spanner-windows-cmake-link.html
 
-<!-- End of automatically generated content -->"
+<!-- End of automatically generated content -->
 
 ## Documentation
 

--- a/ci/generate-badges.sh
+++ b/ci/generate-badges.sh
@@ -78,7 +78,7 @@ cat <<'_EOF_'
 [windows/cmake-shield]: https://storage.googleapis.com/cloud-cpp-kokoro-status/spanner-windows-cmake.svg
 [windows/cmake-link]:   https://storage.googleapis.com/cloud-cpp-kokoro-status/spanner-windows-cmake-link.html
 
-<!-- End of automatically generated content -->"
+<!-- End of automatically generated content -->
 _EOF_
 
 exit 0


### PR DESCRIPTION
I made a mistake in the script, it generated an extra quote character.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/611)
<!-- Reviewable:end -->
