### PR TITLE
feat: implement remaining stubs on InstanceAdminClient.

### DIFF
--- a/google/cloud/spanner/internal/instance_admin_logging.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging.cc
@@ -33,6 +33,36 @@ StatusOr<gcsa::Instance> InstanceAdminLogging::GetInstance(
       context, request, __func__);
 }
 
+StatusOr<google::longrunning::Operation> InstanceAdminLogging::CreateInstance(
+    grpc::ClientContext& context, gcsa::CreateInstanceRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             gcsa::CreateInstanceRequest const& request) {
+        return child_->CreateInstance(context, request);
+      },
+      context, request, __func__);
+}
+
+StatusOr<google::longrunning::Operation> InstanceAdminLogging::UpdateInstance(
+    grpc::ClientContext& context, gcsa::UpdateInstanceRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             gcsa::UpdateInstanceRequest const& request) {
+        return child_->UpdateInstance(context, request);
+      },
+      context, request, __func__);
+}
+
+Status InstanceAdminLogging::DeleteInstance(
+    grpc::ClientContext& context, gcsa::DeleteInstanceRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             gcsa::DeleteInstanceRequest const& request) {
+        return child_->DeleteInstance(context, request);
+      },
+      context, request, __func__);
+}
+
 StatusOr<gcsa::InstanceConfig> InstanceAdminLogging::GetInstanceConfig(
     grpc::ClientContext& context,
     gcsa::GetInstanceConfigRequest const& request) {

--- a/google/cloud/spanner/internal/instance_admin_logging.h
+++ b/google/cloud/spanner/internal/instance_admin_logging.h
@@ -45,6 +45,15 @@ class InstanceAdminLogging : public InstanceAdminStub {
   StatusOr<gcsa::Instance> GetInstance(
       grpc::ClientContext&, gcsa::GetInstanceRequest const&) override;
 
+  StatusOr<google::longrunning::Operation> CreateInstance(
+      grpc::ClientContext&, gcsa::CreateInstanceRequest const&) override;
+
+  StatusOr<google::longrunning::Operation> UpdateInstance(
+      grpc::ClientContext&, gcsa::UpdateInstanceRequest const&) override;
+
+  Status DeleteInstance(grpc::ClientContext&,
+                        gcsa::DeleteInstanceRequest const&) override;
+
   StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
       grpc::ClientContext&, gcsa::GetInstanceConfigRequest const&) override;
 

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -77,6 +77,45 @@ TEST_F(InstanceAdminLoggingTest, GetInstance) {
   HasLogLineWith(TransientError().message());
 }
 
+TEST_F(InstanceAdminLoggingTest, CreateInstance) {
+  EXPECT_CALL(*mock_, CreateInstance(_, _)).WillOnce(Return(TransientError()));
+
+  InstanceAdminLogging stub(mock_);
+
+  grpc::ClientContext context;
+  auto response = stub.CreateInstance(context, gcsa::CreateInstanceRequest{});
+  EXPECT_EQ(TransientError(), response.status());
+
+  HasLogLineWith("CreateInstance");
+  HasLogLineWith(TransientError().message());
+}
+
+TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
+  EXPECT_CALL(*mock_, UpdateInstance(_, _)).WillOnce(Return(TransientError()));
+
+  InstanceAdminLogging stub(mock_);
+
+  grpc::ClientContext context;
+  auto response = stub.UpdateInstance(context, gcsa::UpdateInstanceRequest{});
+  EXPECT_EQ(TransientError(), response.status());
+
+  HasLogLineWith("UpdateInstance");
+  HasLogLineWith(TransientError().message());
+}
+
+TEST_F(InstanceAdminLoggingTest, DeleteInstance) {
+  EXPECT_CALL(*mock_, DeleteInstance(_, _)).WillOnce(Return(TransientError()));
+
+  InstanceAdminLogging stub(mock_);
+
+  grpc::ClientContext context;
+  auto status = stub.DeleteInstance(context, gcsa::DeleteInstanceRequest{});
+  EXPECT_EQ(TransientError(), status);
+
+  HasLogLineWith("DeleteInstance");
+  HasLogLineWith(TransientError().message());
+}
+
 TEST_F(InstanceAdminLoggingTest, GetInstanceConfig) {
   EXPECT_CALL(*mock_, GetInstanceConfig(_, _))
       .WillOnce(Return(TransientError()));

--- a/google/cloud/spanner/internal/instance_admin_metadata.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata.cc
@@ -41,7 +41,7 @@ StatusOr<google::longrunning::Operation> InstanceAdminMetadata::CreateInstance(
 
 StatusOr<google::longrunning::Operation> InstanceAdminMetadata::UpdateInstance(
     grpc::ClientContext& context, gcsa::UpdateInstanceRequest const& request) {
-  SetMetadata(context, "instance=" + request.instance().name());
+  SetMetadata(context, "instance.name=" + request.instance().name());
   return child_->UpdateInstance(context, request);
 }
 

--- a/google/cloud/spanner/internal/instance_admin_metadata.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata.cc
@@ -33,6 +33,24 @@ StatusOr<gcsa::Instance> InstanceAdminMetadata::GetInstance(
   return child_->GetInstance(context, request);
 }
 
+StatusOr<google::longrunning::Operation> InstanceAdminMetadata::CreateInstance(
+    grpc::ClientContext& context, gcsa::CreateInstanceRequest const& request) {
+  SetMetadata(context, "parent=" + request.parent());
+  return child_->CreateInstance(context, request);
+}
+
+StatusOr<google::longrunning::Operation> InstanceAdminMetadata::UpdateInstance(
+    grpc::ClientContext& context, gcsa::UpdateInstanceRequest const& request) {
+  SetMetadata(context, "instance=" + request.instance().name());
+  return child_->UpdateInstance(context, request);
+}
+
+Status InstanceAdminMetadata::DeleteInstance(
+    grpc::ClientContext& context, gcsa::DeleteInstanceRequest const& request) {
+  SetMetadata(context, "name=" + request.name());
+  return child_->DeleteInstance(context, request);
+}
+
 StatusOr<gcsa::InstanceConfig> InstanceAdminMetadata::GetInstanceConfig(
     grpc::ClientContext& context,
     gcsa::GetInstanceConfigRequest const& request) {

--- a/google/cloud/spanner/internal/instance_admin_metadata.h
+++ b/google/cloud/spanner/internal/instance_admin_metadata.h
@@ -42,6 +42,15 @@ class InstanceAdminMetadata : public InstanceAdminStub {
   StatusOr<gcsa::Instance> GetInstance(
       grpc::ClientContext&, gcsa::GetInstanceRequest const&) override;
 
+  StatusOr<google::longrunning::Operation> CreateInstance(
+      grpc::ClientContext&, gcsa::CreateInstanceRequest const&) override;
+
+  StatusOr<google::longrunning::Operation> UpdateInstance(
+      grpc::ClientContext&, gcsa::UpdateInstanceRequest const&) override;
+
+  Status DeleteInstance(grpc::ClientContext&,
+                        gcsa::DeleteInstanceRequest const&) override;
+
   StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
       grpc::ClientContext&, gcsa::GetInstanceConfigRequest const&) override;
 

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -112,6 +112,68 @@ TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
   EXPECT_EQ(TransientError(), response.status());
 }
 
+TEST_F(InstanceAdminMetadataTest, CreateInstance) {
+  EXPECT_CALL(*mock_, CreateInstance(_, _))
+      .WillOnce(Invoke([this](grpc::ClientContext& context,
+                              gcsa::CreateInstanceRequest const&) {
+        EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
+            context,
+            "google.spanner.admin.instance.v1.InstanceAdmin."
+            "CreateInstance",
+            expected_api_client_header_));
+        return TransientError();
+      }));
+
+  InstanceAdminMetadata stub(mock_);
+  grpc::ClientContext context;
+  gcsa::CreateInstanceRequest request;
+  request.set_parent("projects/test-project-id");
+  request.set_instance_id("test-instance-id");
+  auto response = stub.CreateInstance(context, request);
+  EXPECT_EQ(TransientError(), response.status());
+}
+
+TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
+  EXPECT_CALL(*mock_, UpdateInstance(_, _))
+      .WillOnce(Invoke([this](grpc::ClientContext& context,
+                              gcsa::UpdateInstanceRequest const&) {
+        EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
+            context,
+            "google.spanner.admin.instance.v1.InstanceAdmin."
+            "UpdateInstance",
+            expected_api_client_header_));
+        return TransientError();
+      }));
+
+  InstanceAdminMetadata stub(mock_);
+  grpc::ClientContext context;
+  gcsa::UpdateInstanceRequest request;
+  request.mutable_instance()->set_name(
+      "projects/test-project-id/instances/test-instance-id");
+  auto response = stub.UpdateInstance(context, request);
+  EXPECT_EQ(TransientError(), response.status());
+}
+
+TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
+  EXPECT_CALL(*mock_, DeleteInstance(_, _))
+      .WillOnce(Invoke([this](grpc::ClientContext& context,
+                              gcsa::DeleteInstanceRequest const&) {
+        EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
+            context,
+            "google.spanner.admin.instance.v1.InstanceAdmin."
+            "DeleteInstance",
+            expected_api_client_header_));
+        return TransientError();
+      }));
+
+  InstanceAdminMetadata stub(mock_);
+  grpc::ClientContext context;
+  gcsa::DeleteInstanceRequest request;
+  request.set_name("projects/test-project-id/instances/test-instance-id");
+  auto status = stub.DeleteInstance(context, request);
+  EXPECT_EQ(TransientError(), status);
+}
+
 TEST_F(InstanceAdminMetadataTest, ListInstances) {
   EXPECT_CALL(*mock_, ListInstances(_, _))
       .WillOnce(Invoke([this](grpc::ClientContext& context,

--- a/google/cloud/spanner/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/internal/instance_admin_stub.cc
@@ -51,6 +51,41 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
     return response;
   }
 
+  StatusOr<google::longrunning::Operation> CreateInstance(
+      grpc::ClientContext& context,
+      gcsa::CreateInstanceRequest const& request) override {
+    google::longrunning::Operation response;
+    grpc::Status status =
+        instance_admin_->CreateInstance(&context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::grpc_utils::MakeStatusFromRpcError(status);
+    }
+    return response;
+  }
+
+  StatusOr<google::longrunning::Operation> UpdateInstance(
+      grpc::ClientContext& context,
+      gcsa::UpdateInstanceRequest const& request) override {
+    google::longrunning::Operation response;
+    grpc::Status status =
+        instance_admin_->UpdateInstance(&context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::grpc_utils::MakeStatusFromRpcError(status);
+    }
+    return response;
+  }
+
+  Status DeleteInstance(grpc::ClientContext& context,
+                        gcsa::DeleteInstanceRequest const& request) override {
+    google::protobuf::Empty response;
+    grpc::Status status =
+        instance_admin_->DeleteInstance(&context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::grpc_utils::MakeStatusFromRpcError(status);
+    }
+    return google::cloud::Status();
+  }
+
   StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
       grpc::ClientContext& context,
       gcsa::GetInstanceConfigRequest const& request) override {

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_INSTANCE_ADMIN_STUB_H_
 
 #include "google/cloud/spanner/connection_options.h"
+#include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>
 
@@ -36,6 +37,15 @@ class InstanceAdminStub {
 
   virtual StatusOr<gcsa::Instance> GetInstance(
       grpc::ClientContext&, gcsa::GetInstanceRequest const&) = 0;
+
+  virtual StatusOr<google::longrunning::Operation> CreateInstance(
+      grpc::ClientContext&, gcsa::CreateInstanceRequest const&) = 0;
+
+  virtual StatusOr<google::longrunning::Operation> UpdateInstance(
+      grpc::ClientContext&, gcsa::UpdateInstanceRequest const&) = 0;
+
+  virtual Status DeleteInstance(grpc::ClientContext&,
+                                gcsa::DeleteInstanceRequest const&) = 0;
 
   virtual StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
       grpc::ClientContext&, gcsa::GetInstanceConfigRequest const&) = 0;

--- a/google/cloud/spanner/testing/mock_instance_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_instance_admin_stub.h
@@ -31,6 +31,14 @@ class MockInstanceAdminStub
   MOCK_METHOD2(GetInstance,
                StatusOr<gcsa::Instance>(grpc::ClientContext&,
                                         gcsa::GetInstanceRequest const&));
+  MOCK_METHOD2(CreateInstance,
+               StatusOr<google::longrunning::Operation>(
+                   grpc::ClientContext&, gcsa::CreateInstanceRequest const&));
+  MOCK_METHOD2(UpdateInstance,
+               StatusOr<google::longrunning::Operation>(
+                   grpc::ClientContext&, gcsa::UpdateInstanceRequest const&));
+  MOCK_METHOD2(DeleteInstance, Status(grpc::ClientContext&,
+                                      gcsa::DeleteInstanceRequest const&));
   MOCK_METHOD2(GetInstanceConfig, StatusOr<gcsa::InstanceConfig>(
                                       grpc::ClientContext&,
                                       gcsa::GetInstanceConfigRequest const&));


### PR DESCRIPTION
Adding remaining stubs first before working on the higher layer because it's easier to write integration tests at once with the later PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/690)
<!-- Reviewable:end -->
