### PR TITLE
Add an "auto" `RUN_INTEGRATION_TESTS` mode.

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -71,12 +71,17 @@ echo "================================================================"
     "${bazel_args[@]}" \
     -- //google/cloud/...:all
 
-if [[ ${RUN_INTEGRATION_TESTS} == "yes" ]]; then
+readonly INTEGRATION_TESTS_CONFIG="/c/spanner-integration-tests-config.sh"
+# yes: always try to run integration tests
+# auto: only try to run integration tests if the config file is executable.
+if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
+      ( "${RUN_INTEGRATION_TESTS}" == "auto" && \
+        -x "${INTEGRATION_TESTS_CONFIG}" ) ]]; then
   echo "================================================================"
   echo "Running the integration tests $(date)"
   echo "================================================================"
   # shellcheck disable=SC1091
-  source /c/spanner-integration-tests-config.sh
+  source "${INTEGRATION_TESTS_CONFIG}"
 
   # Run the integration tests using Bazel to drive them.
   "${BAZEL_BIN}" test \

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -83,12 +83,17 @@ if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
   echo "================================================================"
 fi
 
-if [[ ${RUN_INTEGRATION_TESTS} == "yes" ]]; then
+# yes: always try to run integration tests.
+# auto: only try to run integration tests if the config file is executable.
+readonly INTEGRATION_TESTS_CONFIG="/c/spanner-integration-tests-config.sh"
+if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
+      ( "${RUN_INTEGRATION_TESTS}" == "auto" && \
+        -x "${INTEGRATION_TESTS_CONFIG}" ) ]]; then
   echo "================================================================"
   echo "Running the integration tests $(date)"
   echo "================================================================"
   # shellcheck disable=SC1091
-  source /c/spanner-integration-tests-config.sh
+  source "${INTEGRATION_TESTS_CONFIG}"
   export GOOGLE_APPLICATION_CREDENTIALS=/c/spanner-credentials.json
   export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 


### PR DESCRIPTION
- Add a new "auto" mode, which only tries to run the tests if the config/
  credentials are available, otherwise it skips them.
- On Kokoro, the default is still "yes", but for other environments the
  default is "auto", which prevents them from failing (#600) but still
  allows running them by configuring the credentials properly.
- Individual builds are not affected, the ones that defaulted to off
  before still do, and the ones that were "yes" are now "auto" (or still
  "yes" on Kokoro) - with the exception of the "integration" build which
  is always set to "yes" for obvious reasons.
- If the user explicitly sets RUN_INTEGRATION_TESTS in the environment,
  we continue to honor that unconditionally.

Fixes #600