### PR TITLE
bug: fix runtime install directory

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -386,7 +386,7 @@ install(EXPORT spanner-targets
 # GNUInstallDirs
 install(TARGETS spanner_client
         EXPORT spanner-targets
-        RUNTIME DESTINATION bin
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
TIL: Use the macro name for the runtime install directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/658)
<!-- Reviewable:end -->
