### PR TITLE
Instance admin update instance

### DIFF
--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -33,6 +33,13 @@ InstanceAdminClient::CreateInstance(
                                 instance_config, node_count, labels});
 }
 
+future<StatusOr<google::spanner::admin::instance::v1::Instance>>
+InstanceAdminClient::UpdateInstance(
+    google::spanner::admin::instance::v1::UpdateInstanceRequest const&
+        request) {
+  return conn_->UpdateInstance({request});
+}
+
 Status InstanceAdminClient::DeleteInstance(Instance const& in) {
   return conn_->DeleteInstance({in.FullName()});
 }

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -122,6 +122,9 @@ class InstanceAdminClient {
   /**
    * Updates a Cloud Spanner instance.
    *
+   * Note that when updating a field, you have to set the field mask on the
+   * `UpdateInstanceRequest` with the field name.
+   *
    * @par Example
    * @snippet samples.cc update-instance
    *

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -118,6 +118,18 @@ class InstanceAdminClient {
                  std::string const& display_name,
                  std::string const& instance_config, int node_count,
                  std::map<std::string, std::string> const& labels = {});
+
+  /**
+   * Updates a Cloud Spanner instance.
+   *
+   * @par Example
+   * @snippet samples.cc update-instance
+   *
+   */
+  future<StatusOr<google::spanner::admin::instance::v1::Instance>>
+  UpdateInstance(
+      google::spanner::admin::instance::v1::UpdateInstanceRequest const&);
+
   /**
    * Deletes an existing Cloud Spanner instance.
    *

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -148,7 +148,24 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
           StatusOr<gcsa::Instance>(operation.status()));
     }
 
-    return AwaitCreateInstance(*std::move(operation));
+    return AwaitCreateOrUpdateInstance(*std::move(operation));
+  }
+
+  future<StatusOr<gcsa::Instance>> UpdateInstance(
+      UpdateInstanceParams p) override {
+    auto operation = RetryLoop(
+        retry_policy_->clone(), backoff_policy_->clone(), false,
+        [this](grpc::ClientContext& context,
+               gcsa::UpdateInstanceRequest const& request) {
+          return stub_->UpdateInstance(context, request);
+        },
+        p.request, __func__);
+    if (!operation) {
+      return google::cloud::make_ready_future(
+          StatusOr<gcsa::Instance>(operation.status()));
+    }
+
+    return AwaitCreateOrUpdateInstance(*std::move(operation));
   }
 
   Status DeleteInstance(DeleteInstanceParams p) override {
@@ -283,7 +300,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   }
 
  private:
-  future<StatusOr<gcsa::Instance>> AwaitCreateInstance(
+  future<StatusOr<gcsa::Instance>> AwaitCreateOrUpdateInstance(
       google::longrunning::Operation operation) {
     promise<StatusOr<gcsa::Instance>> pr;
     auto f = pr.get_future();

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -98,6 +98,11 @@ class InstanceAdminConnection {
     std::map<std::string, std::string> labels;
   };
 
+  /// Wrap the arguments for `UpdateInstance()`.
+  struct UpdateInstanceParams {
+    google::spanner::admin::instance::v1::UpdateInstanceRequest request;
+  };
+
   /// Wrap the arguments for `DeleteInstance()`.
   struct DeleteInstanceParams {
     std::string instance_name;
@@ -161,6 +166,9 @@ class InstanceAdminConnection {
 
   virtual future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(CreateInstanceParams p) = 0;
+
+  virtual future<StatusOr<google::spanner::admin::instance::v1::Instance>>
+  UpdateInstance(UpdateInstanceParams p) = 0;
 
   virtual Status DeleteInstance(DeleteInstanceParams p) = 0;
 

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -170,6 +170,61 @@ TEST(InstanceAdminClientTest, CreateInstanceError) {
   EXPECT_EQ(StatusCode::kPermissionDenied, instance.status().code());
 }
 
+TEST(InstanceAdminClientTest, UpdateInstanceSuccess) {
+  auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
+  std::string expected_name = "projects/test-project/instances/test-instance";
+
+  EXPECT_CALL(*mock, UpdateInstance(_, _))
+      .WillOnce(Invoke([&expected_name](grpc::ClientContext&,
+                                        gcsa::UpdateInstanceRequest const& r) {
+        EXPECT_EQ(expected_name, r.instance().name());
+        google::longrunning::Operation op;
+        op.set_name("test-operation-name");
+        op.set_done(false);
+        return make_status_or(op);
+      }));
+  EXPECT_CALL(*mock, GetOperation(_, _))
+      .WillOnce(Invoke(
+          [&expected_name](grpc::ClientContext&,
+                           google::longrunning::GetOperationRequest const& r) {
+            EXPECT_EQ("test-operation-name", r.name());
+            google::longrunning::Operation op;
+            op.set_name(r.name());
+            op.set_done(true);
+            gcsa::Instance instance;
+            instance.set_name(expected_name);
+            op.mutable_response()->PackFrom(instance);
+            return make_status_or(op);
+          }));
+
+  auto conn = MakeTestConnection(std::move(mock));
+  gcsa::UpdateInstanceRequest req;
+  req.mutable_instance()->set_name(expected_name);
+  auto fut = conn->UpdateInstance({req});
+  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
+  auto instance = fut.get();
+  EXPECT_STATUS_OK(instance);
+
+  EXPECT_EQ(expected_name, instance->name());
+}
+
+TEST(InstanceAdminClientTest, UpdateInstanceError) {
+  auto mock = std::make_shared<spanner_testing::MockInstanceAdminStub>();
+
+  EXPECT_CALL(*mock, UpdateInstance(_, _))
+      .WillOnce(
+          Invoke([](grpc::ClientContext&, gcsa::UpdateInstanceRequest const&) {
+            return StatusOr<google::longrunning::Operation>(
+                Status(StatusCode::kPermissionDenied, "uh-oh"));
+          }));
+
+  auto conn = MakeTestConnection(std::move(mock));
+  auto fut = conn->UpdateInstance({gcsa::UpdateInstanceRequest()});
+  EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
+  auto instance = fut.get();
+  EXPECT_EQ(StatusCode::kPermissionDenied, instance.status().code());
+}
+
 TEST(InstanceAdminConnectionTest, DeleteInstance_Success) {
   std::string const expected_name =
       "projects/test-project/instances/test-instance";

--- a/google/cloud/spanner/mocks/mock_instance_admin_connection.h
+++ b/google/cloud/spanner/mocks/mock_instance_admin_connection.h
@@ -39,6 +39,9 @@ class MockInstanceAdminConnection
   MOCK_METHOD1(CreateInstance,
                future<StatusOr<google::spanner::admin::instance::v1::Instance>>(
                    CreateInstanceParams));
+  MOCK_METHOD1(UpdateInstance,
+               future<StatusOr<google::spanner::admin::instance::v1::Instance>>(
+                   UpdateInstanceParams));
   MOCK_METHOD1(DeleteInstance, Status(DeleteInstanceParams));
   MOCK_METHOD1(GetInstanceConfig,
                StatusOr<google::spanner::admin::instance::v1::InstanceConfig>(


### PR DESCRIPTION
fixes #520 

I surfaced `gcsa::UpdateInstanceRequest`, and wrote samples and integration tests accordingly. The sample code doesn't look so bad as I worried, so I created this PR without implementing the request builder.

Another question.
Well, then, when I look at `CreateInstance` and `UpdateInstance`, I feel they are inconsistent. I'm thinking to also surface `CreateInstanceRequest` on `CreateInstance` to users. WDYT?

