### PR TITLE
chore!: Implements Database in terms of Instance

### DIFF
--- a/google/cloud/spanner/database.cc
+++ b/google/cloud/spanner/database.cc
@@ -20,32 +20,26 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-Database::Database(std::string const& project_id,
-                   std::string const& instance_id,
-                   std::string const& database_id)
-    : full_name_("projects/" + project_id + "/instances/" + instance_id +
-                 "/databases/" + database_id) {}
+Database::Database(Instance instance, std::string database_id)
+    : instance_(std::move(instance)), database_id_(std::move(database_id)) {}
 
-std::string Database::FullName() const { return full_name_; }
+Database::Database(std::string project_id, std::string instance_id,
+                   std::string database_id)
+    : Database(Instance(std::move(project_id), std::move(instance_id)),
+               std::move(database_id)) {}
 
-std::string Database::DatabaseId() const {
-  auto pos = full_name_.rfind("/databases/");
-  return full_name_.substr(pos + sizeof("/databases/") - 1);
-}
-
-std::string Database::ParentName() const {
-  auto pos = full_name_.rfind("/databases/");
-  return full_name_.substr(0, pos);
+std::string Database::FullName() const {
+  return instance().FullName() + "/databases/" + database_id_;
 }
 
 bool operator==(Database const& a, Database const& b) {
-  return a.full_name_ == b.full_name_;
+  return a.instance_ == b.instance_ && a.database_id_ == b.database_id_;
 }
 
 bool operator!=(Database const& a, Database const& b) { return !(a == b); }
 
 std::ostream& operator<<(std::ostream& os, Database const& dn) {
-  return os << dn.full_name_;
+  return os << dn.FullName();
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/database.h
+++ b/google/cloud/spanner/database.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_DATABASE_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_DATABASE_H_
 
+#include "google/cloud/spanner/instance.h"
 #include "google/cloud/spanner/version.h"
 #include <ostream>
 #include <string>
@@ -41,9 +42,19 @@ inline namespace SPANNER_CLIENT_NS {
  */
 class Database {
  public:
-  /// Constructs a Database object identified by the given IDs.
-  Database(std::string const& project_id, std::string const& instance_id,
-           std::string const& database_id);
+  /// Constructs a Database object identified by the given @p database_id and
+  /// @p instance.
+  Database(Instance instance, std::string database_id);
+
+  /**
+   * Constructs a Database object identified by the given IDs.
+   *
+   * This is equivalent to first constructing an `Instance` from the given
+   * @p project_id and @p instance_id arguments then calling the
+   * `Database(Instance, std::string)` constructor.
+   */
+  Database(std::string project_id, std::string instance_id,
+           std::string database_id);
 
   /// @name Copy and move
   //@{
@@ -53,20 +64,15 @@ class Database {
   Database& operator=(Database&&) = default;
   //@}
 
-  /// Returns the database ID.
-  std::string DatabaseId() const;
-
   /**
    * Returns the fully qualified database name as a string of the form:
    * "projects/<project-id>/instances/<instance-id>/databases/<database-id>"
    */
   std::string FullName() const;
 
-  /**
-   * Returns the fully qualified name of the database's parent of the form:
-   * "projects/<project-id>/instances/<instance-id>"
-   */
-  std::string ParentName() const;
+  /// Returns the `Instance` containing this database.
+  Instance const& instance() const { return instance_; }
+  std::string const& database_id() const { return database_id_; }
 
   /// @name Equality operators
   //@{
@@ -78,7 +84,8 @@ class Database {
   friend std::ostream& operator<<(std::ostream& os, Database const& dn);
 
  private:
-  std::string full_name_;
+  Instance instance_;
+  std::string database_id_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -31,8 +31,8 @@ future<StatusOr<gcsa::Database>> DatabaseAdminClient::CreateDatabase(
     Database const& db, std::vector<std::string> const& extra_statements) {
   grpc::ClientContext context;
   gcsa::CreateDatabaseRequest request;
-  request.set_parent(db.ParentName());
-  request.set_create_statement("CREATE DATABASE `" + db.DatabaseId() + "`");
+  request.set_parent(db.instance().FullName());
+  request.set_create_statement("CREATE DATABASE `" + db.database_id() + "`");
   for (auto const& s : extra_statements) {
     *request.add_extra_statements() = s;
   }

--- a/google/cloud/spanner/database_test.cc
+++ b/google/cloud/spanner/database_test.cc
@@ -24,32 +24,35 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 TEST(Database, Basics) {
-  Database db("p1", "i1", "d1");
-  EXPECT_EQ("d1", db.DatabaseId());
+  Instance in("p1", "i1");
+  Database db(in, "d1");
+  EXPECT_EQ("d1", db.database_id());
+  EXPECT_EQ(in, db.instance());
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", db.FullName());
-  EXPECT_EQ("projects/p1/instances/i1", db.ParentName());
 
   auto copy = db;
   EXPECT_EQ(copy, db);
-  EXPECT_EQ("d1", copy.DatabaseId());
+  EXPECT_EQ("d1", copy.database_id());
+  EXPECT_EQ(in, copy.instance());
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", copy.FullName());
-  EXPECT_EQ("projects/p1/instances/i1", db.ParentName());
 
   auto moved = std::move(copy);
   EXPECT_EQ(moved, db);
-  EXPECT_EQ("d1", moved.DatabaseId());
+  EXPECT_EQ("d1", moved.database_id());
+  EXPECT_EQ(in, moved.instance());
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", moved.FullName());
-  EXPECT_EQ("projects/p1/instances/i1", db.ParentName());
 
-  Database db2("p2", "i2", "d2");
+  Instance in2("p2", "i2");
+  Database db2(in2, "d2");
   EXPECT_NE(db2, db);
-  EXPECT_EQ("d2", db2.DatabaseId());
+  EXPECT_EQ("d2", db2.database_id());
+  EXPECT_EQ(in2, db2.instance());
   EXPECT_EQ("projects/p2/instances/i2/databases/d2", db2.FullName());
-  EXPECT_EQ("projects/p2/instances/i2", db2.ParentName());
 }
 
 TEST(Database, OutputStream) {
-  Database db("p1", "i1", "d1");
+  Instance in("p1", "i1");
+  Database db(in, "d1");
   std::ostringstream os;
   os << db;
   EXPECT_EQ("projects/p1/instances/i1/databases/d1", os.str());

--- a/google/cloud/spanner/instance.cc
+++ b/google/cloud/spanner/instance.cc
@@ -20,25 +20,22 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-Instance::Instance(std::string const& project_id,
-                   std::string const& instance_id)
-    : full_name_("projects/" + project_id + "/instances/" + instance_id) {}
+Instance::Instance(std::string project_id, std::string instance_id)
+    : project_id_(std::move(project_id)),
+      instance_id_(std::move(instance_id)) {}
 
-std::string Instance::FullName() const { return full_name_; }
-
-std::string Instance::InstanceId() const {
-  auto pos = full_name_.rfind("/instances/");
-  return full_name_.substr(pos + sizeof("/instances/") - 1);
+std::string Instance::FullName() const {
+  return "projects/" + project_id_ + "/instances/" + instance_id_;
 }
 
 bool operator==(Instance const& a, Instance const& b) {
-  return a.full_name_ == b.full_name_;
+  return a.project_id_ == b.project_id_ && a.instance_id_ == b.instance_id_;
 }
 
 bool operator!=(Instance const& a, Instance const& b) { return !(a == b); }
 
 std::ostream& operator<<(std::ostream& os, Instance const& dn) {
-  return os << dn.full_name_;
+  return os << dn.FullName();
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/instance.h
+++ b/google/cloud/spanner/instance.h
@@ -41,7 +41,7 @@ inline namespace SPANNER_CLIENT_NS {
 class Instance {
  public:
   /// Constructs a Instance object identified by the given IDs.
-  Instance(std::string const& project_id, std::string const& instance_id);
+  Instance(std::string project_id, std::string instance_id);
 
   /// @name Copy and move
   //@{
@@ -51,8 +51,11 @@ class Instance {
   Instance& operator=(Instance&&) = default;
   //@}
 
-  /// Returns the instance ID.
-  std::string InstanceId() const;
+  /// Returns the Project ID
+  std::string const& project_id() const { return project_id_; }
+
+  /// Returns the Instance ID
+  std::string const& instance_id() const { return instance_id_; }
 
   /**
    * Returns the fully qualified instance name as a string of the form:
@@ -70,7 +73,8 @@ class Instance {
   friend std::ostream& operator<<(std::ostream& os, Instance const& dn);
 
  private:
-  std::string full_name_;
+  std::string project_id_;
+  std::string instance_id_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/instance_test.cc
+++ b/google/cloud/spanner/instance_test.cc
@@ -25,22 +25,26 @@ namespace {
 
 TEST(Instance, Basics) {
   Instance in("p1", "i1");
-  EXPECT_EQ("i1", in.InstanceId());
+  EXPECT_EQ("p1", in.project_id());
+  EXPECT_EQ("i1", in.instance_id());
   EXPECT_EQ("projects/p1/instances/i1", in.FullName());
 
   auto copy = in;
   EXPECT_EQ(copy, in);
-  EXPECT_EQ("i1", copy.InstanceId());
+  EXPECT_EQ("p1", copy.project_id());
+  EXPECT_EQ("i1", copy.instance_id());
   EXPECT_EQ("projects/p1/instances/i1", copy.FullName());
 
   auto moved = std::move(copy);
   EXPECT_EQ(moved, in);
-  EXPECT_EQ("i1", moved.InstanceId());
+  EXPECT_EQ("p1", moved.project_id());
+  EXPECT_EQ("i1", moved.instance_id());
   EXPECT_EQ("projects/p1/instances/i1", moved.FullName());
 
   Instance in2("p2", "i2");
   EXPECT_NE(in2, in);
-  EXPECT_EQ("i2", in2.InstanceId());
+  EXPECT_EQ("p2", in2.project_id());
+  EXPECT_EQ("i2", in2.instance_id());
   EXPECT_EQ("projects/p2/instances/i2", in2.FullName());
 }
 

--- a/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
@@ -77,7 +77,7 @@ class RpcFailureThresholdTest : public ::testing::Test {
     if (!db_) {
       return;
     }
-    std::cout << "Dropping database " << db_->DatabaseId() << std::flush;
+    std::cout << "Dropping database " << db_->database_id() << std::flush;
     DatabaseAdminClient admin_client;
     auto drop_status = admin_client.DropDatabase(*db_);
     std::cout << " DONE\n";

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -227,7 +227,7 @@ void InstanceTestIamPermissions(
   std::cout
       << "The caller " << msg
       << " have permission to list databases on the Cloud Spanner instance "
-      << in.InstanceId() << "\n";
+      << in.instance_id() << "\n";
 }
 //! [instance-test-iam-permissions]
 


### PR DESCRIPTION
BREAKING CHANGE: This PR removes renames some accessors like
`InstanceId` -> `instance_id` due to their trivial nature now (style
guide). It also removes some methods like `Database::ParentName()`,
which is now replaced by `Database::instance()`.

Fixes: 586

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/652)
<!-- Reviewable:end -->
