### PR TITLE
feat: use separate policies for retry vs. rerun

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -160,18 +160,18 @@ namespace internal {
 StatusOr<CommitResult> RunTransactionWithPolicies(
     Client client, Transaction::ReadWriteOptions const& opts,
     std::function<StatusOr<Mutations>(Client, Transaction)> const& f,
-    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<TransactionReRunPolicy> re_run_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy) {
   Status last_status(
       StatusCode::kFailedPrecondition,
       "Retry policy should not be exhausted when retry loop starts");
   char const* reason = "Too many failures in ";
-  while (!retry_policy->IsExhausted()) {
+  while (!re_run_policy->IsExhausted()) {
     auto result = RunTransactionImpl(client, opts, f);
     if (result) return result;
     last_status = std::move(result).status();
-    if (!retry_policy->OnFailure(last_status)) {
-      if (internal::SafeGrpcRetry::IsPermanentFailure(last_status)) {
+    if (!re_run_policy->OnFailure(last_status)) {
+      if (internal::SafeTransactionReRun::IsPermanentFailure(last_status)) {
         reason = "Permanent failure in ";
       }
       break;
@@ -181,8 +181,9 @@ StatusOr<CommitResult> RunTransactionWithPolicies(
   return internal::RetryLoopError(reason, __func__, last_status);
 }
 
-std::unique_ptr<RetryPolicy> DefaultRunTransactionRetryPolicy() {
-  return LimitedTimeRetryPolicy(/*maximum_duration=*/std::chrono::minutes(10))
+std::unique_ptr<TransactionReRunPolicy> DefaultRunTransactionReRunPolicy() {
+  return LimitedTimeTransactionReRunPolicy(
+             /*maximum_duration=*/std::chrono::minutes(10))
       .clone();
 }
 

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -160,18 +160,18 @@ namespace internal {
 StatusOr<CommitResult> RunTransactionWithPolicies(
     Client client, Transaction::ReadWriteOptions const& opts,
     std::function<StatusOr<Mutations>(Client, Transaction)> const& f,
-    std::unique_ptr<TransactionReRunPolicy> re_run_policy,
+    std::unique_ptr<TransactionRerunPolicy> rerun_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy) {
   Status last_status(
       StatusCode::kFailedPrecondition,
       "Retry policy should not be exhausted when retry loop starts");
   char const* reason = "Too many failures in ";
-  while (!re_run_policy->IsExhausted()) {
+  while (!rerun_policy->IsExhausted()) {
     auto result = RunTransactionImpl(client, opts, f);
     if (result) return result;
     last_status = std::move(result).status();
-    if (!re_run_policy->OnFailure(last_status)) {
-      if (internal::SafeTransactionReRun::IsPermanentFailure(last_status)) {
+    if (!rerun_policy->OnFailure(last_status)) {
+      if (internal::SafeTransactionRerun::IsPermanentFailure(last_status)) {
         reason = "Permanent failure in ";
       }
       break;
@@ -181,8 +181,8 @@ StatusOr<CommitResult> RunTransactionWithPolicies(
   return internal::RetryLoopError(reason, __func__, last_status);
 }
 
-std::unique_ptr<TransactionReRunPolicy> DefaultRunTransactionReRunPolicy() {
-  return LimitedTimeTransactionReRunPolicy(
+std::unique_ptr<TransactionRerunPolicy> DefaultRunTransactionRerunPolicy() {
+  return LimitedTimeTransactionRerunPolicy(
              /*maximum_duration=*/std::chrono::minutes(10))
       .clone();
 }

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -430,11 +430,11 @@ namespace internal {
 StatusOr<CommitResult> RunTransactionWithPolicies(
     Client client, Transaction::ReadWriteOptions const& opts,
     std::function<StatusOr<Mutations>(Client, Transaction)> const& f,
-    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<TransactionReRunPolicy> re_run_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy);
 
-/// The default retry policy for RunTransaction()
-std::unique_ptr<RetryPolicy> DefaultRunTransactionRetryPolicy();
+/// The default re-run policy for RunTransaction()
+std::unique_ptr<TransactionReRunPolicy> DefaultRunTransactionReRunPolicy();
 
 /// The default backoff policy for RunTransaction()
 std::unique_ptr<BackoffPolicy> DefaultRunTransactionBackoffPolicy();
@@ -459,7 +459,7 @@ inline StatusOr<CommitResult> RunTransaction(
     std::function<StatusOr<Mutations>(Client, Transaction)> f) {
   return internal::RunTransactionWithPolicies(
       std::move(client), opts, std::move(f),
-      internal::DefaultRunTransactionRetryPolicy(),
+      internal::DefaultRunTransactionReRunPolicy(),
       internal::DefaultRunTransactionBackoffPolicy());
 }
 

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -430,11 +430,11 @@ namespace internal {
 StatusOr<CommitResult> RunTransactionWithPolicies(
     Client client, Transaction::ReadWriteOptions const& opts,
     std::function<StatusOr<Mutations>(Client, Transaction)> const& f,
-    std::unique_ptr<TransactionReRunPolicy> re_run_policy,
+    std::unique_ptr<TransactionRerunPolicy> rerun_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy);
 
-/// The default re-run policy for RunTransaction()
-std::unique_ptr<TransactionReRunPolicy> DefaultRunTransactionReRunPolicy();
+/// The default rerun policy for RunTransaction()
+std::unique_ptr<TransactionRerunPolicy> DefaultRunTransactionRerunPolicy();
 
 /// The default backoff policy for RunTransaction()
 std::unique_ptr<BackoffPolicy> DefaultRunTransactionBackoffPolicy();
@@ -459,7 +459,7 @@ inline StatusOr<CommitResult> RunTransaction(
     std::function<StatusOr<Mutations>(Client, Transaction)> f) {
   return internal::RunTransactionWithPolicies(
       std::move(client), opts, std::move(f),
-      internal::DefaultRunTransactionReRunPolicy(),
+      internal::DefaultRunTransactionRerunPolicy(),
       internal::DefaultRunTransactionBackoffPolicy());
 }
 

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -568,7 +568,7 @@ TEST(ClientTest, RunTransaction_TooManyFailures) {
   // so the unit tests run faster.
   auto result = internal::RunTransactionWithPolicies(
       client, Transaction::ReadWriteOptions{}, f,
-      LimitedErrorCountTransactionReRunPolicy(2).clone(),
+      LimitedErrorCountTransactionRerunPolicy(2).clone(),
       ExponentialBackoffPolicy(std::chrono::microseconds(10),
                                std::chrono::microseconds(10), 2.0)
           .clone());

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -568,7 +568,7 @@ TEST(ClientTest, RunTransaction_TooManyFailures) {
   // so the unit tests run faster.
   auto result = internal::RunTransactionWithPolicies(
       client, Transaction::ReadWriteOptions{}, f,
-      LimitedErrorCountRetryPolicy(2).clone(),
+      LimitedErrorCountTransactionReRunPolicy(2).clone(),
       ExponentialBackoffPolicy(std::chrono::microseconds(10),
                                std::chrono::microseconds(10), 2.0)
           .clone());

--- a/google/cloud/spanner/internal/retry_loop_test.cc
+++ b/google/cloud/spanner/internal/retry_loop_test.cc
@@ -69,7 +69,7 @@ TEST(RetryLoopTest, ReturnJustStatus) {
       TestRetryPolicy(), TestBackoffPolicy(), true,
       [&counter](grpc::ClientContext&, int) {
         if (++counter <= 3) {
-          return Status(StatusCode::kAborted, "nothing done");
+          return Status(StatusCode::kResourceExhausted, "slow-down");
         }
         return Status();
       },

--- a/google/cloud/spanner/retry_policy.h
+++ b/google/cloud/spanner/retry_policy.h
@@ -28,8 +28,24 @@ namespace internal {
 /// Define the gRPC status code semantics for retrying requests.
 struct SafeGrpcRetry {
   static inline bool IsTransientFailure(google::cloud::StatusCode code) {
-    return code == StatusCode::kAborted || code == StatusCode::kUnavailable ||
-           code == StatusCode::kDeadlineExceeded;
+    return code == StatusCode::kUnavailable ||
+           code == StatusCode::kResourceExhausted;
+  }
+  static inline bool IsOk(google::cloud::Status const& status) {
+    return status.ok();
+  }
+  static inline bool IsTransientFailure(google::cloud::Status const& status) {
+    return IsTransientFailure(status.code());
+  }
+  static inline bool IsPermanentFailure(google::cloud::Status const& status) {
+    return !IsOk(status) && !IsTransientFailure(status);
+  }
+};
+
+/// Define the gRPC status code semantics for rerunning transactions.
+struct SafeTransactionReRun {
+  static inline bool IsTransientFailure(google::cloud::StatusCode code) {
+    return code == StatusCode::kAborted;
   }
   static inline bool IsOk(google::cloud::Status const& status) {
     return status.ok();
@@ -57,6 +73,21 @@ using LimitedTimeRetryPolicy =
 using LimitedErrorCountRetryPolicy =
     google::cloud::internal::LimitedErrorCountRetryPolicy<
         google::cloud::Status, internal::SafeGrpcRetry>;
+
+/// The base class for transaction re-run policies.
+using TransactionReRunPolicy =
+    google::cloud::internal::RetryPolicy<google::cloud::Status,
+                                         internal::SafeTransactionReRun>;
+
+/// A transaction re-run policy that limits the duration of the re-run loop.
+using LimitedTimeTransactionReRunPolicy =
+    google::cloud::internal::LimitedTimeRetryPolicy<
+        google::cloud::Status, internal::SafeTransactionReRun>;
+
+/// A transaction re-run policy that limits the number of failures.
+using LimitedErrorCountTransactionReRunPolicy =
+    google::cloud::internal::LimitedErrorCountRetryPolicy<
+        google::cloud::Status, internal::SafeTransactionReRun>;
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/retry_policy.h
+++ b/google/cloud/spanner/retry_policy.h
@@ -43,7 +43,7 @@ struct SafeGrpcRetry {
 };
 
 /// Define the gRPC status code semantics for rerunning transactions.
-struct SafeTransactionReRun {
+struct SafeTransactionRerun {
   static inline bool IsTransientFailure(google::cloud::StatusCode code) {
     return code == StatusCode::kAborted;
   }
@@ -74,20 +74,20 @@ using LimitedErrorCountRetryPolicy =
     google::cloud::internal::LimitedErrorCountRetryPolicy<
         google::cloud::Status, internal::SafeGrpcRetry>;
 
-/// The base class for transaction re-run policies.
-using TransactionReRunPolicy =
+/// The base class for transaction rerun policies.
+using TransactionRerunPolicy =
     google::cloud::internal::RetryPolicy<google::cloud::Status,
-                                         internal::SafeTransactionReRun>;
+                                         internal::SafeTransactionRerun>;
 
-/// A transaction re-run policy that limits the duration of the re-run loop.
-using LimitedTimeTransactionReRunPolicy =
+/// A transaction rerun policy that limits the duration of the rerun loop.
+using LimitedTimeTransactionRerunPolicy =
     google::cloud::internal::LimitedTimeRetryPolicy<
-        google::cloud::Status, internal::SafeTransactionReRun>;
+        google::cloud::Status, internal::SafeTransactionRerun>;
 
-/// A transaction re-run policy that limits the number of failures.
-using LimitedErrorCountTransactionReRunPolicy =
+/// A transaction rerun policy that limits the number of failures.
+using LimitedErrorCountTransactionRerunPolicy =
     google::cloud::internal::LimitedErrorCountRetryPolicy<
-        google::cloud::Status, internal::SafeTransactionReRun>;
+        google::cloud::Status, internal::SafeTransactionRerun>;
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/retry_policy_test.cc
+++ b/google/cloud/spanner/retry_policy_test.cc
@@ -35,17 +35,17 @@ TEST(RetryPolicyTest, PermanentFailure) {
       Status(StatusCode::kPermissionDenied, "uh oh")));
 }
 
-TEST(TransactionReRunPolicyTest, PermanentFailure) {
-  EXPECT_FALSE(internal::SafeTransactionReRun::IsPermanentFailure(Status()));
-  EXPECT_FALSE(internal::SafeTransactionReRun::IsPermanentFailure(
+TEST(TransactionRerunPolicyTest, PermanentFailure) {
+  EXPECT_FALSE(internal::SafeTransactionRerun::IsPermanentFailure(Status()));
+  EXPECT_FALSE(internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kAborted, "nothing done")));
-  EXPECT_TRUE(internal::SafeTransactionReRun::IsPermanentFailure(
+  EXPECT_TRUE(internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kUnavailable, "try again")));
-  EXPECT_TRUE(internal::SafeTransactionReRun::IsPermanentFailure(
+  EXPECT_TRUE(internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kResourceExhausted, "slow down please")));
-  EXPECT_TRUE(internal::SafeTransactionReRun::IsPermanentFailure(
+  EXPECT_TRUE(internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kDeadlineExceeded, "not enough time")));
-  EXPECT_TRUE(internal::SafeTransactionReRun::IsPermanentFailure(
+  EXPECT_TRUE(internal::SafeTransactionRerun::IsPermanentFailure(
       Status(StatusCode::kPermissionDenied, "uh oh")));
 }
 

--- a/google/cloud/spanner/retry_policy_test.cc
+++ b/google/cloud/spanner/retry_policy_test.cc
@@ -24,12 +24,28 @@ namespace {
 TEST(RetryPolicyTest, PermanentFailure) {
   EXPECT_FALSE(internal::SafeGrpcRetry::IsPermanentFailure(Status()));
   EXPECT_FALSE(internal::SafeGrpcRetry::IsPermanentFailure(
-      Status(StatusCode::kAborted, "nothing done")));
-  EXPECT_FALSE(internal::SafeGrpcRetry::IsPermanentFailure(
       Status(StatusCode::kUnavailable, "try again")));
   EXPECT_FALSE(internal::SafeGrpcRetry::IsPermanentFailure(
+      Status(StatusCode::kResourceExhausted, "slow down please")));
+  EXPECT_TRUE(internal::SafeGrpcRetry::IsPermanentFailure(
       Status(StatusCode::kDeadlineExceeded, "not enough time")));
   EXPECT_TRUE(internal::SafeGrpcRetry::IsPermanentFailure(
+      Status(StatusCode::kAborted, "nothing done")));
+  EXPECT_TRUE(internal::SafeGrpcRetry::IsPermanentFailure(
+      Status(StatusCode::kPermissionDenied, "uh oh")));
+}
+
+TEST(TransactionReRunPolicyTest, PermanentFailure) {
+  EXPECT_FALSE(internal::SafeTransactionReRun::IsPermanentFailure(Status()));
+  EXPECT_FALSE(internal::SafeTransactionReRun::IsPermanentFailure(
+      Status(StatusCode::kAborted, "nothing done")));
+  EXPECT_TRUE(internal::SafeTransactionReRun::IsPermanentFailure(
+      Status(StatusCode::kUnavailable, "try again")));
+  EXPECT_TRUE(internal::SafeTransactionReRun::IsPermanentFailure(
+      Status(StatusCode::kResourceExhausted, "slow down please")));
+  EXPECT_TRUE(internal::SafeTransactionReRun::IsPermanentFailure(
+      Status(StatusCode::kDeadlineExceeded, "not enough time")));
+  EXPECT_TRUE(internal::SafeTransactionReRun::IsPermanentFailure(
       Status(StatusCode::kPermissionDenied, "uh oh")));
 }
 


### PR DESCRIPTION
We only want to retry requests on kUnavailable and kResourceExhausted,
and we want to re-run transactions only on kAborted.

Fixes #666 and fixes #529

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/667)
<!-- Reviewable:end -->
