### PR TITLE
chore!: Fixes inconsistent naming of the Batch DML params struct.

### DIFF
--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -115,7 +115,7 @@ class Connection {
   };
 
   /// Wrap the arguments to `ExecuteBatchDml()`.
-  struct BatchDmlParams {
+  struct ExecuteBatchDmlParams {
     Transaction transaction;
     std::vector<SqlStatement> statements;
   };
@@ -152,7 +152,7 @@ class Connection {
       PartitionQueryParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteBatchDml RPC
-  virtual StatusOr<BatchDmlResult> ExecuteBatchDml(BatchDmlParams) = 0;
+  virtual StatusOr<BatchDmlResult> ExecuteBatchDml(ExecuteBatchDmlParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.Commit RPC
   virtual StatusOr<CommitResult> Commit(CommitParams) = 0;

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -81,7 +81,7 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQuery(
 }
 
 StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDml(
-    BatchDmlParams params) {
+    ExecuteBatchDmlParams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -329,7 +329,7 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
 
 StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, BatchDmlParams params) {
+    std::int64_t seqno, ExecuteBatchDmlParams params) {
   if (!session) {
     auto session_or = GetSession();
     if (!session_or) {

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -55,7 +55,7 @@ class ConnectionImpl : public Connection,
       ExecutePartitionedDmlParams) override;
   StatusOr<std::vector<QueryPartition>> PartitionQuery(
       PartitionQueryParams) override;
-  StatusOr<BatchDmlResult> ExecuteBatchDml(BatchDmlParams) override;
+  StatusOr<BatchDmlResult> ExecuteBatchDml(ExecuteBatchDmlParams) override;
   StatusOr<CommitResult> Commit(CommitParams) override;
   Status Rollback(RollbackParams) override;
 
@@ -82,7 +82,7 @@ class ConnectionImpl : public Connection,
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, BatchDmlParams params);
+      std::int64_t seqno, ExecuteBatchDmlParams params);
 
   StatusOr<CommitResult> CommitImpl(SessionHolder& session,
                                     google::spanner::v1::TransactionSelector& s,

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -46,7 +46,7 @@ class MockConnection : public spanner::Connection {
   MOCK_METHOD1(PartitionQuery, StatusOr<std::vector<spanner::QueryPartition>>(
                                    PartitionQueryParams));
   MOCK_METHOD1(ExecuteBatchDml,
-               StatusOr<spanner::BatchDmlResult>(BatchDmlParams));
+               StatusOr<spanner::BatchDmlResult>(ExecuteBatchDmlParams));
   MOCK_METHOD1(Commit, StatusOr<spanner::CommitResult>(CommitParams));
   MOCK_METHOD1(Rollback, Status(RollbackParams));
 };


### PR DESCRIPTION
BREAKING CHANGE: This struct has been renamed, so any code using this
struct will need to be updated. However, it's unlikely that anyone is
using this now.

Fixes: #584

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/650)
<!-- Reviewable:end -->
