### PR TITLE
bug: give sample programs a long timeout time.

### DIFF
--- a/google/cloud/spanner/samples/BUILD
+++ b/google/cloud/spanner/samples/BUILD
@@ -23,6 +23,7 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
 
 [cc_test(
     name = "spanner_client_" + test.replace("/", "_").replace(".cc", ""),
+    timeout = "long",
     srcs = [test],
     tags = ["integration-tests"],
     deps = [


### PR DESCRIPTION
Just like we did for the integration tests, the samples also need a long
time to run because they create a database, which can take minutes.