### PR TITLE
feat!: implement CreateInstanceRequestBuilder

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(spanner_client
             connection.h
             connection_options.cc
             connection_options.h
+            create_instance_request_builder.h
             database.cc
             database.h
             database_admin_client.cc
@@ -332,6 +333,7 @@ function (spanner_client_define_tests)
         spanner_version_test.cc
         sql_statement_test.cc
         transaction_test.cc
+        create_instance_request_builder_test.cc
         update_instance_request_builder_test.cc
         value_test.cc)
 

--- a/google/cloud/spanner/create_instance_request_builder.h
+++ b/google/cloud/spanner/create_instance_request_builder.h
@@ -1,0 +1,132 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CREATE_INSTANCE_REQUEST_BUILDER_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CREATE_INSTANCE_REQUEST_BUILDER_H_
+
+#include "google/cloud/spanner/instance.h"
+#include "google/cloud/spanner/version.h"
+#include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
+#include <map>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+/**
+ * CreateInstanceRequestBuilder is a builder class for
+ * `google::spanner::admin::instance::v1::CreateInstanceRequest`
+ *
+ * This is useful when calling InstanceAdminClient::CreateInstance()
+ * function. If you see an error message like "error: no member named 'Build'",
+ * this means you don't set a mandatory field.
+ *
+ * @par Example
+ * @snippet samples.cc create-instance
+ */
+class CreateInstanceRequestBuilder {
+ public:
+  // Copy and move.
+  CreateInstanceRequestBuilder(CreateInstanceRequestBuilder const&) = default;
+  CreateInstanceRequestBuilder(CreateInstanceRequestBuilder&&) = default;
+  CreateInstanceRequestBuilder& operator=(CreateInstanceRequestBuilder const&) =
+      default;
+  CreateInstanceRequestBuilder& operator=(CreateInstanceRequestBuilder&&) =
+      default;
+
+  /**
+   * Only constructor that accepts Instance.
+   */
+  explicit CreateInstanceRequestBuilder(Instance const& in) {
+    request_.set_parent("projects/" + in.project_id());
+    request_.set_instance_id(in.instance_id());
+    request_.mutable_instance()->set_name(in.FullName());
+  }
+
+  class NodeCountSetter;
+  class ConfigSetter;
+  class Builder;
+
+  NodeCountSetter& SetDisplayName(std::string const& display_name) & {
+    request_.mutable_instance()->set_display_name(std::move(display_name));
+    return reinterpret_cast<NodeCountSetter&>(*this);
+  }
+
+  NodeCountSetter&& SetDisplayName(std::string const& display_name) && {
+    request_.mutable_instance()->set_display_name(std::move(display_name));
+    return std::move(reinterpret_cast<NodeCountSetter&>(*this));
+  }
+
+ protected:
+  google::spanner::admin::instance::v1::CreateInstanceRequest request_;
+};
+
+class CreateInstanceRequestBuilder::NodeCountSetter
+    : public CreateInstanceRequestBuilder {
+ public:
+  ConfigSetter& SetNodeCount(int node_count) & {
+    request_.mutable_instance()->set_node_count(node_count);
+    return reinterpret_cast<ConfigSetter&>(*this);
+  }
+  ConfigSetter&& SetNodeCount(int node_count) && {
+    request_.mutable_instance()->set_node_count(node_count);
+    return std::move(reinterpret_cast<ConfigSetter&>(*this));
+  }
+};
+
+class CreateInstanceRequestBuilder::ConfigSetter
+    : public CreateInstanceRequestBuilder {
+ public:
+  Builder& SetConfig(std::string config) & {
+    request_.mutable_instance()->set_config(std::move(config));
+    return reinterpret_cast<Builder&>(*this);
+  }
+  Builder&& SetConfig(std::string config) && {
+    request_.mutable_instance()->set_config(std::move(config));
+    return std::move(reinterpret_cast<Builder&>(*this));
+  }
+};
+
+class CreateInstanceRequestBuilder::Builder
+    : public CreateInstanceRequestBuilder {
+ public:
+  Builder& SetLabels(std::map<std::string, std::string> const& labels) & {
+    for (auto const& pair : labels) {
+      request_.mutable_instance()->mutable_labels()->insert(
+          {pair.first, pair.second});
+    }
+    return *this;
+  }
+  Builder&& SetLabels(std::map<std::string, std::string> const& labels) && {
+    for (auto const& pair : labels) {
+      request_.mutable_instance()->mutable_labels()->insert(
+          {pair.first, pair.second});
+    }
+    return std::move(*this);
+  }
+  google::spanner::admin::instance::v1::CreateInstanceRequest& Build() & {
+    return request_;
+  }
+  google::spanner::admin::instance::v1::CreateInstanceRequest&& Build() && {
+    return std::move(request_);
+  }
+};
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CREATE_INSTANCE_REQUEST_BUILDER_H_

