### PR TITLE
feat: Changed RowParser to require a Row<Ts...> template param

### DIFF
--- a/ci/test-install/spanner_install_test.cc
+++ b/ci/test-install/spanner_install_test.cc
@@ -105,7 +105,7 @@ int main(int argc, char* argv[]) try {
       client.ExecuteSql(spanner::SqlStatement("SELECT 'Hello World'"));
   if (!reader) throw std::runtime_error(reader.status().message());
 
-  for (auto&& row : reader->Rows<std::string>()) {
+  for (auto&& row : reader->Rows<spanner::Row<std::string>>()) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << row->get<0>() << "\n";
   }

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -85,7 +85,8 @@ inline namespace SPANNER_CLIENT_NS {
  * if (!result) {
  *   return result.status();
  * }
- * for (auto const& row : result.Rows<std::int64_t, std::string>()) {
+ * using RowType = Row<std::int64_t, std::string>;
+ * for (auto const& row : result.Rows<RowType>()) {
  *   // ...
  * }
  * @endcode

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -112,17 +112,18 @@ TEST(ClientTest, ReadSuccess) {
   auto result = client.Read("table", std::move(keys), {"column1", "column2"});
   EXPECT_STATUS_OK(result);
 
-  std::array<std::pair<std::string, std::int64_t>, 2> expected = {
-      {std::make_pair("Steve", 12), std::make_pair("Ann", 42)}};
+  using RowType = Row<std::string, std::int64_t>;
+  auto expected = std::vector<RowType>{
+      RowType("Steve", 12),
+      RowType("Ann", 42),
+  };
   int row_number = 0;
-  for (auto& row : result->Rows<std::string, std::int64_t>()) {
+  for (auto& row : result->Rows<RowType>()) {
     EXPECT_STATUS_OK(row);
-    EXPECT_EQ(row->size(), 2);
-    EXPECT_EQ(row->get<0>(), expected[row_number].first);
-    EXPECT_EQ(row->get<1>(), expected[row_number].second);
+    EXPECT_EQ(*row, expected[row_number]);
     ++row_number;
   }
-  EXPECT_EQ(row_number, 2);
+  EXPECT_EQ(row_number, expected.size());
 }
 
 TEST(ClientTest, ReadFailure) {
@@ -156,7 +157,7 @@ TEST(ClientTest, ReadFailure) {
   auto result = client.Read("table", std::move(keys), {"column1"});
   EXPECT_STATUS_OK(result);
 
-  auto rows = result->Rows<std::string>();
+  auto rows = result->Rows<Row<std::string>>();
   auto iter = rows.begin();
   EXPECT_NE(iter, rows.end());
   EXPECT_STATUS_OK(*iter);
@@ -210,17 +211,18 @@ TEST(ClientTest, ExecuteSqlSuccess) {
   auto result = client.ExecuteSql(SqlStatement("select * from table;"));
   EXPECT_STATUS_OK(result);
 
-  std::array<std::pair<std::string, std::int64_t>, 2> expected = {
-      {std::make_pair("Steve", 12), std::make_pair("Ann", 42)}};
+  using RowType = Row<std::string, std::int64_t>;
+  auto expected = std::vector<RowType>{
+      RowType("Steve", 12),
+      RowType("Ann", 42),
+  };
   int row_number = 0;
-  for (auto& row : result->Rows<std::string, std::int64_t>()) {
+  for (auto& row : result->Rows<RowType>()) {
     EXPECT_STATUS_OK(row);
-    EXPECT_EQ(row->size(), 2);
-    EXPECT_EQ(row->get<0>(), expected[row_number].first);
-    EXPECT_EQ(row->get<1>(), expected[row_number].second);
+    EXPECT_EQ(*row, expected[row_number]);
     ++row_number;
   }
-  EXPECT_EQ(row_number, 2);
+  EXPECT_EQ(row_number, expected.size());
 }
 
 TEST(ClientTest, ExecuteSqlFailure) {
@@ -255,7 +257,7 @@ TEST(ClientTest, ExecuteSqlFailure) {
   auto result = client.ExecuteSql(SqlStatement("select * from table;"));
   EXPECT_STATUS_OK(result);
 
-  auto rows = result->Rows<std::string>();
+  auto rows = result->Rows<Row<std::string>>();
   auto iter = rows.begin();
   EXPECT_NE(iter, rows.end());
   EXPECT_STATUS_OK(*iter);

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -106,8 +106,8 @@ TEST(ClientSqlStressTest, UpsertAndSelect) {
                           {"max", spanner::Value(key + size)}}));
         result.Update(reader.status());
         if (!reader) continue;
-        for (auto row :
-             reader->Rows<std::int64_t, std::string, std::string>()) {
+        using RowType = Row<std::int64_t, std::string, std::string>;
+        for (auto row : reader->Rows<RowType>()) {
           result.Update(row.status());
         }
       }
@@ -179,8 +179,8 @@ TEST(ClientStressTest, UpsertAndRead) {
                                   {"SingerId", "FirstName", "LastName"});
         result.Update(reader.status());
         if (!reader) continue;
-        for (auto row :
-             reader->Rows<std::int64_t, std::string, std::string>()) {
+        using RowType = Row<std::int64_t, std::string, std::string>;
+        for (auto row : reader->Rows<RowType>()) {
           result.Update(row.status());
         }
       }

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -192,17 +192,18 @@ TEST(ConnectionImplTest, ReadSuccess) {
                   {"UserId", "UserName"},
                   ReadOptions()});
   EXPECT_STATUS_OK(result);
-  std::array<std::pair<std::int64_t, std::string>, 2> expected = {
-      {std::make_pair(12, "Steve"), std::make_pair(42, "Ann")}};
+  using RowType = Row<std::int64_t, std::string>;
+  auto expected = std::vector<RowType>{
+      RowType(12, "Steve"),
+      RowType(42, "Ann"),
+  };
   int row_number = 0;
-  for (auto& row : result->Rows<std::int64_t, std::string>()) {
+  for (auto& row : result->Rows<RowType>()) {
     EXPECT_STATUS_OK(row);
-    EXPECT_EQ(row->size(), 2);
-    EXPECT_EQ(row->get<0>(), expected[row_number].first);
-    EXPECT_EQ(row->get<1>(), expected[row_number].second);
+    EXPECT_EQ(*row, expected[row_number]);
     ++row_number;
   }
-  EXPECT_EQ(row_number, 2);
+  EXPECT_EQ(row_number, expected.size());
 }
 
 /// @test Verify implicit "begin transaction" in Read() works.
@@ -337,17 +338,18 @@ TEST(ConnectionImplTest, ExecuteSqlReadSuccess) {
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        SqlStatement("select * from table")});
   EXPECT_STATUS_OK(result);
-  std::array<std::pair<std::int64_t, std::string>, 2> expected = {
-      {std::make_pair(12, "Steve"), std::make_pair(42, "Ann")}};
+  using RowType = Row<std::int64_t, std::string>;
+  auto expected = std::vector<RowType>{
+      RowType(12, "Steve"),
+      RowType(42, "Ann"),
+  };
   int row_number = 0;
-  for (auto& row : result->Rows<std::int64_t, std::string>()) {
+  for (auto& row : result->Rows<RowType>()) {
     EXPECT_STATUS_OK(row);
-    EXPECT_EQ(row->size(), 2);
-    EXPECT_EQ(row->get<0>(), expected[row_number].first);
-    EXPECT_EQ(row->get<1>(), expected[row_number].second);
+    EXPECT_EQ(*row, expected[row_number]);
     ++row_number;
   }
-  EXPECT_EQ(row_number, 2);
+  EXPECT_EQ(row_number, expected.size());
 }
 
 /// @test Verify implicit "begin transaction" in ExecuteSql() works.
@@ -1003,7 +1005,7 @@ TEST(ConnectionImplTest, TransactionSessionBinding) {
       conn->Read({txn1, "table", KeySet::All(), {"Number"}, ReadOptions()});
   EXPECT_STATUS_OK(result);
   EXPECT_THAT(txn1, HasSessionAndTransactionId("session-1", "ABCDEF01"));
-  for (auto& row : result->Rows<std::int64_t>()) {
+  for (auto& row : result->Rows<Row<std::int64_t>>()) {
     EXPECT_STATUS_OK(row);
     EXPECT_EQ(row->size(), 1);
     EXPECT_EQ(row->get<0>(), 0);
@@ -1014,7 +1016,7 @@ TEST(ConnectionImplTest, TransactionSessionBinding) {
       conn->Read({txn2, "table", KeySet::All(), {"Number"}, ReadOptions()});
   EXPECT_STATUS_OK(result);
   EXPECT_THAT(txn2, HasSessionAndTransactionId("session-2", "ABCDEF02"));
-  for (auto& row : result->Rows<std::int64_t>()) {
+  for (auto& row : result->Rows<Row<std::int64_t>>()) {
     EXPECT_STATUS_OK(row);
     EXPECT_EQ(row->size(), 1);
     EXPECT_EQ(row->get<0>(), 1);
@@ -1024,7 +1026,7 @@ TEST(ConnectionImplTest, TransactionSessionBinding) {
       conn->Read({txn1, "table", KeySet::All(), {"Number"}, ReadOptions()});
   EXPECT_STATUS_OK(result);
   EXPECT_THAT(txn1, HasSessionAndTransactionId("session-1", "ABCDEF01"));
-  for (auto& row : result->Rows<std::int64_t>()) {
+  for (auto& row : result->Rows<Row<std::int64_t>>()) {
     EXPECT_STATUS_OK(row);
     EXPECT_EQ(row->size(), 1);
     EXPECT_EQ(row->get<0>(), 2);
@@ -1034,7 +1036,7 @@ TEST(ConnectionImplTest, TransactionSessionBinding) {
       conn->Read({txn2, "table", KeySet::All(), {"Number"}, ReadOptions()});
   EXPECT_STATUS_OK(result);
   EXPECT_THAT(txn2, HasSessionAndTransactionId("session-2", "ABCDEF02"));
-  for (auto& row : result->Rows<std::int64_t>()) {
+  for (auto& row : result->Rows<Row<std::int64_t>>()) {
     EXPECT_STATUS_OK(row);
     EXPECT_EQ(row->size(), 1);
     EXPECT_EQ(row->get<0>(), 3);

--- a/google/cloud/spanner/result_set.h
+++ b/google/cloud/spanner/result_set.h
@@ -66,9 +66,10 @@ class ResultSet {
    * time. Doing so is not thread safe, and may result in errors or data
    * corruption.
    */
-  template <typename... Ts>
-  RowParser<Ts...> Rows() {
-    return RowParser<Ts...>([this]() mutable { return source_->NextValue(); });
+  template <typename RowType>
+  RowParser<RowType> Rows() {
+    return RowParser<RowType>(
+        [this]() mutable { return source_->NextValue(); });
   }
 
   /**

--- a/google/cloud/spanner/result_set_test.cc
+++ b/google/cloud/spanner/result_set_test.cc
@@ -44,7 +44,7 @@ TEST(ResultSet, IterateNoRows) {
 
   ResultSet result_set(std::move(mock_source));
   int num_rows = 0;
-  for (auto const& row : result_set.Rows<bool>()) {
+  for (auto const& row : result_set.Rows<Row<bool>>()) {
     static_cast<void>(row);
     ++num_rows;
   }
@@ -64,7 +64,8 @@ TEST(ResultSet, IterateOverRows) {
 
   ResultSet result_set(std::move(mock_source));
   int num_rows = 0;
-  for (auto const& row : result_set.Rows<std::int64_t, bool, std::string>()) {
+  for (auto const& row :
+       result_set.Rows<Row<std::int64_t, bool, std::string>>()) {
     EXPECT_TRUE(row.ok());
     switch (num_rows++) {
       case 0:
@@ -98,7 +99,8 @@ TEST(ResultSet, IterateError) {
 
   ResultSet result_set(std::move(mock_source));
   int num_rows = 0;
-  for (auto const& row : result_set.Rows<std::int64_t, bool, std::string>()) {
+  for (auto const& row :
+       result_set.Rows<Row<std::int64_t, bool, std::string>>()) {
     switch (num_rows++) {
       case 0:
         EXPECT_TRUE(row.ok());

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -342,10 +342,12 @@ Row<internal::PromoteLiteral<Ts>...> MakeRow(Ts&&... ts) {
 }
 
 /**
- * Parses a `std::array` of `Value` objects into a `Row<Ts...>` holding C++ types.
+ * Parses a `std::array` of `Value` objects into a `Row<Ts...>` holding C++
+ * types.
  *
  * If parsing fails, an error `Status` is returned. The given array size must
- * exactly match the number of types in the specified `Row<Ts...>`. See `Row::size()`.
+ * exactly match the number of types in the specified `Row<Ts...>`. See
+ * `Row::size()`.
  *
  * @par Example
  *

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -342,24 +342,24 @@ Row<internal::PromoteLiteral<Ts>...> MakeRow(Ts&&... ts) {
 }
 
 /**
- * Parses a `std::array` of `Value` objects into the specified C++ types and
- * returns a `Row<Ts...>` with all the parsed values. If the specified C++ type
- * is unable to be extracted from a `Value`, an error `Status` is returned. The
- * given array size must exactly match the number of specified C++ types.
+ * Parses a `std::array` of `Value` objects into a `Row<Ts...>` holding C++ types.
+ *
+ * If parsing fails, an error `Status` is returned. The given array size must
+ * exactly match the number of types in the specified `Row<Ts...>`. See `Row::size()`.
  *
  * @par Example
  *
  * @code
  * std::array<Value, 3> array = {Value(true), Value(42), Value("hello")};
- * auto row = ParseRow<bool, std::int64_t, std::string>(array);
+ * using RowType = Row<bool, std::int64_t, std::string>;
+ * auto row = ParseRow<RowType>(array);
  * assert(row.ok());
  * assert(MakeRow(true, 42, "hello"), *row);
  * @endcode
  */
-template <typename... Ts>
-StatusOr<Row<internal::PromoteLiteral<Ts>...>> ParseRow(
-    std::array<Value, sizeof...(Ts)> const& array) {
-  Row<internal::PromoteLiteral<Ts>...> row;
+template <typename RowType>
+StatusOr<RowType> ParseRow(std::array<Value, RowType::size()> const& array) {
+  RowType row;
   auto it = array.begin();
   Status status;
   internal::ForEach(row, internal::ExtractValue{status}, it);

--- a/google/cloud/spanner/row_parser.h
+++ b/google/cloud/spanner/row_parser.h
@@ -187,7 +187,7 @@ class RowParser {
       }
       values[i] = **std::move(v);
     }
-    curr_ = ParseRow<T, Ts...>(values);
+    curr_ = ParseRow<RowType>(values);
   }
 
   ValueSource value_source_;  // nullpr is end

--- a/google/cloud/spanner/row_parser.h
+++ b/google/cloud/spanner/row_parser.h
@@ -60,8 +60,8 @@ using ValueSource = std::function<StatusOr<optional<Value>>()>;
  * range of `Row<Ts...>` objects.
  *
  * Instances of this class are typically obtained from the
- * `ResultSet::rows<Ts...>` member function. Callers should iterate `RowParser`
- * using a range-for loop as follows.
+ * `ResultSet::Rows<Row<Ts...>>` member function. Callers should iterate
+ * `RowParser` using a range-for loop as follows.
  *
  * @warning Moving a `RowParser` invalidates all iterators referring to the
  *     moved-from instance.
@@ -70,7 +70,7 @@ using ValueSource = std::function<StatusOr<optional<Value>>()>;
  *
  * @code
  * ValueSource vs = ...
- * RowParser<bool, std::int64_t> rp(std::move(vs));
+ * RowParser<Row<bool, std::int64_t>> rp(std::move(vs));
  * for (auto row : rp) {
  *   if (!row) {
  *     // handle error
@@ -84,13 +84,11 @@ using ValueSource = std::function<StatusOr<optional<Value>>()>;
  * }
  * @endcode
  *
- * @tparam T the C++ type of the first column in each `Row` (required)
- * @tparam Ts... the types of the remaining columns in each `Row` (optional)
+ * @tparam RowType a `Row<Ts...>`
  */
-template <typename T, typename... Ts>
+template <typename RowType>
 class RowParser {
  public:
-  using RowType = Row<T, Ts...>;
   using value_type = StatusOr<RowType>;
 
   /// A single-pass input iterator that coalesces multiple `Value` results into

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -220,7 +220,7 @@ TEST(Row, MakeRowCVQualifications) {
 
 TEST(Row, ParseRowEmpty) {
   std::array<Value, 0> const array = {};
-  auto const row = ParseRow(array);
+  auto const row = ParseRow<Row<>>(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(), *row);
   EXPECT_EQ(array, row->values());
@@ -230,12 +230,12 @@ TEST(Row, ParseRowOneValue) {
   // The extra braces are working around an old clang bug that was fixed in 6.0
   // https://bugs.llvm.org/show_bug.cgi?id=21629
   std::array<Value, 1> const array = {{Value(42)}};
-  auto const row = ParseRow<std::int64_t>(array);
+  auto const row = ParseRow<Row<std::int64_t>>(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(42), *row);
   EXPECT_EQ(array, row->values());
   // Tests parsing the Value with the wrong type.
-  auto const error_row = ParseRow<double>(array);
+  auto const error_row = ParseRow<Row<double>>(array);
   EXPECT_FALSE(error_row.ok());
 }
 
@@ -243,19 +243,19 @@ TEST(Row, ParseRowThree) {
   // The extra braces are working around an old clang bug that was fixed in 6.0
   // https://bugs.llvm.org/show_bug.cgi?id=21629
   std::array<Value, 3> array = {{Value(true), Value(42), Value("hello")}};
-  auto row = ParseRow<bool, std::int64_t, std::string>(array);
+  auto row = ParseRow<Row<bool, std::int64_t, std::string>>(array);
   EXPECT_TRUE(row.ok());
   EXPECT_EQ(MakeRow(true, 42, "hello"), *row);
   EXPECT_EQ(array, row->values());
   // Tests parsing the Value with the wrong type.
-  auto const error_row = ParseRow<bool, double, std::string>(array);
+  auto const error_row = ParseRow<Row<bool, double, std::string>>(array);
   EXPECT_FALSE(error_row.ok());
 }
 
-template <typename... Ts>
-void RoundTripRow(Row<Ts...> const& row) {
+template <typename RowType>
+void RoundTripRow(RowType const& row) {
   auto array = row.values();
-  auto parsed = ParseRow<Ts...>(array);
+  auto parsed = ParseRow<RowType>(array);
   EXPECT_TRUE(parsed.ok());
   EXPECT_EQ(row, *parsed);
 }

--- a/google/cloud/spanner/samples/mock_execute_sql.cc
+++ b/google/cloud/spanner/samples/mock_execute_sql.cc
@@ -97,7 +97,8 @@ TEST(MockSpannerClient, SuccessfulExecuteSql) {
 
   //! [expected-results]
   int count = 0;
-  for (auto row : reader->Rows<std::int64_t, std::string>()) {
+  using RowType = spanner::Row<std::int64_t, std::string>;
+  for (auto row : reader->Rows<RowType>()) {
     ASSERT_TRUE(row);
     auto expected_id = ++count;
     EXPECT_EQ(expected_id, row->get<0>());

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -566,8 +566,7 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
     if (!read) {
       throw std::runtime_error(read.status().message());
     }
-    using RowType = spanner::Row<std::int64_t>;
-    for (auto row : read->Rows<RowType>()) {
+    for (auto row : read->Rows<spanner::Row<std::int64_t>>()) {
       if (!row) {
         throw std::runtime_error(read.status().message());
       }
@@ -720,8 +719,7 @@ void QueryDataWithStruct(google::cloud::spanner::Client client) {
   //! [spanner-sql-statement-params]
   if (!reader) throw std::runtime_error(reader.status().message());
 
-  using RowType = spanner::Row<std::int64_t>;
-  for (auto row : reader->Rows<RowType>()) {
+  for (auto row : reader->Rows<spanner::Row<std::int64_t>>()) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << "SingerId: " << row->get<0>() << "\n";
   }
@@ -756,8 +754,7 @@ void QueryDataWithArrayOfStruct(google::cloud::spanner::Client client) {
       {{"names", spanner::Value(singer_info)}}));
   if (!reader) throw std::runtime_error(reader.status().message());
 
-  using RowType = spanner::Row<std::int64_t>;
-  for (auto row : reader->Rows<RowType>()) {
+  for (auto row : reader->Rows<spanner::Row<std::int64_t>>()) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << "SingerId: " << row->get<0>() << "\n";
   }
@@ -781,8 +778,7 @@ void FieldAccessOnStructParameters(google::cloud::spanner::Client client) {
       {{"name", spanner::Value(name)}}));
   if (!reader) throw std::runtime_error(reader.status().message());
 
-  using RowType = spanner::Row<std::int64_t>;
-  for (auto row : reader->Rows<RowType>()) {
+  for (auto row : reader->Rows<spanner::Row<std::int64_t>>()) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << "SingerId: " << row->get<0>() << "\n";
   }

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -413,7 +413,8 @@ void Quickstart(std::string const& project_id, std::string const& instance_id,
       client.ExecuteSql(spanner::SqlStatement("SELECT 'Hello World'"));
   if (!reader) throw std::runtime_error(reader.status().message());
 
-  for (auto row : reader->Rows<std::string>()) {
+  using RowType = spanner::Row<std::string>;
+  for (auto row : reader->Rows<RowType>()) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << row->get<0>() << "\n";
   }
@@ -525,11 +526,12 @@ void ReadOnlyTransaction(google::cloud::spanner::Client client) {
 
   spanner::SqlStatement select(
       "SELECT SingerId, AlbumId, AlbumTitle FROM Albums");
+  using RowType = spanner::Row<std::int64_t, std::int64_t, std::string>;
 
   // Read#1.
   auto read1 = client.ExecuteSql(read_only, select);
   std::cout << "Read 1 results\n";
-  for (auto row : read1->Rows<std::int64_t, std::int64_t, std::string>()) {
+  for (auto row : read1->Rows<RowType>()) {
     if (!row) {
       throw std::runtime_error(row.status().message());
     }
@@ -540,7 +542,7 @@ void ReadOnlyTransaction(google::cloud::spanner::Client client) {
   // that Read #1 and Read #2 return the same data.
   auto read2 = client.ExecuteSql(read_only, select);
   std::cout << "Read 2 results\n";
-  for (auto row : read2->Rows<std::int64_t, std::int64_t, std::string>()) {
+  for (auto row : read2->Rows<RowType>()) {
     if (!row) {
       throw std::runtime_error(row.status().message());
     }
@@ -564,7 +566,8 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
     if (!read) {
       throw std::runtime_error(read.status().message());
     }
-    for (auto row : read->Rows<std::int64_t>()) {
+    using RowType = spanner::Row<std::int64_t>;
+    for (auto row : read->Rows<RowType>()) {
       if (!row) {
         throw std::runtime_error(read.status().message());
       }
@@ -717,7 +720,8 @@ void QueryDataWithStruct(google::cloud::spanner::Client client) {
   //! [spanner-sql-statement-params]
   if (!reader) throw std::runtime_error(reader.status().message());
 
-  for (auto row : reader->Rows<std::int64_t>()) {
+  using RowType = spanner::Row<std::int64_t>;
+  for (auto row : reader->Rows<RowType>()) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << "SingerId: " << row->get<0>() << "\n";
   }
@@ -752,7 +756,8 @@ void QueryDataWithArrayOfStruct(google::cloud::spanner::Client client) {
       {{"names", spanner::Value(singer_info)}}));
   if (!reader) throw std::runtime_error(reader.status().message());
 
-  for (auto row : reader->Rows<std::int64_t>()) {
+  using RowType = spanner::Row<std::int64_t>;
+  for (auto row : reader->Rows<RowType>()) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << "SingerId: " << row->get<0>() << "\n";
   }
@@ -776,7 +781,8 @@ void FieldAccessOnStructParameters(google::cloud::spanner::Client client) {
       {{"name", spanner::Value(name)}}));
   if (!reader) throw std::runtime_error(reader.status().message());
 
-  for (auto row : reader->Rows<std::int64_t>()) {
+  using RowType = spanner::Row<std::int64_t>;
+  for (auto row : reader->Rows<RowType>()) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << "SingerId: " << row->get<0>() << "\n";
   }
@@ -812,7 +818,8 @@ void FieldAccessOnNestedStruct(google::cloud::spanner::Client client) {
       {{"songinfo", spanner::Value(songinfo)}}));
   if (!reader) throw std::runtime_error(reader.status().message());
 
-  for (auto row : reader->Rows<std::int64_t, std::string>()) {
+  using RowType = spanner::Row<std::int64_t, std::string>;
+  for (auto row : reader->Rows<RowType>()) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << "SingerId: " << row->get<0>() << " SongName: " << row->get<1>()
               << "\n";
@@ -904,7 +911,8 @@ void PartitionRead(google::cloud::spanner::Client client) {
   if (!partition) throw std::runtime_error(partition.status().message());
   auto result_set = client.Read(*partition);
   if (!result_set) throw std::runtime_error(result_set.status().message());
-  for (auto& row : result_set->Rows<std::int64_t, std::string, std::string>()) {
+  using RowType = spanner::Row<std::int64_t, std::string, std::string>;
+  for (auto& row : result_set->Rows<RowType>()) {
     if (!row) throw std::runtime_error(row.status().message());
     ProcessRow(*row);
   }
@@ -933,7 +941,8 @@ void PartitionQuery(google::cloud::spanner::Client client) {
   if (!partition) throw std::runtime_error(partition.status().message());
   auto result_set = client.ExecuteSql(*partition);
   if (!result_set) throw std::runtime_error(result_set.status().message());
-  for (auto& row : result_set->Rows<std::int64_t, std::string, std::string>()) {
+  using RowType = spanner::Row<std::int64_t, std::string, std::string>;
+  for (auto& row : result_set->Rows<RowType>()) {
     if (!row) throw std::runtime_error(row.status().message());
     ProcessRow(*row);
   }


### PR DESCRIPTION

BREAKING CHANGE: `ResultSet::Rows` used to be a variadic template that
took the individual C++ types for each row. With this change that
function is now a template with one parameter, which must be a
`Row<...>` type.

Some reasons for this change:

* Our code is simpler when we minimize the functions that need to be
variadic. Instead of making a bunch of functions variadic, we should use
the `Row` class, which handles all the variadic stuff.

* Using a type named "Row" seems more sensible when we're talking about
a "row" than does a sequence of C++ types. That is, bundling C++ types
in a `Row<...>` when those types logically represent a "row" seems like
a readability win.

* A sequence of bare C++ types cannot be aliased, so they need to be
repeated wherever they're needed.

* Spelling all the C++ types (without an alias) in a call to `Rows()` in
a range-for loop causes a bunch of wrapping which hurts readability.

Fixes: #502

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/653)
<!-- Reviewable:end -->
