### PR TITLE
Fix integration tests on Windows CMake builds.

### DIFF
--- a/ci/kokoro/windows/build-project.ps1
+++ b/ci/kokoro/windows/build-project.ps1
@@ -53,7 +53,7 @@ if ($LastExitCode) {
     throw "cmake failed with exit code $LastExitCode"
 }
 
-if (Test-Path env:RUN_INTEGRATION_TESTS ) {
+if ($env:RUN_INTEGRATION_TESTS -eq "true") {
   Write-Host "================================================================"
   Write-Host "Run integration tests $(Get-Date -Format o)."
   cd cmake-out\w\build\g-c-spanner\src\g-c-spanner-build

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -25,7 +25,7 @@ cmd /c gcloud auth activate-service-account --key-file "%KOKORO_GFILE_DIR%/build
 call "%KOKORO_GFILE_DIR%/spanner-integration-tests-config.bat"
 set GOOGLE_APPLICATION_CREDENTIALS=%KOKORO_GFILE_DIR%\spanner-credentials.json
 set GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
-set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=T:\src\github\vcpkg\packages\grpc_x64-windows-static\share\grpc\roots.pem
+set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=T:\src\github\vcpkg\installed\x64-windows-static\share\grpc\roots.pem
 
 echo %date% %time%
 powershell -exec bypass ci\kokoro\windows\build-dependencies.ps1

--- a/ci/kokoro/windows/common.cfg
+++ b/ci/kokoro/windows/common.cfg
@@ -24,3 +24,8 @@ env_vars {
   key: "BUILD_CACHE"
   value: "gs://cloud-cpp-kokoro-results/build-artifacts/spanner-vcpkg-installed.zip"
 }
+
+env_vars {
+  key: "RUN_INTEGRATION_TESTS"
+  value: "true"
+}


### PR DESCRIPTION
Also enable the integration tests by default

Fixes #601 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/615)
<!-- Reviewable:end -->