--- a/google/cloud/spanner/create_instance_request_builder.h
+++ b/google/cloud/spanner/create_instance_request_builder.h
@@ -29,7 +29,7 @@ inline namespace SPANNER_CLIENT_NS {
  * CreateInstanceRequestBuilderTemplate turns on the field bit once it is set
  * and carries the bit as the template argument.
  */
-template <unsigned CurrentBit>
+template <unsigned CurrentMask>
 class CreateInstanceRequestBuilderTemplate {
   struct FieldBits {
     enum {
@@ -60,61 +60,61 @@ class CreateInstanceRequestBuilderTemplate {
     request_.mutable_instance()->set_name(in.FullName());
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::DisplayName>&
+  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::DisplayName>&
   SetDisplayName(std::string display_name) & {
     request_.mutable_instance()->set_display_name(std::move(display_name));
     return reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-        CurrentBit | FieldBits::DisplayName>&>(*this);
+        CurrentMask | FieldBits::DisplayName>&>(*this);
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::DisplayName>&&
+  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::DisplayName>&&
   SetDisplayName(std::string display_name) && {
     request_.mutable_instance()->set_display_name(std::move(display_name));
     return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-                         CurrentBit | FieldBits::DisplayName>&>(*this));
+                         CurrentMask | FieldBits::DisplayName>&>(*this));
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::NodeCount>&
+  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::NodeCount>&
   SetNodeCount(int node_count) & {
     request_.mutable_instance()->set_node_count(node_count);
     return reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-        CurrentBit | FieldBits::NodeCount>&>(*this);
+        CurrentMask | FieldBits::NodeCount>&>(*this);
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::NodeCount>&&
+  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::NodeCount>&&
   SetNodeCount(int node_count) && {
     request_.mutable_instance()->set_node_count(node_count);
     return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-                         CurrentBit | FieldBits::NodeCount>&>(*this));
+                         CurrentMask | FieldBits::NodeCount>&>(*this));
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Config>&
+  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Config>&
   SetConfig(std::string config) & {
     request_.mutable_instance()->set_config(std::move(config));
     return reinterpret_cast<
-        CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Config>&>(
+        CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Config>&>(
         *this);
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Config>&&
+  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Config>&&
   SetConfig(std::string config) && {
     request_.mutable_instance()->set_config(std::move(config));
     return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-                         CurrentBit | FieldBits::Config>&>(*this));
+                         CurrentMask | FieldBits::Config>&>(*this));
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Labels>&
+  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Labels>&
   SetLabels(std::map<std::string, std::string> const& labels) & {
     for (auto const& pair : labels) {
       request_.mutable_instance()->mutable_labels()->insert(
           {pair.first, pair.second});
     }
     return reinterpret_cast<
-        CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Labels>&>(
+        CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Labels>&>(
         *this);
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Labels>&&
+  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Labels>&&
   SetLabels(std::map<std::string, std::string> const& labels) && {
     CreateInstanceRequestBuilderTemplate next = *this;
     for (auto const& pair : labels) {
@@ -122,12 +122,12 @@ class CreateInstanceRequestBuilderTemplate {
           {pair.first, pair.second});
     }
     return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-                         CurrentBit | FieldBits::Labels>&>(*this));
+                         CurrentMask | FieldBits::Labels>&>(*this));
   }
 
   google::spanner::admin::instance::v1::CreateInstanceRequest& Build() & {
     static_assert(
-        (CurrentBit &
+        (CurrentMask &
          (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config)) ==
             (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config),
         "Call SetDisplayName(), SetNodeCount(), and SetConfig() before calling "
@@ -136,7 +136,7 @@ class CreateInstanceRequestBuilderTemplate {
   }
   google::spanner::admin::instance::v1::CreateInstanceRequest&& Build() && {
     static_assert(
-        (CurrentBit &
+        (CurrentMask &
          (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config)) ==
             (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config),
         "Call SetDisplayName(), SetNodeCount(), and SetConfig() before calling "

--- a/google/cloud/spanner/create_instance_request_builder.h
+++ b/google/cloud/spanner/create_instance_request_builder.h
@@ -29,7 +29,7 @@ inline namespace SPANNER_CLIENT_NS {
  * CreateInstanceRequestBuilder is a builder class for
  * `google::spanner::admin::instance::v1::CreateInstanceRequest`
  *
- * This is useful when calling InstanceAdminClient::CreateInstance()
+ * This is useful when calling the `InstanceAdminClient::CreateInstance()`
  * function.
  *
  * @par Example
@@ -47,7 +47,7 @@ class CreateInstanceRequestBuilder {
 
   /**
    * Constructor requires Instance and Cloud Spanner instance config name. It
-   * sets node_count = 1, and display_name = instance_id as the default value.
+   * sets node_count = 1, and display_name = instance_id as the default values.
    */
   explicit CreateInstanceRequestBuilder(Instance const& in,
                                         std::string config) {

--- a/google/cloud/spanner/create_instance_request_builder.h
+++ b/google/cloud/spanner/create_instance_request_builder.h
@@ -26,140 +26,87 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 /**
- * CreateInstanceRequestBuilderTemplate turns on the field bit once it is set
- * and carries the bit as the template argument.
+ * CreateInstanceRequestBuilder is a builder class for
+ * `google::spanner::admin::instance::v1::CreateInstanceRequest`
+ *
+ * This is useful when calling InstanceAdminClient::CreateInstance()
+ * function.
+ *
+ * @par Example
+ * @snippet samples.cc create-instance
  */
-template <unsigned CurrentMask>
-class CreateInstanceRequestBuilderTemplate {
-  struct FieldBits {
-    enum {
-      DisplayName = (1 << 0),
-      NodeCount = (1 << 1),
-      Config = (1 << 2),
-      Labels = (1 << 3)
-    };
-  };
-
+class CreateInstanceRequestBuilder {
  public:
   // Copy and move.
-  CreateInstanceRequestBuilderTemplate(
-      CreateInstanceRequestBuilderTemplate const&) = default;
-  CreateInstanceRequestBuilderTemplate(CreateInstanceRequestBuilderTemplate&&) =
+  CreateInstanceRequestBuilder(CreateInstanceRequestBuilder const&) = default;
+  CreateInstanceRequestBuilder(CreateInstanceRequestBuilder&&) = default;
+  CreateInstanceRequestBuilder& operator=(CreateInstanceRequestBuilder const&) =
       default;
-  CreateInstanceRequestBuilderTemplate& operator=(
-      CreateInstanceRequestBuilderTemplate const&) = default;
-  CreateInstanceRequestBuilderTemplate& operator=(
-      CreateInstanceRequestBuilderTemplate&&) = default;
+  CreateInstanceRequestBuilder& operator=(CreateInstanceRequestBuilder&&) =
+      default;
 
   /**
-   * Constructor that accepts Instance.
+   * Constructor requires Instance and Cloud Spanner instance config name. It
+   * sets node_count = 1, and display_name = instance_id as the default value.
    */
-  explicit CreateInstanceRequestBuilderTemplate(Instance const& in) {
+  explicit CreateInstanceRequestBuilder(Instance const& in,
+                                        std::string config) {
     request_.set_parent("projects/" + in.project_id());
     request_.set_instance_id(in.instance_id());
     request_.mutable_instance()->set_name(in.FullName());
-  }
-
-  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::DisplayName>&
-  SetDisplayName(std::string display_name) & {
-    request_.mutable_instance()->set_display_name(std::move(display_name));
-    return reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-        CurrentMask | FieldBits::DisplayName>&>(*this);
-  }
-
-  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::DisplayName>&&
-  SetDisplayName(std::string display_name) && {
-    request_.mutable_instance()->set_display_name(std::move(display_name));
-    return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-                         CurrentMask | FieldBits::DisplayName>&>(*this));
-  }
-
-  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::NodeCount>&
-  SetNodeCount(int node_count) & {
-    request_.mutable_instance()->set_node_count(node_count);
-    return reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-        CurrentMask | FieldBits::NodeCount>&>(*this);
-  }
-
-  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::NodeCount>&&
-  SetNodeCount(int node_count) && {
-    request_.mutable_instance()->set_node_count(node_count);
-    return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-                         CurrentMask | FieldBits::NodeCount>&>(*this));
-  }
-
-  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Config>&
-  SetConfig(std::string config) & {
+    request_.mutable_instance()->set_display_name(in.instance_id());
+    request_.mutable_instance()->set_node_count(1);
     request_.mutable_instance()->set_config(std::move(config));
-    return reinterpret_cast<
-        CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Config>&>(
-        *this);
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Config>&&
-  SetConfig(std::string config) && {
-    request_.mutable_instance()->set_config(std::move(config));
-    return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-                         CurrentMask | FieldBits::Config>&>(*this));
+  CreateInstanceRequestBuilder& SetDisplayName(std::string display_name) & {
+    request_.mutable_instance()->set_display_name(std::move(display_name));
+    return *this;
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Labels>&
-  SetLabels(std::map<std::string, std::string> const& labels) & {
+  CreateInstanceRequestBuilder&& SetDisplayName(std::string display_name) && {
+    request_.mutable_instance()->set_display_name(std::move(display_name));
+    return std::move(*this);
+  }
+
+  CreateInstanceRequestBuilder& SetNodeCount(int node_count) & {
+    request_.mutable_instance()->set_node_count(node_count);
+    return *this;
+  }
+
+  CreateInstanceRequestBuilder&& SetNodeCount(int node_count) && {
+    request_.mutable_instance()->set_node_count(node_count);
+    return std::move(*this);
+  }
+
+  CreateInstanceRequestBuilder& SetLabels(
+      std::map<std::string, std::string> const& labels) & {
     for (auto const& pair : labels) {
       request_.mutable_instance()->mutable_labels()->insert(
           {pair.first, pair.second});
     }
-    return reinterpret_cast<
-        CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Labels>&>(
-        *this);
+    return *this;
   }
 
-  CreateInstanceRequestBuilderTemplate<CurrentMask | FieldBits::Labels>&&
-  SetLabels(std::map<std::string, std::string> const& labels) && {
-    CreateInstanceRequestBuilderTemplate next = *this;
+  CreateInstanceRequestBuilder&& SetLabels(
+      std::map<std::string, std::string> const& labels) && {
     for (auto const& pair : labels) {
       request_.mutable_instance()->mutable_labels()->insert(
           {pair.first, pair.second});
     }
-    return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
-                         CurrentMask | FieldBits::Labels>&>(*this));
+    return std::move(*this);
   }
 
   google::spanner::admin::instance::v1::CreateInstanceRequest& Build() & {
-    static_assert(
-        (CurrentMask &
-         (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config)) ==
-            (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config),
-        "Call SetDisplayName(), SetNodeCount(), and SetConfig() before calling "
-        "Build().");
     return request_;
   }
   google::spanner::admin::instance::v1::CreateInstanceRequest&& Build() && {
-    static_assert(
-        (CurrentMask &
-         (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config)) ==
-            (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config),
-        "Call SetDisplayName(), SetNodeCount(), and SetConfig() before calling "
-        "Build().");
     return std::move(request_);
   }
 
  private:
   google::spanner::admin::instance::v1::CreateInstanceRequest request_;
 };
-
-/**
- * CreateInstanceRequestBuilder is a builder class for
- * `google::spanner::admin::instance::v1::CreateInstanceRequest`
- *
- * This is useful when calling InstanceAdminClient::CreateInstance()
- * function. Call SetDiplayName(), SetNodeCount(), and SetConfig() before
- * calling Build().
- *
- * @par Example
- * @snippet samples.cc create-instance
- */
-typedef CreateInstanceRequestBuilderTemplate<0> CreateInstanceRequestBuilder;
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/create_instance_request_builder.h
+++ b/google/cloud/spanner/create_instance_request_builder.h
@@ -26,103 +26,140 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 /**
- * CreateInstanceRequestBuilder is a builder class for
- * `google::spanner::admin::instance::v1::CreateInstanceRequest`
- *
- * This is useful when calling InstanceAdminClient::CreateInstance()
- * function. If you see an error message like "error: no member named 'Build'",
- * this means you don't set a mandatory field.
- *
- * @par Example
- * @snippet samples.cc create-instance
+ * CreateInstanceRequestBuilderTemplate turns on the field bit once it is set
+ * and carries the bit as the template argument.
  */
-class CreateInstanceRequestBuilder {
+template <unsigned CurrentBit>
+class CreateInstanceRequestBuilderTemplate {
+  struct FieldBits {
+    enum {
+      DisplayName = (1 << 0),
+      NodeCount = (1 << 1),
+      Config = (1 << 2),
+      Labels = (1 << 3)
+    };
+  };
+
  public:
   // Copy and move.
-  CreateInstanceRequestBuilder(CreateInstanceRequestBuilder const&) = default;
-  CreateInstanceRequestBuilder(CreateInstanceRequestBuilder&&) = default;
-  CreateInstanceRequestBuilder& operator=(CreateInstanceRequestBuilder const&) =
+  CreateInstanceRequestBuilderTemplate(
+      CreateInstanceRequestBuilderTemplate const&) = default;
+  CreateInstanceRequestBuilderTemplate(CreateInstanceRequestBuilderTemplate&&) =
       default;
-  CreateInstanceRequestBuilder& operator=(CreateInstanceRequestBuilder&&) =
-      default;
+  CreateInstanceRequestBuilderTemplate& operator=(
+      CreateInstanceRequestBuilderTemplate const&) = default;
+  CreateInstanceRequestBuilderTemplate& operator=(
+      CreateInstanceRequestBuilderTemplate&&) = default;
 
   /**
-   * Only constructor that accepts Instance.
+   * Constructor that accepts Instance.
    */
-  explicit CreateInstanceRequestBuilder(Instance const& in) {
+  explicit CreateInstanceRequestBuilderTemplate(Instance const& in) {
     request_.set_parent("projects/" + in.project_id());
     request_.set_instance_id(in.instance_id());
     request_.mutable_instance()->set_name(in.FullName());
   }
 
-  class NodeCountSetter;
-  class ConfigSetter;
-  class Builder;
-
-  NodeCountSetter& SetDisplayName(std::string const& display_name) & {
+  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::DisplayName>&
+  SetDisplayName(std::string display_name) & {
     request_.mutable_instance()->set_display_name(std::move(display_name));
-    return reinterpret_cast<NodeCountSetter&>(*this);
+    return reinterpret_cast<CreateInstanceRequestBuilderTemplate<
+        CurrentBit | FieldBits::DisplayName>&>(*this);
   }
 
-  NodeCountSetter&& SetDisplayName(std::string const& display_name) && {
+  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::DisplayName>&&
+  SetDisplayName(std::string display_name) && {
     request_.mutable_instance()->set_display_name(std::move(display_name));
-    return std::move(reinterpret_cast<NodeCountSetter&>(*this));
+    return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
+                         CurrentBit | FieldBits::DisplayName>&>(*this));
   }
 
- protected:
-  google::spanner::admin::instance::v1::CreateInstanceRequest request_;
-};
-
-class CreateInstanceRequestBuilder::NodeCountSetter
-    : public CreateInstanceRequestBuilder {
- public:
-  ConfigSetter& SetNodeCount(int node_count) & {
+  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::NodeCount>&
+  SetNodeCount(int node_count) & {
     request_.mutable_instance()->set_node_count(node_count);
-    return reinterpret_cast<ConfigSetter&>(*this);
+    return reinterpret_cast<CreateInstanceRequestBuilderTemplate<
+        CurrentBit | FieldBits::NodeCount>&>(*this);
   }
-  ConfigSetter&& SetNodeCount(int node_count) && {
+
+  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::NodeCount>&&
+  SetNodeCount(int node_count) && {
     request_.mutable_instance()->set_node_count(node_count);
-    return std::move(reinterpret_cast<ConfigSetter&>(*this));
+    return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
+                         CurrentBit | FieldBits::NodeCount>&>(*this));
   }
-};
 
-class CreateInstanceRequestBuilder::ConfigSetter
-    : public CreateInstanceRequestBuilder {
- public:
-  Builder& SetConfig(std::string config) & {
+  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Config>&
+  SetConfig(std::string config) & {
     request_.mutable_instance()->set_config(std::move(config));
-    return reinterpret_cast<Builder&>(*this);
+    return reinterpret_cast<
+        CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Config>&>(
+        *this);
   }
-  Builder&& SetConfig(std::string config) && {
-    request_.mutable_instance()->set_config(std::move(config));
-    return std::move(reinterpret_cast<Builder&>(*this));
-  }
-};
 
-class CreateInstanceRequestBuilder::Builder
-    : public CreateInstanceRequestBuilder {
- public:
-  Builder& SetLabels(std::map<std::string, std::string> const& labels) & {
+  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Config>&&
+  SetConfig(std::string config) && {
+    request_.mutable_instance()->set_config(std::move(config));
+    return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
+                         CurrentBit | FieldBits::Config>&>(*this));
+  }
+
+  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Labels>&
+  SetLabels(std::map<std::string, std::string> const& labels) & {
     for (auto const& pair : labels) {
       request_.mutable_instance()->mutable_labels()->insert(
           {pair.first, pair.second});
     }
-    return *this;
+    return reinterpret_cast<
+        CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Labels>&>(
+        *this);
   }
-  Builder&& SetLabels(std::map<std::string, std::string> const& labels) && {
+
+  CreateInstanceRequestBuilderTemplate<CurrentBit | FieldBits::Labels>&&
+  SetLabels(std::map<std::string, std::string> const& labels) && {
+    CreateInstanceRequestBuilderTemplate next = *this;
     for (auto const& pair : labels) {
       request_.mutable_instance()->mutable_labels()->insert(
           {pair.first, pair.second});
     }
-    return std::move(*this);
+    return std::move(reinterpret_cast<CreateInstanceRequestBuilderTemplate<
+                         CurrentBit | FieldBits::Labels>&>(*this));
   }
+
   google::spanner::admin::instance::v1::CreateInstanceRequest& Build() & {
+    static_assert(
+        (CurrentBit &
+         (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config)) ==
+            (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config),
+        "Call SetDisplayName(), SetNodeCount(), and SetConfig() before calling "
+        "Build().");
     return request_;
   }
   google::spanner::admin::instance::v1::CreateInstanceRequest&& Build() && {
+    static_assert(
+        (CurrentBit &
+         (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config)) ==
+            (FieldBits::DisplayName | FieldBits::NodeCount | FieldBits::Config),
+        "Call SetDisplayName(), SetNodeCount(), and SetConfig() before calling "
+        "Build().");
     return std::move(request_);
   }
+
+ private:
+  google::spanner::admin::instance::v1::CreateInstanceRequest request_;
 };
+
+/**
+ * CreateInstanceRequestBuilder is a builder class for
+ * `google::spanner::admin::instance::v1::CreateInstanceRequest`
+ *
+ * This is useful when calling InstanceAdminClient::CreateInstance()
+ * function. Call SetDiplayName(), SetNodeCount(), and SetConfig() before
+ * calling Build().
+ *
+ * @par Example
+ * @snippet samples.cc create-instance
+ */
+typedef CreateInstanceRequestBuilderTemplate<0> CreateInstanceRequestBuilder;
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/create_instance_request_builder_test.cc
+++ b/google/cloud/spanner/create_instance_request_builder_test.cc
@@ -1,0 +1,74 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/create_instance_request_builder.h"
+#include "google/cloud/spanner/instance.h"
+#include <google/protobuf/util/field_mask_util.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+TEST(CreateInstanceRequestBuilder, RvalueReference) {
+  std::string expected_name = "projects/test-project/instances/test-instance";
+  std::string expected_config =
+      "projects/test-project/instanceConfigs/test-config";
+  std::string expected_display_name = "test-display-name";
+  Instance in("test-project", "test-instance");
+
+  auto req = CreateInstanceRequestBuilder(in)
+                 .SetDisplayName(expected_display_name)
+                 .SetNodeCount(1)
+                 .SetConfig(expected_config)
+                 .SetLabels({{"key", "value"}})
+                 .Build();
+  EXPECT_EQ("projects/test-project", req.parent());
+  EXPECT_EQ("test-instance", req.instance_id());
+  EXPECT_EQ(expected_name, req.instance().name());
+  EXPECT_EQ(expected_config, req.instance().config());
+  EXPECT_EQ(1, req.instance().node_count());
+  EXPECT_EQ(1, req.instance().labels_size());
+  EXPECT_EQ("value", req.instance().labels().at("key"));
+  EXPECT_EQ(expected_display_name, req.instance().display_name());
+}
+
+TEST(CreateInstanceRequestBuilder, Lvalue) {
+  std::string expected_name = "projects/test-project/instances/test-instance";
+  std::string expected_config =
+      "projects/test-project/instanceConfigs/test-config";
+  std::string expected_display_name = "test-display-name";
+  Instance in("test-project", "test-instance");
+
+  auto builder = CreateInstanceRequestBuilder(in);
+  auto req = builder.SetDisplayName(expected_display_name)
+                 .SetNodeCount(1)
+                 .SetConfig(expected_config)
+                 .SetLabels({{"key", "value"}})
+                 .Build();
+  EXPECT_EQ("projects/test-project", req.parent());
+  EXPECT_EQ("test-instance", req.instance_id());
+  EXPECT_EQ(expected_name, req.instance().name());
+  EXPECT_EQ(expected_config, req.instance().config());
+  EXPECT_EQ(1, req.instance().node_count());
+  EXPECT_EQ(1, req.instance().labels_size());
+  EXPECT_EQ("value", req.instance().labels().at("key"));
+  EXPECT_EQ(expected_display_name, req.instance().display_name());
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/create_instance_request_builder_test.cc
+++ b/google/cloud/spanner/create_instance_request_builder_test.cc
@@ -22,6 +22,23 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
+TEST(CreateInstanceRequestBuilder, DefaultValues) {
+  std::string expected_name = "projects/test-project/instances/test-instance";
+  std::string expected_config =
+      "projects/test-project/instanceConfigs/test-config";
+  std::string expected_display_name = "test-instance";
+  CreateInstanceRequestBuilder builder(
+      Instance("test-project", "test-instance"), expected_config);
+  auto req = builder.Build();
+  EXPECT_EQ("projects/test-project", req.parent());
+  EXPECT_EQ("test-instance", req.instance_id());
+  EXPECT_EQ(expected_name, req.instance().name());
+  EXPECT_EQ(expected_config, req.instance().config());
+  EXPECT_EQ(1, req.instance().node_count());
+  EXPECT_EQ(0, req.instance().labels_size());
+  EXPECT_EQ(expected_display_name, req.instance().display_name());
+}
+
 TEST(CreateInstanceRequestBuilder, RvalueReference) {
   std::string expected_name = "projects/test-project/instances/test-instance";
   std::string expected_config =
@@ -29,10 +46,9 @@ TEST(CreateInstanceRequestBuilder, RvalueReference) {
   std::string expected_display_name = "test-display-name";
   Instance in("test-project", "test-instance");
 
-  auto req = CreateInstanceRequestBuilder(in)
+  auto req = CreateInstanceRequestBuilder(in, expected_config)
                  .SetDisplayName(expected_display_name)
                  .SetNodeCount(1)
-                 .SetConfig(expected_config)
                  .SetLabels({{"key", "value"}})
                  .Build();
   EXPECT_EQ("projects/test-project", req.parent());
@@ -52,10 +68,9 @@ TEST(CreateInstanceRequestBuilder, Lvalue) {
   std::string expected_display_name = "test-display-name";
   Instance in("test-project", "test-instance");
 
-  auto builder = CreateInstanceRequestBuilder(in);
+  auto builder = CreateInstanceRequestBuilder(in, expected_config);
   auto req = builder.SetDisplayName(expected_display_name)
                  .SetNodeCount(1)
-                 .SetConfig(expected_config)
                  .SetLabels({{"key", "value"}})
                  .Build();
   EXPECT_EQ("projects/test-project", req.parent());

--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -26,11 +26,9 @@ InstanceAdminClient::GetInstance(Instance const& in) {
 
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::CreateInstance(
-    std::string const& project_id, std::string const& instance_id,
-    std::string const& display_name, std::string const& instance_config,
-    int node_count, std::map<std::string, std::string> const& labels) {
-  return conn_->CreateInstance({project_id, instance_id, display_name,
-                                instance_config, node_count, labels});
+    google::spanner::admin::instance::v1::CreateInstanceRequest const&
+        request) {
+  return conn_->CreateInstance({request});
 }
 
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -103,6 +103,9 @@ class InstanceAdminClient {
   /**
    * Creates a new Cloud Spanner instance in the given project.
    *
+   * Use CreateInstanceRequestBuilder to build the
+   * `google::spanner::admin::instance::v1::CreateInstanceRequest` object.
+   *
    * Note that the instance id must be between 2 and 64 characters long, it must
    * start with a lowercase letter (`[a-z]`), it must end with a lowercase
    * letter or a number (`[a-z0-9]`) and any characters between the beginning
@@ -114,10 +117,8 @@ class InstanceAdminClient {
    *
    */
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
-  CreateInstance(std::string const& project_id, std::string const& instance_id,
-                 std::string const& display_name,
-                 std::string const& instance_config, int node_count,
-                 std::map<std::string, std::string> const& labels = {});
+  CreateInstance(
+      google::spanner::admin::instance::v1::CreateInstanceRequest const&);
 
   /**
    * Updates a Cloud Spanner instance.

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -90,12 +90,7 @@ class InstanceAdminConnection {
 
   /// Wrap the arguments for `CreateInstance()`.
   struct CreateInstanceParams {
-    std::string project_id;
-    std::string instance_id;
-    std::string display_name;
-    std::string instance_config;
-    int node_count;
-    std::map<std::string, std::string> labels;
+    google::spanner::admin::instance::v1::CreateInstanceRequest request;
   };
 
   /// Wrap the arguments for `UpdateInstance()`.

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/instance_admin_connection.h"
+#include "google/cloud/spanner/create_instance_request_builder.h"
 #include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/testing/mock_instance_admin_stub.h"
 #include "google/cloud/testing_util/assert_ok.h"
@@ -139,10 +140,13 @@ TEST(InstanceAdminClientTest, CreateInstanceSuccess) {
           }));
 
   auto conn = MakeTestConnection(std::move(mock));
-  auto fut = conn->CreateInstance(
-      {"test-project", "test-instance", "test-display-name",
-       "test-instance-config", 1,
-       std::map<std::string, std::string>({{"key", "value"}})});
+  Instance in("test-project", "test-instance");
+  auto fut = conn->CreateInstance({CreateInstanceRequestBuilder(in)
+                                       .SetDisplayName("test-display-name")
+                                       .SetNodeCount(1)
+                                       .SetConfig("test-instance-config")
+                                       .SetLabels({{"key", "value"}})
+                                       .Build()});
   EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto instance = fut.get();
   EXPECT_STATUS_OK(instance);
@@ -161,10 +165,13 @@ TEST(InstanceAdminClientTest, CreateInstanceError) {
           }));
 
   auto conn = MakeTestConnection(std::move(mock));
-  auto fut = conn->CreateInstance(
-      {"test-project", "test-instance", "test-display-name",
-       "test-instance-config", 1,
-       std::map<std::string, std::string>({{"key", "value"}})});
+  Instance in("test-project", "test-instance");
+  auto fut = conn->CreateInstance({CreateInstanceRequestBuilder(in)
+                                       .SetDisplayName("test-display-name")
+                                       .SetNodeCount(1)
+                                       .SetConfig("test-instance-config")
+                                       .SetLabels({{"key", "value"}})
+                                       .Build()});
   EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto instance = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, instance.status().code());

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -167,7 +167,7 @@ TEST(InstanceAdminClientTest, CreateInstanceError) {
   auto conn = MakeTestConnection(std::move(mock));
   Instance in("test-project", "test-instance");
   auto fut = conn->CreateInstance(
-      {CreateInstanceRequestBuilder(in, "test-instnace-config")
+      {CreateInstanceRequestBuilder(in, "test-instance-config")
            .SetDisplayName("test-display-name")
            .SetNodeCount(1)
            .SetLabels({{"key", "value"}})

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -141,12 +141,12 @@ TEST(InstanceAdminClientTest, CreateInstanceSuccess) {
 
   auto conn = MakeTestConnection(std::move(mock));
   Instance in("test-project", "test-instance");
-  auto fut = conn->CreateInstance({CreateInstanceRequestBuilder(in)
-                                       .SetDisplayName("test-display-name")
-                                       .SetNodeCount(1)
-                                       .SetConfig("test-instance-config")
-                                       .SetLabels({{"key", "value"}})
-                                       .Build()});
+  auto fut = conn->CreateInstance(
+      {CreateInstanceRequestBuilder(in, "test-instance-config")
+           .SetDisplayName("test-display-name")
+           .SetNodeCount(1)
+           .SetLabels({{"key", "value"}})
+           .Build()});
   EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(10)));
   auto instance = fut.get();
   EXPECT_STATUS_OK(instance);
@@ -166,12 +166,12 @@ TEST(InstanceAdminClientTest, CreateInstanceError) {
 
   auto conn = MakeTestConnection(std::move(mock));
   Instance in("test-project", "test-instance");
-  auto fut = conn->CreateInstance({CreateInstanceRequestBuilder(in)
-                                       .SetDisplayName("test-display-name")
-                                       .SetNodeCount(1)
-                                       .SetConfig("test-instance-config")
-                                       .SetLabels({{"key", "value"}})
-                                       .Build()});
+  auto fut = conn->CreateInstance(
+      {CreateInstanceRequestBuilder(in, "test-instnace-config")
+           .SetDisplayName("test-display-name")
+           .SetNodeCount(1)
+           .SetLabels({{"key", "value"}})
+           .Build()});
   EXPECT_EQ(std::future_status::ready, fut.wait_for(std::chrono::seconds(0)));
   auto instance = fut.get();
   EXPECT_EQ(StatusCode::kPermissionDenied, instance.status().code());

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -157,10 +157,9 @@ TEST_F(InstanceAdminClientTestWithCleanup, InstanceCRUDOperations) {
   auto instance_config = instance_config_names[0];
 
   future<StatusOr<google::spanner::admin::instance::v1::Instance>> f =
-      client_.CreateInstance(CreateInstanceRequestBuilder(in)
+      client_.CreateInstance(CreateInstanceRequestBuilder(in, instance_config)
                                  .SetDisplayName("test-display-name")
                                  .SetNodeCount(1)
-                                 .SetConfig(instance_config)
                                  .SetLabels({{"label-key", "label-value"}})
                                  .Build());
   StatusOr<google::spanner::admin::instance::v1::Instance> instance = f.get();

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/spanner/create_instance_request_builder.h"
 #include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/spanner/testing/random_instance_name.h"
 #include "google/cloud/spanner/update_instance_request_builder.h"
@@ -156,9 +157,12 @@ TEST_F(InstanceAdminClientTestWithCleanup, InstanceCRUDOperations) {
   auto instance_config = instance_config_names[0];
 
   future<StatusOr<google::spanner::admin::instance::v1::Instance>> f =
-      client_.CreateInstance(
-          project_id_, instance_id, "test-display-name", instance_config, 1,
-          std::map<std::string, std::string>{{"label-key", "label-value"}});
+      client_.CreateInstance(CreateInstanceRequestBuilder(in)
+                                 .SetDisplayName("test-display-name")
+                                 .SetNodeCount(1)
+                                 .SetConfig(instance_config)
+                                 .SetLabels({{"label-key", "label-value"}})
+                                 .Build());
   StatusOr<google::spanner::admin::instance::v1::Instance> instance = f.get();
 
   EXPECT_STATUS_OK(instance.status());

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -78,10 +78,10 @@ void CreateInstance(google::cloud::spanner::InstanceAdminClient client,
   auto instance_config = instance_config_names[0];
   future<StatusOr<google::spanner::admin::instance::v1::Instance>> f =
       client.CreateInstance(
-          google::cloud::spanner::CreateInstanceRequestBuilder(in)
+          google::cloud::spanner::CreateInstanceRequestBuilder(in,
+                                                               instance_config)
               .SetDisplayName(display_name)
               .SetNodeCount(1)
-              .SetConfig(instance_config)
               .SetLabels({{"label-key", "label-value"}})
               .Build());
   StatusOr<google::spanner::admin::instance::v1::Instance> instance = f.get();

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -15,6 +15,7 @@
 //! [START spanner_quickstart]
 #include "google/cloud/spanner/client.h"
 //! [END spanner_quickstart]
+#include "google/cloud/spanner/create_instance_request_builder.h"
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
@@ -77,8 +78,12 @@ void CreateInstance(google::cloud::spanner::InstanceAdminClient client,
   auto instance_config = instance_config_names[0];
   future<StatusOr<google::spanner::admin::instance::v1::Instance>> f =
       client.CreateInstance(
-          project_id, instance_id, display_name, instance_config, 1,
-          std::map<std::string, std::string>{{"label-key", "label-value"}});
+          google::cloud::spanner::CreateInstanceRequestBuilder(in)
+              .SetDisplayName(display_name)
+              .SetNodeCount(1)
+              .SetConfig(instance_config)
+              .SetLabels({{"label-key", "label-value"}})
+              .Build());
   StatusOr<google::spanner::admin::instance::v1::Instance> instance = f.get();
   if (!instance) {
     throw std::runtime_error(instance.status().message());

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -23,6 +23,7 @@ spanner_client_hdrs = [
     "commit_result.h",
     "connection.h",
     "connection_options.h",
+    "create_instance_request_builder.h",
     "database.h",
     "database_admin_client.h",
     "database_admin_connection.h",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -61,6 +61,7 @@ spanner_client_unit_tests = [
     "spanner_version_test.cc",
     "sql_statement_test.cc",
     "transaction_test.cc",
+    "create_instance_request_builder_test.cc",
     "update_instance_request_builder_test.cc",
     "value_test.cc",
 ]


### PR DESCRIPTION
* BREAKING CHANGE: changed the function signature of InstanceAdminClient::CreateInstance()

fixes #931 

The builder forces you to provide `Instance` object and Spanner Config name when constructing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/933)
<!-- Reviewable:end -->
