### PR TITLE
feat: support install components for the library

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -393,6 +393,8 @@ install(TARGETS spanner_client
                 NAMELINK_SKIP
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT google_cloud_cpp_spanner_development)
+# With CMake-3.12 and higher we could avoid this separate command (and the
+# duplication).
 install(TARGETS spanner_client
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT google_cloud_cpp_spanner_development

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -39,9 +39,7 @@ function (google_cloud_cpp_spanner_initialize_git_head var)
             # Run `git rev-parse --short HEAD` and capture the output in a
             # variable.
             execute_process(COMMAND "${GOOGLE_CLOUD_CPP_SPANNER_GIT_PROGRAM}"
-                                    rev-parse
-                                    --short
-                                    HEAD
+                                    rev-parse --short HEAD
                             OUTPUT_VARIABLE GIT_HEAD_LOG
                             ERROR_VARIABLE GIT_HEAD_LOG)
             string(REPLACE "\n"

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -39,7 +39,9 @@ function (google_cloud_cpp_spanner_initialize_git_head var)
             # Run `git rev-parse --short HEAD` and capture the output in a
             # variable.
             execute_process(COMMAND "${GOOGLE_CLOUD_CPP_SPANNER_GIT_PROGRAM}"
-                                    rev-parse --short HEAD
+                                    rev-parse
+                                    --short
+                                    HEAD
                             OUTPUT_VARIABLE GIT_HEAD_LOG
                             ERROR_VARIABLE GIT_HEAD_LOG)
             string(REPLACE "\n"
@@ -387,8 +389,16 @@ install(EXPORT spanner-targets
 install(TARGETS spanner_client
         EXPORT spanner-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                COMPONENT google_cloud_cpp_spanner_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                COMPONENT google_cloud_cpp_spanner_development
+                NAMELINK_SKIP
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_spanner_development)
+install(TARGETS spanner_client
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_spanner_runtime
+                NAMELINK_ONLY)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
         DESTINATION include/google/cloud/spanner

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -396,7 +396,9 @@ install(TARGETS spanner_client
 install(TARGETS spanner_client
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT google_cloud_cpp_spanner_development
-                NAMELINK_ONLY)
+                NAMELINK_ONLY
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                COMPONENT google_cloud_cpp_spanner_development)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
         DESTINATION include/google/cloud/spanner

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -389,21 +389,23 @@ install(TARGETS spanner_client
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                 COMPONENT google_cloud_cpp_spanner_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_spanner_development
+                COMPONENT google_cloud_cpp_spanner_runtime
                 NAMELINK_SKIP
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT google_cloud_cpp_spanner_development)
 install(TARGETS spanner_client
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_spanner_runtime
+                COMPONENT google_cloud_cpp_spanner_development
                 NAMELINK_ONLY)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
         DESTINATION include/google/cloud/spanner
+        COMPONENT google_cloud_cpp_spanner_development
         FILES_MATCHING
         PATTERN "*.h")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
         DESTINATION include/google/cloud/spanner
+        COMPONENT google_cloud_cpp_spanner_development
         FILES_MATCHING
         PATTERN "*.inc")
 
@@ -422,7 +424,8 @@ set(GOOGLE_CLOUD_SPANNER_PC_LIBS "-lspanner_client")
 configure_file("${PROJECT_SOURCE_DIR}/google/cloud/spanner/config.pc.in"
                "spanner_client.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/spanner_client.pc"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        COMPONENT google_cloud_cpp_spanner_development)
 
 # Create and install the CMake configuration files.
 configure_file("config.cmake.in" "spanner_client-config.cmake" @ONLY)
@@ -431,4 +434,5 @@ configure_file(
     "spanner_client-config-version.cmake" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/spanner_client-config.cmake"
               "${CMAKE_CURRENT_BINARY_DIR}/spanner_client-config-version.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/spanner_client")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/spanner_client"
+        COMPONENT google_cloud_cpp_spanner_development)


### PR DESCRIPTION
TIL: we can make it easier for package maintainers to create separate
packages for development vs. runtime if we use named components for
the library install directories. With CMake 3.5, however, we need to
use a secondary `install()` command for the libFoo.so.X.Y.Z link (aka
the NAMELINK_ONLY install)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/659)
<!-- Reviewable:end -->
