### PR TITLE
feat: implement CreateInstance and DeleteInstance on InstanceAdminClient

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -162,6 +162,7 @@ elif [[ "${BUILD_NAME}" = "coverage" ]]; then
   export DISTRO=fedora-install
   export DISTRO_VERSION=30
   : "${RUN_INTEGRATION_TESTS:=$DEFAULT_RUN_INTEGRATION_TESTS}"
+  export RUN_SLOW_INTEGRATION_TESTS=yes
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "bazel-dependency" ]]; then
   export DISTRO=ubuntu

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -261,6 +261,8 @@ function (spanner_client_define_tests)
                 testing/pick_random_instance.h
                 testing/random_database_name.cc
                 testing/random_database_name.h
+                testing/random_instance_name.cc
+                testing/random_instance_name.h
                 testing/validate_metadata.cc
                 testing/validate_metadata.h)
     target_link_libraries(spanner_client_testing

--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -33,6 +33,10 @@ InstanceAdminClient::CreateInstance(
                                 instance_config, node_count, labels});
 }
 
+Status InstanceAdminClient::DeleteInstance(Instance const& in) {
+  return conn_->DeleteInstance({in.FullName()});
+}
+
 StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminClient::GetInstanceConfig(std::string const& name) {
   return conn_->GetInstanceConfig({name});

--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -24,6 +24,15 @@ InstanceAdminClient::GetInstance(Instance const& in) {
   return conn_->GetInstance({in.FullName()});
 }
 
+future<StatusOr<google::spanner::admin::instance::v1::Instance>>
+InstanceAdminClient::CreateInstance(
+    std::string const& project_id, std::string const& instance_id,
+    std::string const& display_name, std::string const& instance_config,
+    int node_count, std::map<std::string, std::string> const& labels) {
+  return conn_->CreateInstance({project_id, instance_id, display_name,
+                                instance_config, node_count, labels});
+}
+
 StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminClient::GetInstanceConfig(std::string const& name) {
   return conn_->GetInstanceConfig({name});

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -107,7 +107,7 @@ class InstanceAdminClient {
    * start with a lowercase letter (`[a-z]`), it must end with a lowercase
    * letter or a number (`[a-z0-9]`) and any characters between the beginning
    * and ending characters must be lower case letters, numbers, or dashes (`-`),
-   * that is, they must belong to the `[a-z0-9-]` character set.
+   * that is, they must belong to the `[-a-z0-9]` character set.
    *
    * @par Example
    * @snippet samples.cc create-instance
@@ -119,6 +119,17 @@ class InstanceAdminClient {
                  std::string const& instance_config, int node_count,
                  std::map<std::string, std::string> const& labels =
                      std::map<std::string, std::string>());
+  /**
+   * Deletes an existing Cloud Spanner instance.
+   *
+   * @warning Deleting an instance deletes all the databases in the
+   * instance. This is an unrecoverable operation.
+   *
+   * @par Example
+   * @snippet samples.cc delete-instance
+   */
+  Status DeleteInstance(Instance const& in);
+
   /**
    * Retrieve information about a Cloud Spanner Instance Config.
    *

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -117,8 +117,7 @@ class InstanceAdminClient {
   CreateInstance(std::string const& project_id, std::string const& instance_id,
                  std::string const& display_name,
                  std::string const& instance_config, int node_count,
-                 std::map<std::string, std::string> const& labels =
-                     std::map<std::string, std::string>());
+                 std::map<std::string, std::string> const& labels = {});
   /**
    * Deletes an existing Cloud Spanner instance.
    *

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -101,6 +101,25 @@ class InstanceAdminClient {
       Instance const& in);
 
   /**
+   * Creates a new Cloud Spanner instance in the given project.
+   *
+   * Note that the instance id must be between 2 and 64 characters long, it must
+   * start with a lowercase letter (`[a-z]`), it must end with a lowercase
+   * letter or a number (`[a-z0-9]`) and any characters between the beginning
+   * and ending characters must be lower case letters, numbers, or dashes (`-`),
+   * that is, they must belong to the `[a-z0-9-]` character set.
+   *
+   * @par Example
+   * @snippet samples.cc create-instance
+   *
+   */
+  future<StatusOr<google::spanner::admin::instance::v1::Instance>>
+  CreateInstance(std::string const& project_id, std::string const& instance_id,
+                 std::string const& display_name,
+                 std::string const& instance_config, int node_count,
+                 std::map<std::string, std::string> const& labels =
+                     std::map<std::string, std::string>());
+  /**
    * Retrieve information about a Cloud Spanner Instance Config.
    *
    * @par Idempotency

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -151,6 +151,18 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
     return AwaitCreateInstance(*std::move(operation));
   }
 
+  Status DeleteInstance(DeleteInstanceParams p) override {
+    gcsa::DeleteInstanceRequest request;
+    request.set_name(std::move(p.instance_name));
+    return internal::RetryLoop(
+        retry_policy_->clone(), backoff_policy_->clone(), true,
+        [this](grpc::ClientContext& context,
+               gcsa::DeleteInstanceRequest const& request) {
+          return stub_->DeleteInstance(context, request);
+        },
+        request, __func__);
+  }
+
   StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
       GetInstanceConfigParams p) override {
     gcsa::GetInstanceConfigRequest request;

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/instance_admin_connection.h"
+#include "google/cloud/spanner/internal/polling_loop.h"
 #include "google/cloud/spanner/internal/retry_loop.h"
 
 namespace google {
@@ -41,6 +42,25 @@ namespace giam = google::iam::v1;
 #define GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_BACKOFF_SCALING 2.0
 #endif  // GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_BACKOFF_SCALING
 
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_TIMEOUT
+#define GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_TIMEOUT \
+  std::chrono::minutes(30)
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_TIMEOUT
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_INITIAL_BACKOFF
+#define GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_INITIAL_BACKOFF \
+  std::chrono::seconds(10)
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_INITIAL_BACKOFF
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_MAXIMUM_BACKOFF
+#define GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_MAXIMUM_BACKOFF \
+  std::chrono::minutes(5)
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_MAXIMUM_BACKOFF
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_BACKOFF_SCALING
+#define GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_BACKOFF_SCALING 2.0
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_BACKOFF_SCALING
+
 namespace {
 
 std::unique_ptr<RetryPolicy> DefaultInstanceAdminRetryPolicy() {
@@ -57,20 +77,34 @@ std::unique_ptr<BackoffPolicy> DefaultInstanceAdminBackoffPolicy() {
       .clone();
 }
 
+std::unique_ptr<PollingPolicy> DefaultInstanceAdminPollingPolicy() {
+  return GenericPollingPolicy<>(
+             LimitedTimeRetryPolicy(
+                 GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_TIMEOUT),
+             ExponentialBackoffPolicy(
+                 GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_INITIAL_BACKOFF,
+                 GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_MAXIMUM_BACKOFF,
+                 GOOGLE_CLOUD_CPP_SPANNER_ADMIN_DEFAULT_POLLING_BACKOFF_SCALING))
+      .clone();
+}
+
 class InstanceAdminConnectionImpl : public InstanceAdminConnection {
  public:
   InstanceAdminConnectionImpl(std::shared_ptr<internal::InstanceAdminStub> stub,
                               std::unique_ptr<RetryPolicy> retry_policy,
-                              std::unique_ptr<BackoffPolicy> backoff_policy)
+                              std::unique_ptr<BackoffPolicy> backoff_policy,
+                              std::unique_ptr<PollingPolicy> polling_policy)
       : stub_(std::move(stub)),
         retry_policy_(std::move(retry_policy)),
-        backoff_policy_(std::move(backoff_policy)) {}
+        backoff_policy_(std::move(backoff_policy)),
+        polling_policy_(std::move(polling_policy)) {}
 
   explicit InstanceAdminConnectionImpl(
       std::shared_ptr<internal::InstanceAdminStub> stub)
       : InstanceAdminConnectionImpl(std::move(stub),
                                     DefaultInstanceAdminRetryPolicy(),
-                                    DefaultInstanceAdminBackoffPolicy()) {}
+                                    DefaultInstanceAdminBackoffPolicy(),
+                                    DefaultInstanceAdminPollingPolicy()) {}
 
   ~InstanceAdminConnectionImpl() override = default;
 
@@ -84,6 +118,37 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
           return stub_->GetInstance(context, request);
         },
         request, __func__);
+  }
+
+  future<StatusOr<gcsa::Instance>> CreateInstance(
+      CreateInstanceParams p) override {
+    gcsa::CreateInstanceRequest request;
+    std::string instance_name =
+        "projects/" + p.project_id + "/instances/" + p.instance_id;
+    request.set_parent("projects/" + p.project_id);
+    request.set_instance_id(std::move(p.instance_id));
+    auto instance = request.mutable_instance();
+    instance->set_config(std::move(p.instance_config));
+    instance->set_name(std::move(instance_name));
+    instance->set_display_name(std::move(p.display_name));
+    instance->set_node_count(p.node_count);
+    auto mutable_labels = instance->mutable_labels();
+    for (auto& pair : p.labels) {
+      (*mutable_labels)[pair.first] = std::move(pair.second);
+    }
+    auto operation = RetryLoop(
+        retry_policy_->clone(), backoff_policy_->clone(), false,
+        [this](grpc::ClientContext& context,
+               gcsa::CreateInstanceRequest const& request) {
+          return stub_->CreateInstance(context, request);
+        },
+        request, __func__);
+    if (!operation) {
+      return google::cloud::make_ready_future(
+          StatusOr<gcsa::Instance>(operation.status()));
+    }
+
+    return AwaitCreateInstance(*std::move(operation));
   }
 
   StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
@@ -206,9 +271,43 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   }
 
  private:
+  future<StatusOr<gcsa::Instance>> AwaitCreateInstance(
+      google::longrunning::Operation operation) {
+    promise<StatusOr<gcsa::Instance>> pr;
+    auto f = pr.get_future();
+
+    // TODO(#127) - use the (implicit) completion queue to run this loop.
+    std::thread t(
+        [](std::shared_ptr<internal::InstanceAdminStub> stub,
+           google::longrunning::Operation operation,
+           std::unique_ptr<PollingPolicy> polling_policy,
+           google::cloud::promise<StatusOr<gcsa::Instance>> promise,
+           char const* location) mutable {
+          auto result = internal::PollingLoop<
+              internal::PollingLoopResponseExtractor<gcsa::Instance>>(
+              std::move(polling_policy),
+              [stub](grpc::ClientContext& context,
+                     google::longrunning::GetOperationRequest const& request) {
+                return stub->GetOperation(context, request);
+              },
+              std::move(operation), location);
+
+          // Drop our reference to stub; ideally we'd have std::moved into the
+          // lambda. Doing this also prevents a false leak from being reported
+          // when using googlemock.
+          stub.reset();
+          promise.set_value(std::move(result));
+        },
+        stub_, std::move(operation), polling_policy_->clone(), std::move(pr),
+        __func__);
+    t.detach();
+
+    return f;
+  }
   std::shared_ptr<internal::InstanceAdminStub> stub_;
   std::unique_ptr<RetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
+  std::unique_ptr<PollingPolicy> polling_policy_;
 };
 }  // namespace
 
@@ -230,10 +329,12 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::shared_ptr<internal::InstanceAdminStub> base_stub,
-    ConnectionOptions const&, std::unique_ptr<RetryPolicy> retry_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy) {
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy,
+    std::unique_ptr<PollingPolicy> polling_policy) {
   return std::make_shared<InstanceAdminConnectionImpl>(
-      std::move(base_stub), std::move(retry_policy), std::move(backoff_policy));
+      std::move(base_stub), std::move(retry_policy), std::move(backoff_policy),
+      std::move(polling_policy));
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/instance_admin_connection.h"
+#include "google/cloud/spanner/instance.h"
 #include "google/cloud/spanner/internal/polling_loop.h"
 #include "google/cloud/spanner/internal/retry_loop.h"
 
@@ -123,13 +124,12 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   future<StatusOr<gcsa::Instance>> CreateInstance(
       CreateInstanceParams p) override {
     gcsa::CreateInstanceRequest request;
-    std::string instance_name =
-        "projects/" + p.project_id + "/instances/" + p.instance_id;
+    google::cloud::spanner::Instance in(p.project_id, p.instance_id);
     request.set_parent("projects/" + p.project_id);
     request.set_instance_id(std::move(p.instance_id));
     auto instance = request.mutable_instance();
     instance->set_config(std::move(p.instance_config));
-    instance->set_name(std::move(instance_name));
+    instance->set_name(in.FullName());
     instance->set_display_name(std::move(p.display_name));
     instance->set_node_count(p.node_count);
     auto mutable_labels = instance->mutable_labels();

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -98,6 +98,11 @@ class InstanceAdminConnection {
     std::map<std::string, std::string> labels;
   };
 
+  /// Wrap the arguments for `DeleteInstance()`.
+  struct DeleteInstanceParams {
+    std::string instance_name;
+  };
+
   /// Wrap the arguments for `GetInstanceConfig()`.
   struct GetInstanceConfigParams {
     std::string instance_config_name;
@@ -156,6 +161,8 @@ class InstanceAdminConnection {
 
   virtual future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(CreateInstanceParams p) = 0;
+
+  virtual Status DeleteInstance(DeleteInstanceParams p) = 0;
 
   /// Return the InstanceConfig with the given name.
   virtual StatusOr<google::spanner::admin::instance::v1::InstanceConfig>

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -18,8 +18,10 @@
 #include "google/cloud/spanner/backoff_policy.h"
 #include "google/cloud/spanner/internal/instance_admin_stub.h"
 #include "google/cloud/spanner/internal/range_from_pagination.h"
+#include "google/cloud/spanner/polling_policy.h"
 #include "google/cloud/spanner/retry_policy.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.grpc.pb.h>
+#include <map>
 
 namespace google {
 namespace cloud {
@@ -86,6 +88,16 @@ class InstanceAdminConnection {
     std::string instance_name;
   };
 
+  /// Wrap the arguments for `CreateInstance()`.
+  struct CreateInstanceParams {
+    std::string project_id;
+    std::string instance_id;
+    std::string display_name;
+    std::string instance_config;
+    int node_count;
+    std::map<std::string, std::string> labels;
+  };
+
   /// Wrap the arguments for `GetInstanceConfig()`.
   struct GetInstanceConfigParams {
     std::string instance_config_name;
@@ -141,6 +153,9 @@ class InstanceAdminConnection {
   /// Return the metadata for the given instance.
   virtual StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       GetInstanceParams) = 0;
+
+  virtual future<StatusOr<google::spanner::admin::instance::v1::Instance>>
+  CreateInstance(CreateInstanceParams p) = 0;
 
   /// Return the InstanceConfig with the given name.
   virtual StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
@@ -202,8 +217,10 @@ std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
 
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     std::shared_ptr<internal::InstanceAdminStub> base_stub,
-    ConnectionOptions const& options, std::unique_ptr<RetryPolicy> retry_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy);
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy,
+    std::unique_ptr<PollingPolicy> polling_policy);
+
 }  // namespace internal
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -37,13 +37,14 @@ namespace giam = ::google::iam::v1;
 
 std::shared_ptr<InstanceAdminConnection> MakeTestConnection(
     std::shared_ptr<spanner_testing::MockInstanceAdminStub> mock) {
+  LimitedErrorCountRetryPolicy retry(/*maximum_failures=*/2);
+  ExponentialBackoffPolicy backoff(
+      /*initial_delay=*/std::chrono::microseconds(1),
+      /*maximum_delay=*/std::chrono::microseconds(1),
+      /*scaling=*/2.0);
+  GenericPollingPolicy<LimitedErrorCountRetryPolicy> polling(retry, backoff);
   return internal::MakeInstanceAdminConnection(
-      std::move(mock), ConnectionOptions(),
-      LimitedErrorCountRetryPolicy(/*maximum_failures=*/2).clone(),
-      ExponentialBackoffPolicy(/*initial_delay=*/std::chrono::microseconds(1),
-                               /*maximum_delay=*/std::chrono::microseconds(1),
-                               /*scaling=*/2.0)
-          .clone());
+      std::move(mock), retry.clone(), backoff.clone(), polling.clone());
 }
 
 TEST(InstanceAdminConnectionTest, GetInstance_Success) {
@@ -99,6 +100,74 @@ TEST(InstanceAdminConnectionTest, GetInstance_TooManyTransients) {
   auto conn = MakeTestConnection(mock);
   auto actual = conn->GetInstance({"test-name"});
   EXPECT_EQ(StatusCode::kUnavailable, actual.status().code());
+}
+
+TEST(InstanceAdminClientTest, CreateInstanceSuccess) {
+  auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
+  std::string const expected_name =
+      "projects/test-project/instances/test-instance";
+
+  EXPECT_CALL(*mock, CreateInstance(_, _))
+      .WillOnce(Invoke([&expected_name](grpc::ClientContext&,
+                                        gcsa::CreateInstanceRequest const& r) {
+        EXPECT_EQ("test-instance", r.instance_id());
+        EXPECT_EQ("projects/test-project", r.parent());
+        auto const& instance = r.instance();
+        EXPECT_EQ(expected_name, instance.name());
+        EXPECT_EQ("test-instance-config", instance.config());
+        EXPECT_EQ("test-display-name", instance.display_name());
+        auto const& labels = instance.labels();
+        EXPECT_EQ(1, labels.count("key"));
+        EXPECT_EQ("value", labels.at("key"));
+        google::longrunning::Operation op;
+        op.set_name("test-operation-name");
+        op.set_done(false);
+        return make_status_or(op);
+      }));
+  EXPECT_CALL(*mock, GetOperation(_, _))
+      .WillOnce(Invoke(
+          [&expected_name](grpc::ClientContext&,
+                           google::longrunning::GetOperationRequest const& r) {
+            EXPECT_EQ("test-operation-name", r.name());
+            google::longrunning::Operation op;
+            op.set_name(r.name());
+            op.set_done(true);
+            gcsa::Instance instance;
+            instance.set_name(expected_name);
+            op.mutable_response()->PackFrom(instance);
+            return make_status_or(op);
+          }));
+
+  auto conn = MakeTestConnection(std::move(mock));
+  auto fut = conn->CreateInstance(
+      {"test-project", "test-instance", "test-display-name",
+       "test-instance-config", 1,
+       std::map<std::string, std::string>({{"key", "value"}})});
+  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
+  auto instance = fut.get();
+  EXPECT_STATUS_OK(instance);
+
+  EXPECT_EQ(expected_name, instance->name());
+}
+
+TEST(InstanceAdminClientTest, CreateInstanceError) {
+  auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
+
+  EXPECT_CALL(*mock, CreateInstance(_, _))
+      .WillOnce(
+          Invoke([](grpc::ClientContext&, gcsa::CreateInstanceRequest const&) {
+            return StatusOr<google::longrunning::Operation>(
+                Status(StatusCode::kPermissionDenied, "uh-oh"));
+          }));
+
+  auto conn = MakeTestConnection(std::move(mock));
+  auto fut = conn->CreateInstance(
+      {"test-project", "test-instance", "test-display-name",
+       "test-instance-config", 1,
+       std::map<std::string, std::string>({{"key", "value"}})});
+  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  auto instance = fut.get();
+  EXPECT_EQ(StatusCode::kPermissionDenied, instance.status().code());
 }
 
 TEST(InstanceAdminConnectionTest, GetInstanceConfig_Success) {

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -71,8 +71,8 @@ TEST(InstanceAdminClient, InstanceCRUDOperations) {
   auto project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
   auto generator = google::cloud::internal::MakeDefaultPRNG();
-  std::string instance_id = google::cloud::spanner_testing::RandomInstanceName(
-      generator, "instance-admin-crud-integration-tests-instance-");
+  std::string instance_id =
+      google::cloud::spanner_testing::RandomInstanceName(generator);
   ASSERT_FALSE(project_id.empty());
   ASSERT_FALSE(instance_id.empty());
   Instance in(project_id, instance_id);

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/spanner/testing/random_instance_name.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
@@ -26,8 +28,8 @@ namespace {
 using ::testing::HasSubstr;
 using ::testing::UnorderedElementsAre;
 
-/// @test Verify the basic CRUD operations for instances work.
-TEST(InstanceAdminClient, InstanceBasicCRUD) {
+/// @test Verify the basic read operations for instances work.
+TEST(InstanceAdminClient, InstanceReadOperations) {
   auto project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
   auto instance_id =
@@ -56,6 +58,56 @@ TEST(InstanceAdminClient, InstanceBasicCRUD) {
   }();
   EXPECT_EQ(1, std::count(instance_names.begin(), instance_names.end(),
                           instance->name()));
+}
+
+/// @test Verify the basic CRUD operations for instances work.
+TEST(InstanceAdminClient, InstanceCRUDOperations) {
+  auto run_slow_integration_tests =
+      google::cloud::internal::GetEnv("RUN_SLOW_INTEGRATION_TESTS")
+          .value_or("");
+  if (run_slow_integration_tests != "yes") {
+    GTEST_SKIP();
+  }
+  auto project_id =
+      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
+  std::string instance_id = google::cloud::spanner_testing::RandomInstanceName(
+      generator, "instance-admin-crud-integration-tests-instance-");
+  ASSERT_FALSE(project_id.empty());
+  ASSERT_FALSE(instance_id.empty());
+  Instance in(project_id, instance_id);
+
+  InstanceAdminClient client(MakeInstanceAdminConnection());
+  std::vector<std::string> instance_config_names = [client,
+                                                    project_id]() mutable {
+    std::vector<std::string> names;
+    for (auto instance_config : client.ListInstanceConfigs(project_id)) {
+      EXPECT_STATUS_OK(instance_config);
+      if (!instance_config) break;
+      names.push_back(instance_config->name());
+    }
+    return names;
+  }();
+  ASSERT_FALSE(instance_config_names.empty());
+  // Use the name of the first element from the list of instance configs.
+  auto instance_config = instance_config_names[0];
+
+  future<StatusOr<google::spanner::admin::instance::v1::Instance>> f =
+      client.CreateInstance(
+          project_id, instance_id, "test-display-name", instance_config, 1,
+          std::map<std::string, std::string>{{"label-key", "label-value"}});
+  StatusOr<google::spanner::admin::instance::v1::Instance> instance = f.get();
+
+  EXPECT_STATUS_OK(instance.status());
+  EXPECT_THAT(instance->name(), HasSubstr(project_id));
+  EXPECT_THAT(instance->name(), HasSubstr(instance_id));
+  EXPECT_NE(0, instance->node_count());
+  EXPECT_NE(0, instance->labels_size());
+  EXPECT_EQ(instance_config, instance->config());
+  EXPECT_EQ("label-value", instance->labels().at("label-key"));
+
+  auto status = client.DeleteInstance(in);
+  EXPECT_STATUS_OK(status);
 }
 
 TEST(InstanceAdminClient, InstanceConfig) {

--- a/google/cloud/spanner/internal/instance_admin_logging.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging.cc
@@ -130,6 +130,17 @@ InstanceAdminLogging::TestIamPermissions(
       context, request, __func__);
 }
 
+StatusOr<google::longrunning::Operation> InstanceAdminLogging::GetOperation(
+    grpc::ClientContext& context,
+    google::longrunning::GetOperationRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::longrunning::GetOperationRequest const& request) {
+        return child_->GetOperation(context, request);
+      },
+      context, request, __func__);
+}
+
 }  // namespace internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/internal/instance_admin_logging.h
+++ b/google/cloud/spanner/internal/instance_admin_logging.h
@@ -74,6 +74,10 @@ class InstanceAdminLogging : public InstanceAdminStub {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       grpc::ClientContext&,
       google::iam::v1::TestIamPermissionsRequest const&) override;
+
+  StatusOr<google::longrunning::Operation> GetOperation(
+      grpc::ClientContext& context,
+      google::longrunning::GetOperationRequest const& request) override;
   //@}
  private:
   std::shared_ptr<InstanceAdminStub> child_;

--- a/google/cloud/spanner/internal/instance_admin_metadata.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata.cc
@@ -94,6 +94,13 @@ InstanceAdminMetadata::TestIamPermissions(
   return child_->TestIamPermissions(context, request);
 }
 
+StatusOr<google::longrunning::Operation> InstanceAdminMetadata::GetOperation(
+    grpc::ClientContext& context,
+    google::longrunning::GetOperationRequest const& request) {
+  SetMetadata(context, "name=" + request.name());
+  return child_->GetOperation(context, request);
+}
+
 void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context,
                                         std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);

--- a/google/cloud/spanner/internal/instance_admin_metadata.h
+++ b/google/cloud/spanner/internal/instance_admin_metadata.h
@@ -71,6 +71,10 @@ class InstanceAdminMetadata : public InstanceAdminStub {
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       grpc::ClientContext&,
       google::iam::v1::TestIamPermissionsRequest const&) override;
+
+  StatusOr<google::longrunning::Operation> GetOperation(
+      grpc::ClientContext& context,
+      google::longrunning::GetOperationRequest const& request) override;
   //@}
  private:
   void SetMetadata(grpc::ClientContext& context,

--- a/google/cloud/spanner/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/internal/instance_admin_stub.cc
@@ -155,6 +155,18 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
     return response;
   }
 
+  StatusOr<google::longrunning::Operation> GetOperation(
+      grpc::ClientContext& client_context,
+      google::longrunning::GetOperationRequest const& request) override {
+    google::longrunning::Operation response;
+    grpc::Status status =
+        operations_->GetOperation(&client_context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::grpc_utils::MakeStatusFromRpcError(status);
+    }
+    return response;
+  }
+
  private:
   std::unique_ptr<gcsa::InstanceAdmin::Stub> instance_admin_;
   std::unique_ptr<google::longrunning::Operations::Stub> operations_;

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -65,6 +65,9 @@ class InstanceAdminStub {
   virtual StatusOr<google::iam::v1::TestIamPermissionsResponse>
   TestIamPermissions(grpc::ClientContext&,
                      google::iam::v1::TestIamPermissionsRequest const&) = 0;
+  virtual StatusOr<google::longrunning::Operation> GetOperation(
+      grpc::ClientContext& client_context,
+      google::longrunning::GetOperationRequest const& request) = 0;
 };
 
 /**

--- a/google/cloud/spanner/mocks/mock_instance_admin_connection.h
+++ b/google/cloud/spanner/mocks/mock_instance_admin_connection.h
@@ -36,6 +36,9 @@ class MockInstanceAdminConnection
   MOCK_METHOD1(GetInstance,
                StatusOr<google::spanner::admin::instance::v1::Instance>(
                    GetInstanceParams));
+  MOCK_METHOD1(CreateInstance,
+               future<StatusOr<google::spanner::admin::instance::v1::Instance>>(
+                   CreateInstanceParams));
   MOCK_METHOD1(GetInstanceConfig,
                StatusOr<google::spanner::admin::instance::v1::InstanceConfig>(
                    GetInstanceConfigParams));

--- a/google/cloud/spanner/mocks/mock_instance_admin_connection.h
+++ b/google/cloud/spanner/mocks/mock_instance_admin_connection.h
@@ -39,6 +39,7 @@ class MockInstanceAdminConnection
   MOCK_METHOD1(CreateInstance,
                future<StatusOr<google::spanner::admin::instance::v1::Instance>>(
                    CreateInstanceParams));
+  MOCK_METHOD1(DeleteInstance, Status(DeleteInstanceParams));
   MOCK_METHOD1(GetInstanceConfig,
                StatusOr<google::spanner::admin::instance::v1::InstanceConfig>(
                    GetInstanceConfigParams));

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -1319,8 +1319,7 @@ void RunAll() {
 
   if (run_slow_integration_tests == "yes") {
     std::string crud_instance_id =
-        google::cloud::spanner_testing::RandomInstanceName(
-            generator, "instance-admin-crud-samples-instance-");
+        google::cloud::spanner_testing::RandomInstanceName(generator);
     std::cout << "\nRunning create-instance sample\n";
     RunOneCommand(
         {"", "create-instance", project_id, crud_instance_id, "Test Instance"});

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -18,6 +18,8 @@
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
+#include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/spanner/testing/random_instance_name.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include <sstream>
@@ -25,20 +27,6 @@
 #include <utility>
 
 namespace {
-
-std::string RandomDatabaseName(
-    google::cloud::internal::DefaultPRNG& generator) {
-  // A database ID must be between 2 and 30 characters, fitting the regular
-  // expression `[a-z][a-z0-9_\-]*[a-z0-9]`
-  int max_size = 30;
-  std::string const prefix = "db-";
-  auto size = static_cast<int>(max_size - 1 - prefix.size());
-  return prefix +
-         google::cloud::internal::Sample(
-             generator, size, "abcdefghijlkmnopqrstuvwxyz012345689_-") +
-         google::cloud::internal::Sample(generator, 1,
-                                         "abcdefghijlkmnopqrstuvwxyz");
-}
 
 //! [get-instance]
 void GetInstance(google::cloud::spanner::InstanceAdminClient client,
@@ -1293,9 +1281,12 @@ void RunAll() {
   RunOneCommand({"", "instance-get-iam-policy", project_id, instance_id});
 
   if (run_slow_integration_tests == "yes") {
+    std::string instance_id =
+        google::cloud::spanner_testing::RandomInstanceName(
+            generator, "instance-admin-crud-samples-instance-");
     std::cout << "\nRunning create-instance sample\n";
     RunOneCommand(
-        {"", "create-instance", project_id, "test-instance", "Test Instance"});
+        {"", "create-instance", project_id, instance_id, "Test Instance"});
 
     std::cout << "\nRunning (instance) add-database-reader sample\n";
     RunOneCommand({"", "add-database-reader", project_id, instance_id,
@@ -1308,7 +1299,8 @@ void RunAll() {
   std::cout << "\nRunning (instance) test-iam-permissions sample\n";
   RunOneCommand({"", "instance-test-iam-permissions", project_id, instance_id});
 
-  std::string database_id = RandomDatabaseName(generator);
+  std::string database_id =
+      google::cloud::spanner_testing::RandomDatabaseName(generator);
 
   std::cout << "Running samples in database " << database_id << "\n";
 

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -24,6 +24,7 @@ spanner_client_testing_hdrs = [
     "testing/mock_spanner_stub.h",
     "testing/pick_random_instance.h",
     "testing/random_database_name.h",
+    "testing/random_instance_name.h",
     "testing/validate_metadata.h",
 ]
 
@@ -31,5 +32,6 @@ spanner_client_testing_srcs = [
     "testing/database_environment.cc",
     "testing/pick_random_instance.cc",
     "testing/random_database_name.cc",
+    "testing/random_instance_name.cc",
     "testing/validate_metadata.cc",
 ]

--- a/google/cloud/spanner/testing/mock_instance_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_instance_admin_stub.h
@@ -59,6 +59,10 @@ class MockInstanceAdminStub
                StatusOr<google::iam::v1::TestIamPermissionsResponse>(
                    grpc::ClientContext&,
                    google::iam::v1::TestIamPermissionsRequest const&));
+  MOCK_METHOD2(GetOperation,
+               StatusOr<google::longrunning::Operation>(
+                   grpc::ClientContext&,
+                   google::longrunning::GetOperationRequest const&));
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/testing/pick_random_instance.cc
+++ b/google/cloud/spanner/testing/pick_random_instance.cc
@@ -29,12 +29,11 @@ StatusOr<std::string> PickRandomInstance(
     if (!instance) return std::move(instance).status();
     auto name = instance->name();
     std::string const sep = "/instances/";
-    auto pos = name.rfind(sep);
-    if (pos == std::string::npos) {
-      return Status(StatusCode::kInternal, "Invalid instance name " + name);
+    std::string const valid_instance_name = sep + "test-instance-";
+    auto pos = name.rfind(valid_instance_name);
+    if (pos != std::string::npos) {
+      instance_ids.push_back(name.substr(pos + sep.size()));
     }
-
-    instance_ids.push_back(name.substr(pos + sep.size()));
   }
 
   if (instance_ids.empty()) {

--- a/google/cloud/spanner/testing/pick_random_instance.cc
+++ b/google/cloud/spanner/testing/pick_random_instance.cc
@@ -26,7 +26,7 @@ StatusOr<std::string> PickRandomInstance(
 
   /**
    * We started to have integration tests for InstanceAdminClient which creates
-   * and deletes temporary instances. If we pick one of those instnaces here,
+   * and deletes temporary instances. If we pick one of those instances here,
    * the following tests will fail after the deletion.
    * InstanceAdminClient's integration tests are using instances prefixed with
    * "temporary-instances-", so we only pick instances prefixed with

--- a/google/cloud/spanner/testing/pick_random_instance.cc
+++ b/google/cloud/spanner/testing/pick_random_instance.cc
@@ -24,6 +24,14 @@ StatusOr<std::string> PickRandomInstance(
     std::string const& project_id) {
   spanner::InstanceAdminClient client(spanner::MakeInstanceAdminConnection());
 
+  /**
+   * We started to have integration tests for InstanceAdminClient which creates
+   * and deletes temporary instances. If we pick one of those instnaces here,
+   * the following tests will fail after the deletion.
+   * InstanceAdminClient's integration tests are using instances prefixed with
+   * "temporary-instances-", so we only pick instances prefixed with
+   * "test-instance-" here for isolation.
+   */
   std::vector<std::string> instance_ids;
   for (auto instance : client.ListInstances(project_id, "")) {
     if (!instance) return std::move(instance).status();

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -22,7 +22,7 @@ std::string RandomDatabaseName(
     google::cloud::internal::DefaultPRNG& generator) {
   // A database ID must be between 2 and 30 characters, fitting the regular
   // expression `[a-z][a-z0-9_\-]*[a-z0-9]`
-  int max_size = 30;
+  std::size_t const max_size = 30;
   std::string const prefix = "db-";
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +

--- a/google/cloud/spanner/testing/random_instance_name.cc
+++ b/google/cloud/spanner/testing/random_instance_name.cc
@@ -22,9 +22,9 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 std::string RandomInstanceName(
     google::cloud::internal::DefaultPRNG& generator) {
-  // A instance ID must be between 2 and 64 characters, fitting the regular
+  // An instance ID must be between 2 and 64 characters, fitting the regular
   // expression `[a-z][-a-z0-9]*[a-z0-9]`
-  int max_size = 64;
+  std::size_t const max_size = 64;
   auto now = std::chrono::system_clock::now();
   auto time_t = std::chrono::system_clock::to_time_t(now);
   std::string date = "1973-03-01";

--- a/google/cloud/spanner/testing/random_instance_name.cc
+++ b/google/cloud/spanner/testing/random_instance_name.cc
@@ -13,16 +13,26 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/testing/random_instance_name.h"
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
 
 namespace google {
 namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
-std::string RandomInstanceName(google::cloud::internal::DefaultPRNG& generator,
-                               const std::string& prefix) {
+std::string RandomInstanceName(
+    google::cloud::internal::DefaultPRNG& generator) {
   // A instance ID must be between 2 and 64 characters, fitting the regular
   // expression `[a-z][-a-z0-9]*[a-z0-9]`
   int max_size = 64;
+  auto now = std::chrono::system_clock::now();
+  auto time_t = std::chrono::system_clock::to_time_t(now);
+  std::stringstream ss;
+  ss << "temporary-instance-"
+     << std::put_time(std::localtime(&time_t), "%Y-%m-%d") << "-";
+  std::string prefix = ss.str();
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +
          google::cloud::internal::Sample(

--- a/google/cloud/spanner/testing/random_instance_name.cc
+++ b/google/cloud/spanner/testing/random_instance_name.cc
@@ -15,8 +15,6 @@
 #include "google/cloud/spanner/testing/random_instance_name.h"
 #include <chrono>
 #include <ctime>
-#include <iomanip>
-#include <sstream>
 
 namespace google {
 namespace cloud {
@@ -29,10 +27,9 @@ std::string RandomInstanceName(
   int max_size = 64;
   auto now = std::chrono::system_clock::now();
   auto time_t = std::chrono::system_clock::to_time_t(now);
-  std::stringstream ss;
-  ss << "temporary-instance-"
-     << std::put_time(std::localtime(&time_t), "%Y-%m-%d") << "-";
-  std::string prefix = ss.str();
+  std::string date = "1973-03-01";
+  std::strftime(&date[0], date.size() + 1, "%Y-%m-%d", std::localtime(&time_t));
+  std::string prefix = "temporary-instance-" + date + "-";
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +
          google::cloud::internal::Sample(

--- a/google/cloud/spanner/testing/random_instance_name.cc
+++ b/google/cloud/spanner/testing/random_instance_name.cc
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/testing/random_instance_name.h"
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+std::string RandomInstanceName(google::cloud::internal::DefaultPRNG& generator,
+                               const std::string& prefix) {
+  // A instance ID must be between 2 and 64 characters, fitting the regular
+  // expression `[a-z][-a-z0-9]*[a-z0-9]`
+  int max_size = 64;
+  auto size = static_cast<int>(max_size - 1 - prefix.size());
+  return prefix +
+         google::cloud::internal::Sample(
+             generator, size, "abcdefghijlkmnopqrstuvwxyz012345689-") +
+         google::cloud::internal::Sample(generator, 1,
+                                         "abcdefghijlkmnopqrstuvwxyz");
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/testing/random_instance_name.h
+++ b/google/cloud/spanner/testing/random_instance_name.h
@@ -25,8 +25,7 @@ namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
 /// Create a random instance name given a PRNG generator.
-std::string RandomInstanceName(google::cloud::internal::DefaultPRNG& generator,
-                               const std::string& prefix);
+std::string RandomInstanceName(google::cloud::internal::DefaultPRNG& generator);
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner_testing

--- a/google/cloud/spanner/testing/random_instance_name.h
+++ b/google/cloud/spanner/testing/random_instance_name.h
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_RANDOM_INSTANCE_NAME_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_RANDOM_INSTANCE_NAME_H_
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/internal/random.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+
+/// Create a random instance name given a PRNG generator.
+std::string RandomInstanceName(google::cloud::internal::DefaultPRNG& generator,
+                               const std::string& prefix);
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_RANDOM_INSTANCE_NAME_H_


### PR DESCRIPTION
With this PR, I introduced basic integration tests and samples for InstanceAdminClient, which create and delete a new instance with a random name, prefixed with `temporary-instance-{DATE}-`.

While these tests are only executed with an environment variable `RUN_SLOW_INTEGRATION_TESTS=yes`, if a random instance created by these tests is picked up by `google::cloud::spanner_testing::PickRandomInstance`, it's going to be problematic.

So, I made a change in `google::cloud::spanner_testing::PickRandomInstance`, now it only picks up the instance prefixed `test-instance-` for isolating instances between normal tests and CRUD tests for `InstanceAdminClient`.

I feel `InstanceAdminClient::CreateInstance` has too many parameters, but I'm somewhat ok with this because I don't expect many people will use this function anyways.

fixes #519 #521

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/711)
<!-- Reviewable:end -->
