### PR TITLE
cleanup: wrap PartialResultSet streaming RPC

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -147,6 +147,7 @@ add_library(spanner_client
             internal/merge_chunk.h
             internal/metadata_spanner_stub.cc
             internal/metadata_spanner_stub.h
+            internal/partial_result_set_reader.h
             internal/partial_result_set_source.cc
             internal/partial_result_set_source.h
             internal/polling_loop.h

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/grpc_utils/grpc_error_delegate.h"
 #include "google/cloud/internal/make_unique.h"
 #include <google/spanner/v1/spanner.pb.h>
+#include <memory>
 
 namespace google {
 namespace cloud {
@@ -199,7 +200,6 @@ StatusOr<ResultSet> ConnectionImpl::ReadImpl(
   auto rpc =
       google::cloud::internal::make_unique<DefaultPartialResultSetReader>(
           std::move(context), stub_->StreamingRead(*context, request));
-
   auto reader = PartialResultSetSource::Create(std::move(rpc));
   if (!reader.ok()) {
     return std::move(reader).status();

--- a/google/cloud/spanner/internal/partial_result_set_reader.h
+++ b/google/cloud/spanner/internal/partial_result_set_reader.h
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_PARTIAL_RESULT_SET_READER_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_PARTIAL_RESULT_SET_READER_H_
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/optional.h"
+#include <google/spanner/v1/spanner.grpc.pb.h>
+#include <google/spanner/v1/spanner.pb.h>
+#include <grpcpp/grpcpp.h>
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+
+/**
+ * Wrap grpc::ClientReaderInterface<google::spanner::v1::PartialResultSet>.
+ *
+ * This defines an interface to handle a streaming RPC returning a sequence of
+ * `google::spanner::v1::PartialResultSet`. Its main purpose is to simplify
+ * memory management, as each streaming RPC requires two separate
+ * `std::unique_ptr<>`. As a side-effect, it is easier to mock this class, as
+ * it has a narrower interface.
+ */
+class PartialResultSetReader {
+ public:
+  virtual ~PartialResultSetReader() = default;
+  virtual void TryCancel() = 0;
+  virtual optional<google::spanner::v1::PartialResultSet> Read() = 0;
+  virtual Status Finish() = 0;
+};
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_PARTIAL_RESULT_SET_READER_H_

--- a/google/cloud/spanner/internal/partial_result_set_reader.h
+++ b/google/cloud/spanner/internal/partial_result_set_reader.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/optional.h"
+#include "google/cloud/status.h"
 #include <google/spanner/v1/spanner.grpc.pb.h>
 #include <google/spanner/v1/spanner.pb.h>
 #include <grpcpp/grpcpp.h>

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/spanner/internal/partial_result_set_source.h"
 #include "google/cloud/spanner/internal/merge_chunk.h"
-#include "google/cloud/grpc_utils/grpc_error_delegate.h"
 #include "google/cloud/log.h"
 
 namespace google {
@@ -24,30 +23,29 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
 StatusOr<std::unique_ptr<PartialResultSetSource>>
-PartialResultSetSource::Create(std::unique_ptr<grpc::ClientContext> context,
-                               std::unique_ptr<GrpcReader> grpc_reader) {
-  std::unique_ptr<PartialResultSetSource> reader(
-      new PartialResultSetSource(std::move(context), std::move(grpc_reader)));
+PartialResultSetSource::Create(std::unique_ptr<PartialResultSetReader> reader) {
+  std::unique_ptr<PartialResultSetSource> source(
+      new PartialResultSetSource(std::move(reader)));
 
   // Do the first read so the metadata is immediately available.
-  auto status = reader->ReadFromStream();
+  auto status = source->ReadFromStream();
   if (!status.ok()) {
     return status;
   }
 
   // The first response must contain metadata.
-  if (!reader->metadata_.has_value()) {
+  if (!source->last_result_.has_metadata()) {
     return Status(StatusCode::kInternal, "response contained no metadata");
   }
 
-  return {std::move(reader)};
+  return {std::move(source)};
 }
 
 StatusOr<optional<Value>> PartialResultSetSource::NextValue() {
   if (finished_) {
     return optional<Value>();
   }
-  while (next_value_index_ >= values_.size()) {
+  while (next_value_index_ >= last_result_.values_size()) {
     // Ran out of buffered values - try to read some more from gRPC.
     next_value_index_ = 0;
     auto status = ReadFromStream();
@@ -65,20 +63,21 @@ StatusOr<optional<Value>> PartialResultSetSource::NextValue() {
     // continue reading until we do get at least one value.
   }
 
-  if (metadata_->row_type().fields().empty()) {
+  if (last_result_.metadata().row_type().fields().empty()) {
     return Status(StatusCode::kInternal,
                   "response metadata is missing row type information");
   }
 
   // The metadata tells us the sequence of types for the field Values;
   // when we reach the end of the sequence start over at the beginning.
-  auto const& fields = metadata_->row_type().fields();
+  auto const& fields = last_result_.metadata().row_type().fields();
   if (next_value_type_index_ >= fields.size()) {
     next_value_type_index_ = 0;
   }
 
-  return {FromProto(fields.Get(next_value_type_index_++).type(),
-                    std::move(*values_.Mutable(next_value_index_++)))};
+  return {
+      FromProto(fields.Get(next_value_type_index_++).type(),
+                std::move(*last_result_.mutable_values(next_value_index_++)))};
 }
 
 PartialResultSetSource::~PartialResultSetSource() {
@@ -86,47 +85,45 @@ PartialResultSetSource::~PartialResultSetSource() {
     // If there is actual data in the streaming RPC Finish() can deadlock, so
     // before trying to read the final status we need to cancel the streaming
     // RPC.
-    context_->TryCancel();
+    reader_->TryCancel();
     // The user didn't iterate over all the data; finish the stream on their
     // behalf, but we have no way to communicate error status.
-    grpc::Status finish_status = grpc_reader_->Finish();
-    if (!finish_status.ok() &&
-        finish_status.error_code() != grpc::StatusCode::CANCELLED) {
-      GCP_LOG(WARNING) << "Finish() failed in destructor: "
-                       << grpc_utils::MakeStatusFromRpcError(finish_status);
+    auto finish_status = reader_->Finish();
+    if (!finish_status.ok() && finish_status.code() != StatusCode::kCancelled) {
+      GCP_LOG(WARNING) << "Finish() failed in destructor: " << finish_status;
     }
   }
 }
 
 Status PartialResultSetSource::ReadFromStream() {
-  google::spanner::v1::PartialResultSet result_set;
-  if (!grpc_reader_->Read(&result_set)) {
+  auto result_set = reader_->Read();
+  if (!result_set) {
     // Read() returns false for end of stream, whether we read all the data or
     // encountered an error. Finish() tells us the status.
     finished_ = true;
-    grpc::Status finish_status = grpc_reader_->Finish();
-    return grpc_utils::MakeStatusFromRpcError(finish_status);
+    return reader_->Finish();
   }
 
-  if (result_set.has_metadata()) {
-    if (!metadata_.has_value()) {
-      metadata_ = std::move(*result_set.mutable_metadata());
+  if (result_set->has_metadata()) {
+    if (!last_result_.has_metadata()) {
+      last_result_.mutable_metadata()->Swap(result_set->mutable_metadata());
     } else {
       GCP_LOG(WARNING) << "Unexpectedly received two sets of metadata";
     }
   }
 
-  if (result_set.has_stats()) {
+  if (result_set->has_stats()) {
     // We should only get stats once; if not, use the last one.
-    if (stats_.has_value()) {
+    if (last_result_.has_stats()) {
       GCP_LOG(WARNING) << "Unexpectedly received two sets of stats";
     }
-    stats_ = std::move(*result_set.mutable_stats());
+    last_result_.mutable_stats()->Swap(result_set->mutable_stats());
   }
 
-  // TODO(#271) store and use resume_token.
+  last_result_.mutable_resume_token()->swap(
+      *result_set->mutable_resume_token());
 
-  values_.Swap(result_set.mutable_values());
+  last_result_.mutable_values()->Swap(result_set->mutable_values());
 
   // Merge values if necessary, as described in:
   // https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.PartialResultSet
@@ -150,19 +147,19 @@ Status PartialResultSetSource::ReadFromStream() {
   // contains the partial value from that response; merge it with the first
   // value in this response and set the first entry in `values_` to the result.
   if (partial_chunked_value_.has_value()) {
-    if (values_.empty()) {
+    if (last_result_.values().empty()) {
       return Status(StatusCode::kInternal,
                     "PartialResultSet contained no values to merge with prior "
                     "chunked_value");
     }
-    auto merge_status =
-        MergeChunk(*partial_chunked_value_, std::move(values_[0]));
+    auto merge_status = MergeChunk(*partial_chunked_value_,
+                                   std::move(*last_result_.mutable_values(0)));
     if (!merge_status.ok()) {
       return merge_status;
     }
     // Move the merged value to the front of the array and make
     // `partial_chunked_value_` empty.
-    values_[0] = *std::move(partial_chunked_value_);
+    *last_result_.mutable_values(0) = *std::move(partial_chunked_value_);
     partial_chunked_value_.reset();
   }
 
@@ -170,14 +167,15 @@ Status PartialResultSetSource::ReadFromStream() {
   // and needs to be merged with the first value in the *next* response. Move it
   // into `partial_chunked_value_`; this ensures everything in `values_` is a
   // complete value, which simplifies things elsewhere.
-  if (result_set.chunked_value()) {
-    if (values_.empty()) {
+  if (result_set->chunked_value()) {
+    if (last_result_.values().empty()) {
       return Status(StatusCode::kInternal,
                     "PartialResultSet had chunked_value set true but contained "
                     "no values");
     }
-    partial_chunked_value_ = std::move(values_[values_.size() - 1]);
-    values_.RemoveLast();
+    auto& values = *last_result_.mutable_values();
+    partial_chunked_value_ = std::move(values[values.size() - 1]);
+    values.RemoveLast();
   }
   return Status();
 }

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -191,7 +191,8 @@ StatusOr<spanner_proto::ResultSet> DefaultSpannerStub::Read(
   return response;
 }
 
-std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
+std::unique_ptr<
+    grpc::ClientReaderInterface<google::spanner::v1::PartialResultSet>>
 DefaultSpannerStub::StreamingRead(grpc::ClientContext& client_context,
                                   spanner_proto::ReadRequest const& request) {
   return grpc_stub_->StreamingRead(&client_context, request);

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -191,8 +191,7 @@ StatusOr<spanner_proto::ResultSet> DefaultSpannerStub::Read(
   return response;
 }
 
-std::unique_ptr<
-    grpc::ClientReaderInterface<google::spanner::v1::PartialResultSet>>
+std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
 DefaultSpannerStub::StreamingRead(grpc::ClientContext& client_context,
                                   spanner_proto::ReadRequest const& request) {
   return grpc_stub_->StreamingRead(&client_context, request);

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -46,6 +46,7 @@ spanner_client_hdrs = [
     "internal/logging_spanner_stub.h",
     "internal/merge_chunk.h",
     "internal/metadata_spanner_stub.h",
+    "internal/partial_result_set_reader.h",
     "internal/partial_result_set_source.h",
     "internal/polling_loop.h",
     "internal/range_from_pagination.h",


### PR DESCRIPTION
Wrapping the `grpc::ClientReadInterface<>` makes it easier to write
tests and to then refactor the code to do retries.

Part of the work for #271

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/692)
<!-- Reviewable:end -->
