### PR TITLE
Start implementing the real SessionPool.

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -658,7 +658,7 @@ Status ConnectionImpl::RollbackImpl(SessionHolder& session,
 
 StatusOr<SessionHolder> ConnectionImpl::AllocateSession(
     bool dissociate_from_pool) {
-  auto session = session_pool_.Allocate();
+  auto session = session_pool_.Allocate(dissociate_from_pool);
   if (!session.ok()) {
     return std::move(session).status();
   }

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -46,7 +46,7 @@ SessionPool::SessionPool(SessionManager* manager, SessionPoolOptions options)
   auto sessions = manager_->CreateSessions(options_.min_sessions);
   if (sessions.ok()) {
     std::unique_lock<std::mutex> lk(mu_);
-    total_sessions_ += sessions->size();
+    total_sessions_ += static_cast<int>(sessions->size());
     sessions_.insert(sessions_.end(),
                      std::make_move_iterator(sessions->begin()),
                      std::make_move_iterator(sessions->end()));
@@ -113,7 +113,7 @@ StatusOr<std::unique_ptr<Session>> SessionPool::Allocate(
       continue;
     }
 
-    total_sessions_ += sessions->size();
+    total_sessions_ += static_cast<int>(sessions->size());
     // Return one of the sessions and add the rest to the pool.
     auto session = std::move(sessions->back());
     sessions->pop_back();

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/spanner/internal/session_pool.h"
 #include "google/cloud/spanner/internal/connection_impl.h"
 #include "google/cloud/spanner/internal/session.h"
+#include "google/cloud/status.h"
+#include <algorithm>
 #include <memory>
 
 namespace google {
@@ -23,28 +25,106 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-StatusOr<std::unique_ptr<Session>> SessionPool::Allocate() {
-  {
-    std::lock_guard<std::mutex> lk(mu_);
-    if (!sessions_.empty()) {
-      auto session = std::move(sessions_.back());
-      sessions_.pop_back();
-      return {std::move(session)};
+SessionPool::SessionPool(SessionManager* manager, SessionPoolOptions options)
+    : manager_(manager), options_(options) {
+  // Eagerly initialize the pool with `min_sessions` sessions.
+  if (options_.min_sessions > 0) {
+    auto sessions = manager_->CreateSessions(options_.min_sessions);
+    if (sessions.ok()) {
+      std::unique_lock<std::mutex> lk(mu_);
+      total_sessions_ += sessions->size();
+      sessions_.insert(sessions_.end(),
+                       std::make_move_iterator(sessions->begin()),
+                       std::make_move_iterator(sessions->end()));
     }
   }
+}
 
-  auto sessions = manager_->CreateSessions(/*num_sessions=*/1);
-  if (!sessions.ok()) {
-    return std::move(sessions).status();
+StatusOr<std::unique_ptr<Session>> SessionPool::Allocate(
+    bool dissociate_from_pool) {
+  std::unique_lock<std::mutex> lk(mu_);
+  for (;;) {
+    if (!sessions_.empty()) {
+      // return the most recently used session.
+      auto session = std::move(sessions_.back());
+      sessions_.pop_back();
+      if (dissociate_from_pool) {
+        --total_sessions_;
+      }
+      return {std::move(session)};
+    }
+
+    // If the pool is at its max size, fail or wait until someone returns a
+    // session to the pool then try again.
+    if (total_sessions_ >= options_.max_sessions) {
+      if (options_.action_on_exhaustion == ActionOnExhaustion::FAIL) {
+        return Status(StatusCode::kResourceExhausted, "session pool exhausted");
+      }
+      cond_.wait(lk, [this] {
+        return !sessions_.empty() || total_sessions_ < options_.max_sessions;
+      });
+      continue;
+    }
+
+    // Create new sessions for the pool. We only allow one thread to do this at
+    // a time; a possible enhancement is tracking the number of waiters and
+    // issuing more simulaneous calls if additional sessions are needed.
+    if (create_in_progress_) {
+      cond_.wait(lk,
+                 [this] { return !sessions_.empty() || !create_in_progress_; });
+      continue;
+    }
+
+    // Add `min_sessions` to the pool (plus the one we're going to return),
+    // subject to the `max_sessions` cap.
+    int sessions_to_create = std::min(options_.min_sessions + 1,
+                                      options_.max_sessions - total_sessions_);
+    create_in_progress_ = true;
+    lk.unlock();
+    // TODO(#307) do we need to limit the call rate here?
+    auto sessions = manager_->CreateSessions(sessions_to_create);
+    lk.lock();
+    create_in_progress_ = false;
+    if (!sessions.ok() || sessions->empty()) {
+      // If the error was anything other than ResourceExhausted, return it.
+      if (sessions.status().code() != StatusCode::kResourceExhausted) {
+        return sessions.status();
+      }
+      // Fail if we're supposed to, otherwise try again.
+      if (options_.action_on_exhaustion == ActionOnExhaustion::FAIL) {
+        return Status(StatusCode::kResourceExhausted, "session pool exhausted");
+      }
+      continue;
+    }
+
+    total_sessions_ += sessions->size();
+    // Return one of the sessions and add the rest to the pool.
+    auto session = std::move(sessions->back());
+    sessions->pop_back();
+    if (dissociate_from_pool) {
+      --total_sessions_;
+    }
+    if (!sessions->empty()) {
+      sessions_.insert(sessions_.end(),
+                       std::make_move_iterator(sessions->begin()),
+                       std::make_move_iterator(sessions->end()));
+      lk.unlock();
+      // Wake up everyone that was waiting for a session.
+      cond_.notify_all();
+    }
+    return {std::move(session)};
   }
-  // TODO(#307) for now, assume CreateSessions() returns exactly one Session on
-  // success (as we requested). Rewrite this to accommodate multiple sessions.
-  return {std::move((*sessions)[0])};
 }
 
 void SessionPool::Release(std::unique_ptr<Session> session) {
-  std::lock_guard<std::mutex> lk(mu_);
+  std::unique_lock<std::mutex> lk(mu_);
+  bool notify = sessions_.empty();
   sessions_.push_back(std::move(session));
+  // If sessions_ was empty, wake up someone who was waiting for a sessiion.
+  if (notify) {
+    lk.unlock();
+    cond_.notify_one();
+  }
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/session.h"
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/status_or.h"
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -38,6 +39,33 @@ class SessionManager {
       int num_sessions) = 0;
 };
 
+// What action to take if the session pool is exhausted.
+enum class ActionOnExhaustion { BLOCK, FAIL };
+
+struct SessionPoolOptions {
+  // The minimum number of sessions to keep in the pool.
+  int min_sessions = 0;
+
+  // The maximum number of sessions to create. This should be the number of
+  // channels * 100.
+  int max_sessions = 100;  // Channel Count * 100
+
+  // The maximum number of sessions that can be in the pool in an idle state.
+  int max_idle_sessions = 0;
+
+  // The fraction of sessions to prepare for write in advance.
+  // This fraction represents observed cloud spanner usage as of May 2019.
+  float write_sessions_fraction = 0.25;
+
+  // Decide whether to block or fail on pool exhaustion.
+  ActionOnExhaustion action_on_exhaustion = ActionOnExhaustion::BLOCK;
+
+  // This is the interval at which we refresh sessions so they don't get
+  // collected by the backend GC. The GC collects objects older than 60
+  // minutes, so any number below 60 should suffice.
+  int keep_alive_interval_minutes = 55;
+};
+
 /**
  * Maintains a pool of `Session` objects.
  *
@@ -54,26 +82,34 @@ class SessionManager {
 class SessionPool {
  public:
   /**
-   * Create a `SessionPool`. Uses `manager` to create, delete, and refresh
-   * sessions in the pool.
+   * Create a `SessionPool`.
+   * Uses `manager` to create, delete, and refresh sessions in the pool.
    */
-  SessionPool(SessionManager* manager) : manager_(manager) {}
+  SessionPool(SessionManager* manager,
+              SessionPoolOptions options = SessionPoolOptions());
 
   /**
    * Allocate a session from the pool, creating a new `Session` if necessary.
+   * If `dissociate_from_pool` is true, the caller does not intend to return
+   * this `Session` to the pool.
    * @returns an error if session creation fails; always returns a non-null
    * pointer on success.
    */
-  StatusOr<std::unique_ptr<Session>> Allocate();
+  StatusOr<std::unique_ptr<Session>> Allocate(
+      bool dissociate_from_pool = false);
 
   /// Release `session` back to the pool.
   void Release(std::unique_ptr<Session> session);
 
  private:
   std::mutex mu_;
+  std::condition_variable cond_;
   std::vector<std::unique_ptr<Session>> sessions_;  // GUARDED_BY(mu_)
+  int total_sessions_ = 0;                          // GUARDED_BY(mu_)
+  bool create_in_progress_ = false;                 // GUARDED_BY(mu_)
 
   SessionManager* manager_;
+  const SessionPoolOptions options_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
- Add options to tune its behavior (these will eventually have to be
  user-visible, but let's make them private for now).
- add `min_sessions` to the pool at construction time.
- when the pool is exhausted, add `min_sessions` more sessions to the
  pool (subject to the `max_sessions` limit.
- we do not yet refresh or delete sessions.

(this is independent of #924 although CreateSessions() will always return 1 session until it's checked in - that is not an issue since it's permitted to return fewer sessions than requested).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/925)
<!-- Reviewable:end -->
