### PR TITLE
feat: implement InstanceAdminClient::SetIamPolicy

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel-dependency.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel-dependency.sh
@@ -67,6 +67,7 @@ if [[ -r "/c/spanner-integration-tests-config.sh" ]]; then
   env "GOOGLE_APPLICATION_CREDENTIALS=/c/spanner-credentials.json" \
       "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}" \
       "GOOGLE_CLOUD_CPP_SPANNER_INSTANCE=${GOOGLE_CLOUD_CPP_SPANNER_INSTANCE}" \
+      "GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA=${GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA}" \
       "${BAZEL_BIN}" run \
       "${bazel_args[@]}" \
       "--spawn_strategy=local" \

--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -85,6 +85,7 @@ if [[ ${RUN_INTEGRATION_TESTS} == "yes" ]]; then
       "--test_env=GOOGLE_APPLICATION_CREDENTIALS=/c/spanner-credentials.json" \
       "--test_env=GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}" \
       "--test_env=GOOGLE_CLOUD_CPP_SPANNER_INSTANCE=${GOOGLE_CLOUD_CPP_SPANNER_INSTANCE}" \
+      "--test_env=GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA=${GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA}" \
       "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
       "--test_tag_filters=integration-tests" \
       -- //google/cloud/...:all

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -86,6 +86,7 @@ if [[ -f "${CONFIG_DIRECTORY}/spanner-integration-tests-config.sh" ]]; then
     "--env" "GOOGLE_APPLICATION_CREDENTIALS=/c/spanner-credentials.json"
     "--env" "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
     "--env" "GOOGLE_CLOUD_CPP_SPANNER_INSTANCE=${GOOGLE_CLOUD_CPP_SPANNER_INSTANCE}"
+    "--env" "GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA=${GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA}"
 
     # Mount the config directory as a volumne in `/c`
     "--volume" "${CONFIG_DIRECTORY}:/c"

--- a/ci/kokoro/macos/build-bazel.sh
+++ b/ci/kokoro/macos/build-bazel.sh
@@ -79,6 +79,7 @@ if [[ ${RUN_INTEGRATION_TESTS} == "yes" ]]; then
       "--test_env=GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
       "--test_env=GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}" \
       "--test_env=GOOGLE_CLOUD_CPP_SPANNER_INSTANCE=${GOOGLE_CLOUD_CPP_SPANNER_INSTANCE}" \
+      "--test_env=GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA=${GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA}" \
       "--test_env=GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes" \
       "--test_tag_filters=integration-tests" \
       -- //google/cloud/...:all

--- a/ci/kokoro/windows/bazel/build.bat
+++ b/ci/kokoro/windows/bazel/build.bat
@@ -65,6 +65,7 @@ bazel --output_user_root=C:\b test ^
   --test_env GOOGLE_APPLICATION_CREDENTIALS=%KOKORO_GFILE_DIR%/spanner-credentials.json ^
   --test_env GOOGLE_CLOUD_PROJECT=%GOOGLE_CLOUD_PROJECT% ^
   --test_env GOOGLE_CLOUD_CPP_SPANNER_INSTANCE=%GOOGLE_CLOUD_CPP_SPANNER_INSTANCE% ^
+  --test_env GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA=%GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA% ^
   --test_env GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes ^
   --test_env GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=%BAZEL_OUTPUT_DIR%/external/com_github_grpc_grpc/etc/roots.pem ^
   -- //google/cloud/spanner/...:all

--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -33,6 +33,11 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
   return conn_->GetIamPolicy({in.FullName()});
 }
 
+StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
+    Instance const& in, google::iam::v1::Policy policy) {
+  return conn_->SetIamPolicy({in.FullName(), std::move(policy)});
+}
+
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 InstanceAdminClient::TestIamPermissions(Instance const& in,
                                         std::vector<std::string> permissions) {

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -136,6 +136,30 @@ class InstanceAdminClient {
   StatusOr<google::iam::v1::Policy> GetIamPolicy(Instance const& in);
 
   /**
+   * Set the IAM policy for the given instance.
+   *
+   * This function changes the IAM policy configured in the given instance to
+   * the value of @p policy.
+   *
+   * @par Idempotency
+   * This function is only idempotent if the `etag` field in @p policy is set.
+   * Therefore, the underlying RPCs are only retried if the field is set, and
+   * the function returns the first RPC error in any other case.
+   *
+   * @par Example
+   * @snippet samples.cc add-database-reader
+   *
+   * @see The [Cloud Spanner
+   *     documentation](https://cloud.google.com/spanner/docs/iam) for a
+   *     description of the roles and permissions supported by Cloud Spanner.
+   * @see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions)
+   *     for an introduction to Identity and Access Management in Google Cloud
+   *     Platform.
+   */
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      Instance const& in, google::iam::v1::Policy policy);
+
+  /**
    * Get the subset of the permissions the caller has on the given instance.
    *
    * This function compares the given list of permissions against those

--- a/google/cloud/spanner/instance_admin_client_test.cc
+++ b/google/cloud/spanner/instance_admin_client_test.cc
@@ -107,6 +107,21 @@ TEST(InstanceAdminClientTest, GetIamPolicy) {
   EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
 }
 
+TEST(InstanceAdminClientTest, SetIamPolicy) {
+  auto mock = std::make_shared<MockInstanceAdminConnection>();
+  EXPECT_CALL(*mock, SetIamPolicy(_))
+      .WillOnce([](InstanceAdminConnection::SetIamPolicyParams const& p) {
+        EXPECT_EQ("projects/test-project/instances/test-instance",
+                  p.instance_name);
+        return Status(StatusCode::kPermissionDenied, "uh-oh");
+      });
+
+  InstanceAdminClient client(mock);
+  auto actual =
+      client.SetIamPolicy(Instance("test-project", "test-instance"), {});
+  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+}
+
 TEST(InstanceAdminClientTest, TestIamPermissions) {
   auto mock = std::make_shared<MockInstanceAdminConnection>();
   EXPECT_CALL(*mock, TestIamPermissions(_))

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -64,6 +64,15 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
     return stub_->GetIamPolicy(context, request);
   }
 
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      SetIamPolicyParams p) override {
+    google::iam::v1::SetIamPolicyRequest request;
+    request.set_resource(std::move(p.instance_name));
+    *request.mutable_policy() = std::move(p.policy);
+    grpc::ClientContext context;
+    return stub_->SetIamPolicy(context, request);
+  }
+
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       TestIamPermissionsParams p) override {
     google::iam::v1::TestIamPermissionsRequest request;

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -100,6 +100,12 @@ class InstanceAdminConnection {
     std::string instance_name;
   };
 
+  /// Wrap the arguments for `SetIamPolicy()`.
+  struct SetIamPolicyParams {
+    std::string instance_name;
+    google::iam::v1::Policy policy;
+  };
+
   /// Wrap the arguments for `TestIamPermissions()`.
   struct TestIamPermissionsParams {
     std::string instance_name;
@@ -121,6 +127,11 @@ class InstanceAdminConnection {
   /// google.spanner.v1.DatabaseAdmin.GetIamPolicy RPC.
   virtual StatusOr<google::iam::v1::Policy> GetIamPolicy(
       GetIamPolicyParams) = 0;
+
+  /// Define the interface for a
+  /// google.spanner.v1.DatabaseAdmin.SetIamPolicy RPC.
+  virtual StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      SetIamPolicyParams) = 0;
 
   /// Define the interface for a
   /// google.spanner.v1.DatabaseAdmin.TestIamPermissions RPC.

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -290,6 +290,7 @@ TEST(InstanceAdminConnectionTest, SetIamPolicy_NonIdempotent) {
 TEST(InstanceAdminConnectionTest, SetIamPolicy_Idempotent) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
   EXPECT_CALL(*mock, SetIamPolicy(_, _))
+      .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
   auto conn = MakeTestConnection(mock);

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -222,6 +222,82 @@ TEST(InstanceAdminConnectionTest, GetIamPolicy_TooManyTransients) {
   EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
 }
 
+TEST(InstanceAdminConnectionTest, SetIamPolicy_Success) {
+  std::string const expected_name =
+      "projects/test-project/instances/test-instance";
+
+  giam::Policy expected_policy;
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        etag: "request-etag"
+        bindings {
+          role: "roles/spanner.databaseReader"
+          members: "user:test-user-1@example.com"
+          members: "user:test-user-2@example.com"
+        }
+      )pb",
+      &expected_policy));
+
+  auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
+  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+      .WillOnce(
+          Invoke([&expected_name](grpc::ClientContext&,
+                                  giam::SetIamPolicyRequest const& request) {
+            EXPECT_EQ(expected_name, request.resource());
+            return Status(StatusCode::kUnavailable, "try-again");
+          }))
+      .WillOnce(Invoke(
+          [&expected_name, &expected_policy](
+              grpc::ClientContext&, giam::SetIamPolicyRequest const& request) {
+            EXPECT_EQ(expected_name, request.resource());
+            EXPECT_THAT(request.policy(), IsProtoEqual(expected_policy));
+            giam::Policy response = expected_policy;
+            response.set_etag("response-etag");
+            return response;
+          }));
+
+  auto conn = MakeTestConnection(mock);
+  auto actual = conn->SetIamPolicy({expected_name, expected_policy});
+  ASSERT_STATUS_OK(actual);
+  expected_policy.set_etag("response-etag");
+  EXPECT_THAT(*actual, IsProtoEqual(expected_policy));
+}
+
+TEST(InstanceAdminConnectionTest, SetIamPolicy_PermanentFailure) {
+  auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
+  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+      .WillOnce(Return(Status(StatusCode::kPermissionDenied, "uh-oh")));
+
+  auto conn = MakeTestConnection(mock);
+  auto actual = conn->SetIamPolicy({"test-instance-name", {}});
+  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+}
+
+TEST(InstanceAdminConnectionTest, SetIamPolicy_NonIdempotent) {
+  auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
+  // If the Etag field is not set, then the RPC is not idempotent and should
+  // fail on the first transient error.
+  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+      .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")));
+
+  auto conn = MakeTestConnection(mock);
+  google::iam::v1::Policy policy;
+  auto actual = conn->SetIamPolicy({"test-instance-name", policy});
+  EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+}
+
+TEST(InstanceAdminConnectionTest, SetIamPolicy_Idempotent) {
+  auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
+  EXPECT_CALL(*mock, SetIamPolicy(_, _))
+      .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
+
+  auto conn = MakeTestConnection(mock);
+  google::iam::v1::Policy policy;
+  policy.set_etag("test-etag-value");
+  auto actual = conn->SetIamPolicy({"test-instance-name", policy});
+  EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+}
+
 TEST(InstanceAdminConnectionTest, TestIamPermissions_Success) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance";

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -28,6 +28,7 @@ namespace {
 using ::google::cloud::spanner_testing::IsProtoEqual;
 using ::google::protobuf::TextFormat;
 using ::testing::_;
+using ::testing::AtLeast;
 using ::testing::Invoke;
 using ::testing::Return;
 
@@ -341,6 +342,7 @@ TEST(InstanceAdminConnectionTest, TestIamPermissions_PermanentFailure) {
 TEST(InstanceAdminConnectionTest, TestIamPermissions_TooManyTransients) {
   auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
   EXPECT_CALL(*mock, TestIamPermissions(_, _))
+      .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
 
   auto conn = MakeTestConnection(mock);

--- a/google/cloud/spanner/integration_tests/README.md
+++ b/google/cloud/spanner/integration_tests/README.md
@@ -20,3 +20,10 @@ configured via the `GOOGLE_CLOUD_PROJECT` environment variable.
 The `GOOGLE_CLOUD_CPP_SPANNER_INSTANCE` environment variable must be the id of a
 Cloud Spanner instance in the project. This instance is used by most tests, as
 it saves them from creating a new instance for just a few operations.
+
+## Test Service Account
+
+The `GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA` environment variable must be the id
+of a Google Cloud Platform service account in the project. This service account
+is used to test IAM operations, the account is added to and removed from
+standard spanner roles.

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -65,8 +65,12 @@ TEST(InstanceAdminClient, InstanceIam) {
   auto instance_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_INSTANCE")
           .value_or("");
+  auto test_iam_service_account =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA")
+          .value_or("");
   ASSERT_FALSE(project_id.empty());
   ASSERT_FALSE(instance_id.empty());
+  ASSERT_FALSE(test_iam_service_account.empty());
 
   Instance in(project_id, instance_id);
 
@@ -74,6 +78,12 @@ TEST(InstanceAdminClient, InstanceIam) {
 
   auto actual_policy = client.GetIamPolicy(in);
   ASSERT_STATUS_OK(actual_policy);
+  EXPECT_FALSE(actual_policy->etag().empty());
+
+  // Set the policy to the existing value of the policy. While this changes
+  // nothing it tests all the code in the client library.
+  auto updated_policy = client.SetIamPolicy(in, *actual_policy);
+  ASSERT_STATUS_OK(updated_policy);
   EXPECT_FALSE(actual_policy->etag().empty());
 
   auto actual = client.TestIamPermissions(

--- a/google/cloud/spanner/internal/instance_admin_retry.cc
+++ b/google/cloud/spanner/internal/instance_admin_retry.cc
@@ -96,6 +96,18 @@ StatusOr<google::iam::v1::Policy> InstanceAdminRetry::GetIamPolicy(
       request, __func__);
 }
 
+StatusOr<google::iam::v1::Policy> InstanceAdminRetry::SetIamPolicy(
+    grpc::ClientContext&, google::iam::v1::SetIamPolicyRequest const& request) {
+  bool is_idempotent = !request.policy().etag().empty();
+  return RetryLoop(
+      retry_policy_->clone(), backoff_policy_->clone(), is_idempotent,
+      [this](grpc::ClientContext& context,
+             giam::SetIamPolicyRequest const& request) {
+        return child_->SetIamPolicy(context, request);
+      },
+      request, __func__);
+}
+
 StatusOr<giam::TestIamPermissionsResponse>
 InstanceAdminRetry::TestIamPermissions(
     grpc::ClientContext&, giam::TestIamPermissionsRequest const& request) {

--- a/google/cloud/spanner/internal/instance_admin_retry.h
+++ b/google/cloud/spanner/internal/instance_admin_retry.h
@@ -60,6 +60,9 @@ class InstanceAdminRetry : public InstanceAdminStub {
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext& /*unused*/,
       google::iam::v1::GetIamPolicyRequest const&) override;
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      grpc::ClientContext&,
+      google::iam::v1::SetIamPolicyRequest const&) override;
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       grpc::ClientContext& /*unused*/,
       google::iam::v1::TestIamPermissionsRequest const&) override;

