### PR TITLE
Ensure ConnectionImpl is allocated via shared_ptr.

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -118,7 +118,7 @@ Status Client::Rollback(Transaction transaction) {
 std::shared_ptr<Connection> MakeConnection(Database const& db,
                                            ConnectionOptions const& options) {
   auto stub = internal::CreateDefaultSpannerStub(options);
-  return std::make_shared<internal::ConnectionImpl>(db, std::move(stub));
+  return internal::MakeConnection(db, std::move(stub));
 }
 
 namespace {

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -94,6 +94,15 @@ std::unique_ptr<BackoffPolicy> DefaultConnectionBackoffPolicy() {
       .clone();
 }
 
+std::shared_ptr<ConnectionImpl> MakeConnection(
+    Database db, std::shared_ptr<SpannerStub> stub,
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy) {
+  return std::shared_ptr<ConnectionImpl>(
+      new ConnectionImpl(std::move(db), std::move(stub),
+                         std::move(retry_policy), std::move(backoff_policy)));
+}
+
 StatusOr<ResultSet> ConnectionImpl::Read(ReadParams rp) {
   return internal::Visit(
       std::move(rp.transaction),

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -74,7 +74,7 @@ MATCHER_P(CreateSessionRequestHasDatabase, database,
 std::shared_ptr<Connection> MakeTestConnection(
     Database const& db,
     std::shared_ptr<spanner_testing::MockSpannerStub> mock) {
-  return std::make_shared<ConnectionImpl>(
+  return MakeConnection(
       db, std::move(mock),
       LimitedErrorCountRetryPolicy(/*maximum_failures=*/2).clone(),
       ExponentialBackoffPolicy(/*initial_delay=*/std::chrono::microseconds(1),
@@ -91,11 +91,6 @@ class MockGrpcReader
   MOCK_METHOD0(Finish, grpc::Status());
   MOCK_METHOD0(WaitForInitialMetadata, void());
 };
-
-std::shared_ptr<Connection> MakeConnection(Database const& db,
-                                           std::shared_ptr<SpannerStub> stub) {
-  return std::make_shared<ConnectionImpl>(db, std::move(stub));
-}
 
 TEST(ConnectionImplTest, ReadGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();


### PR DESCRIPTION
Since `ConnectionImpl` relies on `std::enable_shared_from_this`, it
should only be allocated and held in a `std::shared_ptr` (otherwise
calling `shared_from_this()` results in an exception). Make its
constructor private and add a factory method that returns a `shared_ptr`
and is the only way to allocate one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/915)
<!-- Reviewable:end -->
