### PR TITLE
feat!: Use ReadResult instead of ResultSet; remove ResultSet

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -27,32 +27,33 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-StatusOr<ResultSet> Client::Read(std::string table, KeySet keys,
-                                 std::vector<std::string> columns,
-                                 ReadOptions read_options) {
+ReadResult Client::Read(std::string table, KeySet keys,
+                        std::vector<std::string> columns,
+                        ReadOptions read_options) {
   return conn_->Read(
       {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        std::move(table), std::move(keys), std::move(columns),
        std::move(read_options)});
 }
 
-StatusOr<ResultSet> Client::Read(
-    Transaction::SingleUseOptions transaction_options, std::string table,
-    KeySet keys, std::vector<std::string> columns, ReadOptions read_options) {
+ReadResult Client::Read(Transaction::SingleUseOptions transaction_options,
+                        std::string table, KeySet keys,
+                        std::vector<std::string> columns,
+                        ReadOptions read_options) {
   return conn_->Read(
       {internal::MakeSingleUseTransaction(std::move(transaction_options)),
        std::move(table), std::move(keys), std::move(columns),
        std::move(read_options)});
 }
 
-StatusOr<ResultSet> Client::Read(Transaction transaction, std::string table,
-                                 KeySet keys, std::vector<std::string> columns,
-                                 ReadOptions read_options) {
+ReadResult Client::Read(Transaction transaction, std::string table, KeySet keys,
+                        std::vector<std::string> columns,
+                        ReadOptions read_options) {
   return conn_->Read({std::move(transaction), std::move(table), std::move(keys),
                       std::move(columns), std::move(read_options)});
 }
 
-StatusOr<ResultSet> Client::Read(ReadPartition const& read_partition) {
+ReadResult Client::Read(ReadPartition const& read_partition) {
   return conn_->Read(internal::MakeReadParams(read_partition));
 }
 

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -75,16 +75,12 @@ inline namespace SPANNER_CLIENT_NS {
  *
  * @code
  * namespace cs = ::google::cloud::spanner;
- * using ::google::cloud::StatusOr;
  *
  * auto db = cs::Database("my_project", "my_instance", "my_db_id"));
  * auto conn = cs::MakeConnection(db);
  * auto client = cs::Client(conn);
  *
- * StatusOr<cs::ResultSet> result = client.Read(...);
- * if (!result) {
- *   return result.status();
- * }
+ * cs::ReadResult result = client.Read(...);
  * using RowType = Row<std::int64_t, std::string>;
  * for (auto const& row : result.Rows<RowType>()) {
  *   // ...
@@ -143,31 +139,30 @@ class Client {
    *     this request.
    * @param read_options `ReadOptions` used for this request.
    *
-   * @return A `StatusOr` containing a `ResultSet` or error status on failure.
-   *     No individual row in the `ResultSet` can exceed 100 MiB, and no column
-   *     value can exceed 10 MiB.
+   * @note No individual row in the `ReadResult` can exceed 100 MiB, and no
+   *     column value can exceed 10 MiB.
    */
-  StatusOr<ResultSet> Read(std::string table, KeySet keys,
-                           std::vector<std::string> columns,
-                           ReadOptions read_options = {});
+  ReadResult Read(std::string table, KeySet keys,
+                  std::vector<std::string> columns,
+                  ReadOptions read_options = {});
   /**
    * @copydoc Read
    *
    * @param transaction_options Execute this read in a single-use transaction
    * with these options.
    */
-  StatusOr<ResultSet> Read(Transaction::SingleUseOptions transaction_options,
-                           std::string table, KeySet keys,
-                           std::vector<std::string> columns,
-                           ReadOptions read_options = {});
+  ReadResult Read(Transaction::SingleUseOptions transaction_options,
+                  std::string table, KeySet keys,
+                  std::vector<std::string> columns,
+                  ReadOptions read_options = {});
   /**
    * @copydoc Read
    *
    * @param transaction Execute this read as part of an existing transaction.
    */
-  StatusOr<ResultSet> Read(Transaction transaction, std::string table,
-                           KeySet keys, std::vector<std::string> columns,
-                           ReadOptions read_options = {});
+  ReadResult Read(Transaction transaction, std::string table, KeySet keys,
+                  std::vector<std::string> columns,
+                  ReadOptions read_options = {});
   //@}
 
   /**
@@ -177,14 +172,13 @@ class Client {
    *
    * @param partition A `ReadPartition`, obtained by calling `PartitionRead`.
    *
-   * @return A `StatusOr` containing a `ResultSet` or error status on failure.
-   *     No individual row in the `ResultSet` can exceed 100 MiB, and no column
-   *     value can exceed 10 MiB.
+   * @note No individual row in the `ReadResult` can exceed 100 MiB, and no
+   *     column value can exceed 10 MiB.
    *
    * @par Example
    * @snippet samples.cc read-read-partition
    */
-  StatusOr<ResultSet> Read(ReadPartition const& partition);
+  ReadResult Read(ReadPartition const& partition);
 
   /**
    * Creates a set of partitions that can be used to execute a read
@@ -237,8 +231,8 @@ class Client {
    *
    * @param statement The SQL statement to execute.
    *
-   * @note No individual row in the `ResultSet` can exceed 100 MiB, and no
-   * column value can exceed 10 MiB.
+   * @note No individual row in the `ExecuteQueryResult` can exceed 100 MiB, and
+   * no column value can exceed 10 MiB.
    */
   ExecuteQueryResult ExecuteQuery(SqlStatement statement);
 
@@ -266,8 +260,8 @@ class Client {
    *
    * @param partition A `QueryPartition`, obtained by calling `PartitionRead`.
    *
-   * @note No individual row in the `ResultSet` can exceed 100 MiB, and no
-   * column value can exceed 10 MiB.
+   * @note No individual row in the `ExecuteQueryResult` can exceed 100 MiB, and
+   * no column value can exceed 10 MiB.
    *
    * @par Example
    * @snippet samples.cc execute-sql-query-partition

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -133,7 +133,7 @@ class Connection {
   //@}
 
   /// Define the interface for a google.spanner.v1.Spanner.Read RPC
-  virtual StatusOr<ResultSet> Read(ReadParams) = 0;
+  virtual ReadResult Read(ReadParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.PartitionRead RPC
   virtual StatusOr<std::vector<ReadPartition>> PartitionRead(

--- a/google/cloud/spanner/doc/spanner-mocking.dox
+++ b/google/cloud/spanner/doc/spanner-mocking.dox
@@ -35,9 +35,9 @@ And then verify the results meet your expectations:
 
 @snippet mock_execute_query.cc expected-results
 
-All of this depends on creating a `google::cloud::spanner::ResultSet` that
-simulates the stream of results you want. To do so, you need to mock a source
-that streams `google::cloud::spanner::Values`:
+All of this depends on creating a `google::cloud::spanner::ExecuteQueryResult`
+that simulates the stream of results you want. To do so, you need to mock a
+source that streams `google::cloud::spanner::Values`:
 
 @snippet mock_execute_query.cc create-streaming-source
 

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -175,10 +175,8 @@ TEST(ClientStressTest, UpsertAndRead) {
 
         auto reader = client.Read("Singers", range,
                                   {"SingerId", "FirstName", "LastName"});
-        result.Update(reader.status());
-        if (!reader) continue;
         using RowType = Row<std::int64_t, std::string, std::string>;
-        for (auto row : reader->Rows<RowType>()) {
+        for (auto row : reader.Rows<RowType>()) {
           result.Update(row.status());
         }
       }

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -67,7 +67,7 @@ class ConnectionImpl : public Connection,
                        public SessionManager,
                        public std::enable_shared_from_this<ConnectionImpl> {
  public:
-  StatusOr<ResultSet> Read(ReadParams) override;
+  ReadResult Read(ReadParams) override;
   StatusOr<std::vector<ReadPartition>> PartitionRead(
       PartitionReadParams) override;
   ExecuteQueryResult ExecuteQuery(ExecuteSqlParams) override;
@@ -89,9 +89,9 @@ class ConnectionImpl : public Connection,
                  std::unique_ptr<RetryPolicy> retry_policy,
                  std::unique_ptr<BackoffPolicy> backoff_policy);
 
-  StatusOr<ResultSet> ReadImpl(SessionHolder& session,
-                               google::spanner::v1::TransactionSelector& s,
-                               ReadParams rp);
+  ReadResult ReadImpl(SessionHolder& session,
+                      google::spanner::v1::TransactionSelector& s,
+                      ReadParams rp);
 
   StatusOr<std::vector<ReadPartition>> PartitionReadImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -39,7 +39,7 @@ inline namespace SPANNER_CLIENT_NS {
  */
 class MockConnection : public spanner::Connection {
  public:
-  MOCK_METHOD1(Read, StatusOr<spanner::ResultSet>(ReadParams));
+  MOCK_METHOD1(Read, spanner::ReadResult(ReadParams));
   MOCK_METHOD1(PartitionRead, StatusOr<std::vector<spanner::ReadPartition>>(
                                   PartitionReadParams));
   MOCK_METHOD1(ExecuteQuery, spanner::ExecuteQueryResult(ExecuteSqlParams));


### PR DESCRIPTION
BREAKING CHANGE: Completes refactoring and removal of ResultSet in favor of more
specific result return types. Profiling methods and result types to be added in a subsequent
PR. Possible combining of ReadResult and ExecuteQueryResult types deferred to a future
PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/935)
<!-- Reviewable:end -->