--- a/google/cloud/spanner/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/internal/instance_admin_stub.cc
@@ -70,6 +70,17 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
     return response;
   }
 
+  StatusOr<giam::Policy> SetIamPolicy(
+      grpc::ClientContext& context,
+      giam::SetIamPolicyRequest const& request) override {
+    giam::Policy response;
+    auto status = instance_admin_->SetIamPolicy(&context, request, &response);
+    if (!status.ok()) {
+      return grpc_utils::MakeStatusFromRpcError(status);
+    }
+    return response;
+  }
+
   StatusOr<giam::TestIamPermissionsResponse> TestIamPermissions(
       grpc::ClientContext& context,
       giam::TestIamPermissionsRequest const& request) override {

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -43,6 +43,9 @@ class InstanceAdminStub {
   virtual StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext&, google::iam::v1::GetIamPolicyRequest const&) = 0;
 
+  virtual StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      grpc::ClientContext&, google::iam::v1::SetIamPolicyRequest const&) = 0;
+
   virtual StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(grpc::ClientContext&,
                      google::iam::v1::TestIamPermissionsRequest const&) = 0;

--- a/google/cloud/spanner/mocks/mock_instance_admin_connection.h
+++ b/google/cloud/spanner/mocks/mock_instance_admin_connection.h
@@ -39,6 +39,8 @@ class MockInstanceAdminConnection
   MOCK_METHOD1(ListInstances, spanner::ListInstancesRange(ListInstancesParams));
   MOCK_METHOD1(GetIamPolicy,
                StatusOr<google::iam::v1::Policy>(GetIamPolicyParams));
