### PR TITLE
bug: create new grpc::ClientContext for each RPC

### DIFF
--- a/google/cloud/spanner/internal/database_admin_retry.cc
+++ b/google/cloud/spanner/internal/database_admin_retry.cc
@@ -96,36 +96,36 @@ DatabaseAdminRetry::DatabaseAdminRetry(PrivateConstructorTag,
 namespace gcsa = google::spanner::admin::database::v1;
 
 StatusOr<google::longrunning::Operation> DatabaseAdminRetry::CreateDatabase(
-    grpc::ClientContext& context, gcsa::CreateDatabaseRequest const& request) {
+    grpc::ClientContext&, gcsa::CreateDatabaseRequest const& request) {
   return RetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(), false,
       [this](grpc::ClientContext& context,
              gcsa::CreateDatabaseRequest const& request) {
         return child_->CreateDatabase(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 StatusOr<gcsa::Database> DatabaseAdminRetry::GetDatabase(
-    grpc::ClientContext& context, gcsa::GetDatabaseRequest const& request) {
+    grpc::ClientContext&, gcsa::GetDatabaseRequest const& request) {
   return RetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(), true,
       [this](grpc::ClientContext& context,
              gcsa::GetDatabaseRequest const& request) {
         return child_->GetDatabase(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 StatusOr<gcsa::GetDatabaseDdlResponse> DatabaseAdminRetry::GetDatabaseDdl(
-    grpc::ClientContext& context, gcsa::GetDatabaseDdlRequest const& request) {
+    grpc::ClientContext&, gcsa::GetDatabaseDdlRequest const& request) {
   return RetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(), true,
       [this](grpc::ClientContext& context,
              gcsa::GetDatabaseDdlRequest const& request) {
         return child_->GetDatabaseDdl(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 future<StatusOr<gcsa::Database>> DatabaseAdminRetry::AwaitCreateDatabase(
@@ -166,7 +166,7 @@ future<StatusOr<gcsa::Database>> DatabaseAdminRetry::AwaitCreateDatabase(
 }
 
 StatusOr<google::longrunning::Operation> DatabaseAdminRetry::UpdateDatabase(
-    grpc::ClientContext& context,
+    grpc::ClientContext&,
     google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
         request) {
   return RetryLoop(
@@ -175,7 +175,7 @@ StatusOr<google::longrunning::Operation> DatabaseAdminRetry::UpdateDatabase(
              gcsa::UpdateDatabaseDdlRequest const& request) {
         return child_->UpdateDatabase(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 future<StatusOr<gcsa::UpdateDatabaseDdlMetadata>>
@@ -219,7 +219,7 @@ DatabaseAdminRetry::AwaitUpdateDatabase(
 }
 
 Status DatabaseAdminRetry::DropDatabase(
-    grpc::ClientContext& context,
+    grpc::ClientContext&,
     google::spanner::admin::database::v1::DropDatabaseRequest const& request) {
   return RetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(), true,
@@ -227,18 +227,18 @@ Status DatabaseAdminRetry::DropDatabase(
              gcsa::DropDatabaseRequest const& request) {
         return child_->DropDatabase(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 StatusOr<gcsa::ListDatabasesResponse> DatabaseAdminRetry::ListDatabases(
-    grpc::ClientContext& context, gcsa::ListDatabasesRequest const& request) {
+    grpc::ClientContext&, gcsa::ListDatabasesRequest const& request) {
   return RetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(), true,
       [this](grpc::ClientContext& context,
              gcsa::ListDatabasesRequest const& request) {
         return child_->ListDatabases(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 StatusOr<google::longrunning::Operation> DatabaseAdminRetry::GetOperation(

--- a/google/cloud/spanner/internal/database_admin_retry.h
+++ b/google/cloud/spanner/internal/database_admin_retry.h
@@ -27,6 +27,9 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 /**
  * Implements the retry Decorator for DatabaseAdminStub.
+ *
+ * @note All retry decorators ignore the `grpc::ClientContext` parameter, and
+ *     create a new context for each child request.
  */
 class DatabaseAdminRetry : public DatabaseAdminStub {
  public:
@@ -47,7 +50,7 @@ class DatabaseAdminRetry : public DatabaseAdminStub {
    */
   ///
   StatusOr<google::longrunning::Operation> CreateDatabase(
-      grpc::ClientContext& context,
+      grpc::ClientContext& /*unused*/,
       google::spanner::admin::database::v1::CreateDatabaseRequest const&
           request) override;
 
@@ -55,17 +58,17 @@ class DatabaseAdminRetry : public DatabaseAdminStub {
       AwaitCreateDatabase(google::longrunning::Operation) override;
 
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
-      grpc::ClientContext&,
+      grpc::ClientContext& /*unused*/,
       google::spanner::admin::database::v1::GetDatabaseRequest const&) override;
 
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(
-      grpc::ClientContext&,
+      grpc::ClientContext& /*unused*/,
       google::spanner::admin::database::v1::GetDatabaseDdlRequest const&)
       override;
 
   StatusOr<google::longrunning::Operation> UpdateDatabase(
-      grpc::ClientContext& context,
+      grpc::ClientContext& /*unused*/,
       google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
           request) override;
 
@@ -74,18 +77,18 @@ class DatabaseAdminRetry : public DatabaseAdminStub {
   AwaitUpdateDatabase(google::longrunning::Operation operation) override;
 
   Status DropDatabase(
-      grpc::ClientContext& context,
+      grpc::ClientContext& /*unused*/,
       google::spanner::admin::database::v1::DropDatabaseRequest const& request)
       override;
 
   StatusOr<google::spanner::admin::database::v1::ListDatabasesResponse>
   ListDatabases(
-      grpc::ClientContext&,
+      grpc::ClientContext& /*unused*/,
       google::spanner::admin::database::v1::ListDatabasesRequest const&)
       override;
 
   StatusOr<google::longrunning::Operation> GetOperation(
-      grpc::ClientContext& context,
+      grpc::ClientContext& /*unused*/,
       google::longrunning::GetOperationRequest const& request) override;
   //@}
 

--- a/google/cloud/spanner/internal/instance_admin_retry.cc
+++ b/google/cloud/spanner/internal/instance_admin_retry.cc
@@ -64,50 +64,48 @@ namespace gcsa = google::spanner::admin::instance::v1;
 namespace giam = google::iam::v1;
 
 StatusOr<gcsa::Instance> InstanceAdminRetry::GetInstance(
-    grpc::ClientContext& context, gcsa::GetInstanceRequest const& request) {
+    grpc::ClientContext&, gcsa::GetInstanceRequest const& request) {
   return RetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(), true,
       [this](grpc::ClientContext& context,
              gcsa::GetInstanceRequest const& request) {
         return child_->GetInstance(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 StatusOr<gcsa::ListInstancesResponse> InstanceAdminRetry::ListInstances(
-    grpc::ClientContext& context, gcsa::ListInstancesRequest const& request) {
+    grpc::ClientContext&, gcsa::ListInstancesRequest const& request) {
   return RetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(), true,
       [this](grpc::ClientContext& context,
              gcsa::ListInstancesRequest const& request) {
         return child_->ListInstances(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminRetry::GetIamPolicy(
-    grpc::ClientContext& context,
-    google::iam::v1::GetIamPolicyRequest const& request) {
+    grpc::ClientContext&, google::iam::v1::GetIamPolicyRequest const& request) {
   return RetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(), true,
       [this](grpc::ClientContext& context,
              giam::GetIamPolicyRequest const& request) {
         return child_->GetIamPolicy(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 StatusOr<giam::TestIamPermissionsResponse>
 InstanceAdminRetry::TestIamPermissions(
-    grpc::ClientContext& context,
-    giam::TestIamPermissionsRequest const& request) {
+    grpc::ClientContext&, giam::TestIamPermissionsRequest const& request) {
   return RetryLoop(
       retry_policy_->clone(), backoff_policy_->clone(), true,
       [this](grpc::ClientContext& context,
              giam::TestIamPermissionsRequest const& request) {
         return child_->TestIamPermissions(context, request);
       },
-      context, request, __func__);
+      request, __func__);
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/instance_admin_retry.h
+++ b/google/cloud/spanner/internal/instance_admin_retry.h
@@ -27,6 +27,9 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 /**
  * Implements the retry Decorator for InstanceAdminStub.
+ *
+ * @note All retry decorators ignore the `grpc::ClientContext` parameter, and
+ *     create a new context for each child request.
  */
 class InstanceAdminRetry : public InstanceAdminStub {
  public:
@@ -46,19 +49,19 @@ class InstanceAdminRetry : public InstanceAdminStub {
    * Run the retry loop (if appropriate) for the child InstanceAdminStub.
    */
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
-      grpc::ClientContext&,
+      grpc::ClientContext& /*unused*/,
       google::spanner::admin::instance::v1::GetInstanceRequest const&) override;
 
   StatusOr<google::spanner::admin::instance::v1::ListInstancesResponse>
   ListInstances(
-      grpc::ClientContext&,
+      grpc::ClientContext& /*unused*/,
       google::spanner::admin::instance::v1::ListInstancesRequest const&)
       override;
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      grpc::ClientContext&,
+      grpc::ClientContext& /*unused*/,
       google::iam::v1::GetIamPolicyRequest const&) override;
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
-      grpc::ClientContext&,
+      grpc::ClientContext& /*unused*/,
       google::iam::v1::TestIamPermissionsRequest const&) override;
   //@}
 


### PR DESCRIPTION
gRPC requires a newly minted grpc::ClientContext for each RPC, and
without assignment operators (no move, no copy) the only way is to
actually create a new instance in the middle of the loop.

Therefore passing a `grpc::ClientContext` has no effect, and we should
not even have that argument in `RetryLoop()`.

Fixes #490

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/617)
<!-- Reviewable:end -->