+  MOCK_METHOD1(SetIamPolicy,
+               StatusOr<google::iam::v1::Policy>(SetIamPolicyParams));
   MOCK_METHOD1(TestIamPermissions,
                StatusOr<google::iam::v1::TestIamPermissionsResponse>(
                    TestIamPermissionsParams));

--- a/google/cloud/spanner/testing/mock_instance_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_instance_admin_stub.h
@@ -38,6 +38,9 @@ class MockInstanceAdminStub
   MOCK_METHOD2(GetIamPolicy, StatusOr<google::iam::v1::Policy>(
                                  grpc::ClientContext&,
                                  google::iam::v1::GetIamPolicyRequest const&));
+  MOCK_METHOD2(SetIamPolicy, StatusOr<google::iam::v1::Policy>(
+                                 grpc::ClientContext&,
+                                 google::iam::v1::SetIamPolicyRequest const&));
   MOCK_METHOD2(TestIamPermissions,
                StatusOr<google::iam::v1::TestIamPermissionsResponse>(
                    grpc::ClientContext&,


### PR DESCRIPTION
Fixes #522 

Please note that this is the first operation that is retried (or not) depending on the contents of the request.  `SetIamPolicy()` is idempotent only if `etag()` is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/618)
<!-- Reviewable:end -->
