### PR TITLE
feat: class templates removed from keys.h

### DIFF
--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -98,10 +98,7 @@ TEST_F(ClientIntegrationTest, DeleteAndCommit) {
 
   auto commit_result =
       RunTransaction(*client_, {}, [](Client const&, Transaction const&) {
-        return Mutations{
-            MakeDeleteMutation("Singers", KeySetBuilder<Row<std::int64_t>>()
-                                              .Add(MakeRow(std::int64_t(1)))
-                                              .Build())};
+        return Mutations{MakeDeleteMutation("Singers", KeySet().AddKey(1))};
       });
   EXPECT_STATUS_OK(commit_result);
 
@@ -262,8 +259,7 @@ TEST_F(ClientIntegrationTest, RunTransaction) {
 
   // Delete SingerId 102.
   auto deleter = [](Client const&, Transaction const&) {
-    auto ksb = KeySetBuilder<Row<std::int64_t>>().Add(MakeRow(102));
-    auto mutation = MakeDeleteMutation("Singers", ksb.Build());
+    auto mutation = MakeDeleteMutation("Singers", KeySet().AddKey(102));
     return Mutations{mutation};
   };
   auto delete_result = RunTransaction(*client_, {}, deleter);
@@ -273,9 +269,8 @@ TEST_F(ClientIntegrationTest, RunTransaction) {
   // Read SingerIds [100 ... 200).
   using RowType = Row<std::int64_t>;
   std::vector<std::int64_t> ids;
-  auto ksb = KeySetBuilder<RowType>().Add(MakeKeyRange(
-      MakeKeyBoundClosed(MakeRow(100)), MakeKeyBoundOpen(MakeRow(200))));
-  auto results = client_->Read("Singers", ksb.Build(), {"SingerId"});
+  auto ks = KeySet().AddRange(MakeKeyBoundClosed(100), MakeKeyBoundOpen(200));
+  auto results = client_->Read("Singers", std::move(ks), {"SingerId"});
   EXPECT_STATUS_OK(results);
   if (results) {
     for (auto& row : results->Rows<RowType>()) {

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -167,11 +167,9 @@ TEST(ClientStressTest, UpsertAndRead) {
         result.Update(commit.status());
       } else {
         auto size = random_limit(generator);
-        using KeyType = Row<std::int64_t>;
         auto range =
-            spanner::KeySetBuilder<KeyType>(
-                spanner::MakeKeyRangeClosed(KeyType(key), KeyType(key + size)))
-                .Build();
+            spanner::KeySet().AddRange(spanner::MakeKeyBoundClosed(key),
+                                       spanner::MakeKeyBoundClosed(key + size));
 
         auto reader = client.Read("Singers", range,
                                   {"SingerId", "FirstName", "LastName"});

--- a/google/cloud/spanner/keys.cc
+++ b/google/cloud/spanner/keys.cc
@@ -22,24 +22,23 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-bool operator==(KeySet const& lhs, KeySet const& rhs) {
-  google::protobuf::util::MessageDifferencer differencer;
-  return differencer.Compare(lhs.proto_, rhs.proto_);
-}
-
-bool operator!=(KeySet const& lhs, KeySet const& rhs) { return !(lhs == rhs); }
-
 namespace internal {
 
-::google::spanner::v1::KeySet ToProto(KeySet keyset) {
-  return std::move(keyset.proto_);
+::google::spanner::v1::KeySet ToProto(KeySet ks) {
+  return std::move(ks.proto_);
 }
 
-KeySet FromProto(::google::spanner::v1::KeySet keyset) {
-  return KeySet(std::move(keyset));
+KeySet FromProto(::google::spanner::v1::KeySet proto) {
+  return KeySet(std::move(proto));
 }
 
 }  // namespace internal
+
+bool operator==(KeySet const& a, KeySet const& b) {
+  google::protobuf::util::MessageDifferencer differencer;
+  return differencer.Compare(a.proto_, b.proto_);
+}
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -32,7 +32,7 @@ inline namespace SPANNER_CLIENT_NS {
  * to the i'th component of the table or primary index key.
  *
  * In C++, this is implemented as a `std::vector<Value>`. See the `MakeKey`
- * factory function below for easy way to construct a valid `Key` instance.
+ * factory function below for an easy way to construct a valid `Key` instance.
  */
 using Key = std::vector<Value>;
 
@@ -71,7 +71,7 @@ class KeyBound {
   /// (open).
   enum Bound { kClosed, kOpen };
 
-  /// No default constructor.
+  /// Not default constructible
   KeyBound() = delete;
 
   /// Constructs an instance with the given @p key and @p bound.

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -42,10 +42,10 @@ using Key = std::vector<Value>;
  * @par Example
  *
  * @code
-*  Key key = MakeKey(123, "hello");
-*  assert(key.size() == 2);
-*  assert(key[0] == Value(123));
-*  assert(key[1] == Value("hello"));
+ *  Key key = MakeKey(123, "hello");
+ *  assert(key.size() == 2);
+ *  assert(key[0] == Value(123));
+ *  assert(key[1] == Value("hello"));
  * @endcode
  */
 template <typename... Ts>
@@ -103,8 +103,8 @@ class KeyBound {
   ///@}
 
  private:
-   Key key_;
-   Bound bound_;
+  Key key_;
+  Bound bound_;
 };
 
 /**
@@ -160,7 +160,7 @@ class KeySet {
   KeySet& operator=(KeySet&& rhs) = default;
 
   /// Adds the given @p key to the `KeySet`.
-  KeySet& AddKey(Key key); 
+  KeySet& AddKey(Key key);
 
   /// Constructs a `Key` from the given args and adds it to the `KeySet`.
   template <typename... Ts>

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -29,204 +29,128 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-class KeySet;
-template <typename RowType>
-class KeySetBuilder;
-
-namespace internal {
-::google::spanner::v1::KeySet ToProto(KeySet keyset);
-KeySet FromProto(::google::spanner::v1::KeySet keyset);
-
-template <typename T>
-struct IsRow : std::false_type {};
-
-template <typename... Ts>
-struct IsRow<Row<Ts...>> : std::true_type {};
-}  // namespace internal
+/**
+ * A `Key` is a collection of `Value` objects where the i'th value corresponds
+ * to the i'th component of the table or primary index key.
+ *
+ * In C++, this is implemented as a `std::vector<Value>`. See the `MakeKey`
+ * factory function below for easy way to construct a valid `Key` instance.
+ */
+using Key = std::vector<Value>;
 
 /**
- * The `KeyBound` class is a regular type that represents one endpoint of an
- * interval of keys.
+ * Constructs a `Key` from the given arguments.
+ *
+ * @par Example
+ *
+ * @code
+*  Key key = MakeKey(123, "hello");
+*  assert(key.size() == 2);
+*  assert(key[0] == Value(123));
+*  assert(key[1] == Value("hello"));
+ * @endcode
+ */
+template <typename... Ts>
+Key MakeKey(Ts&&... ts) {
+  return Key{Value(std::forward<Ts>(ts))...};
+}
+
+/**
+ * The `KeyBound` class is a regular type that represents an open or closed
+ * endpoint for a range of keys.
  *
  * `KeyBound`s can be "open", meaning the matching row will be excluded from
  * the results, or "closed" meaning the matching row will be included.
  * `KeyBound` instances should be created with the `MakeKeyBoundOpen()` or
  * `MakeKeyBoundClosed()` factory functions.
  *
- * @tparam KeyType spanner::Row<Types...> that corresponds to the desired index
- * definition.
+ * See the `MakeKeyBoundClosed()` and `MakeKeyBoundOpen()` factory functions
+ * below for convenient ways to construct instances of KeyBound.
  */
-template <typename RowType>
 class KeyBound {
  public:
-  static_assert(internal::IsRow<RowType>::value,
-                "KeyType must be of type spanner::Row<>.");
+  enum Bound { kClosed, kOpen };
 
-  // Not default constructible
   KeyBound() = delete;
 
-  // Copy and move constructors and assignment operators.
-  KeyBound(KeyBound const& key_range) = default;
-  KeyBound& operator=(KeyBound const& rhs) = default;
-  KeyBound(KeyBound&& key_range) = default;
-  KeyBound& operator=(KeyBound&& rhs) = default;
+  /// Constructs an instance with the given @p key and @p bound.
+  KeyBound(Key key, Bound bound) : key_(std::move(key)), bound_(bound) {}
 
-  RowType const& key() const& { return key_; }
-  RowType&& key() && { return std::move(key_); }
+  /// @name Copy and move
+  ///@{
+  KeyBound(KeyBound const&) = default;
+  KeyBound& operator=(KeyBound const&) = default;
+  KeyBound(KeyBound&&) = default;
+  KeyBound& operator=(KeyBound&&) = default;
+  ///@}
 
-  bool IsClosed() const { return mode_ == Mode::kClosed; }
-  bool IsOpen() const { return mode_ == Mode::kOpen; }
+  /// @name Returns the `Key`.
+  ///@{
+  Key const& key() const& { return key_; }
+  Key&& key() && { return std::move(key_); }
+  ///@}
 
-  friend bool operator==(KeyBound const& lhs, KeyBound const& rhs) {
-    return lhs.key_ == rhs.key_ && lhs.mode_ == rhs.mode_;
+  /// Returns the bound.
+  Bound bound() const { return bound_; }
+
+  /// @name Equality.
+  ///@{
+  friend bool operator==(KeyBound const& a, KeyBound const& b) {
+    return a.key_ == b.key_ && a.bound_ == b.bound_;
   }
-  friend bool operator!=(KeyBound const& lhs, KeyBound const& rhs) {
-    return !(lhs == rhs);
+  friend bool operator!=(KeyBound const& a, KeyBound const& b) {
+    return !(a == b);
   }
+  ///@}
 
  private:
-  enum class Mode { kClosed, kOpen };
-
-  KeyBound(RowType key, Mode mode) : key_(std::move(key)), mode_(mode) {}
-
-  template <typename T>
-  friend KeyBound<T> MakeKeyBoundClosed(T key);
-
-  template <typename T>
-  friend KeyBound<T> MakeKeyBoundOpen(T key);
-
-  RowType key_;
-  Mode mode_;
+   Key key_;
+   Bound bound_;
 };
 
 /**
- * Helper function to create a closed `KeyBound` on the key `spanner::Row`
- * provided.
- *
- * @tparam RowType spanner::Row<Types...> that corresponds to the desired index
- * definition.
- * @param key spanner::Row<Types...>
- * @return KeyBound<RowType>
+ * Returns a "closed" `KeyBound` with a `Key` constructed from the given
+ * arguments.
  */
-template <typename RowType>
-KeyBound<RowType> MakeKeyBoundClosed(RowType key) {
-  return KeyBound<RowType>(std::move(key), KeyBound<RowType>::Mode::kClosed);
+template <typename... Ts>
+KeyBound MakeKeyBoundClosed(Ts&&... ts) {
+  return KeyBound(MakeKey(std::forward<Ts>(ts)...), KeyBound::kClosed);
 }
 
 /**
- * Helper function to create an open `KeyBound` on the key `spanner::Row`
- * provided.
- *
- * @tparam RowType spanner::Row<Types...> that corresponds to the desired index
- * definition.
- * @param key spanner::Row<Types...>
- * @return KeyBound<RowType>
+ * Returns an "open" `KeyBound` with a `Key` constructed from the given
+ * arguments.
  */
-template <typename RowType>
-KeyBound<RowType> MakeKeyBoundOpen(RowType key) {
-  return KeyBound<RowType>(std::move(key), KeyBound<RowType>::Mode::kOpen);
+template <typename... Ts>
+KeyBound MakeKeyBoundOpen(Ts&&... ts) {
+  return KeyBound(MakeKey(std::forward<Ts>(ts)...), KeyBound::kOpen);
 }
 
-/**
- * The `KeyRange` class is a regular type that represents the pair of
- * `KeyBound`s necessary to uniquely identify a contiguous group of key
- * `spanner::Row`s in its index.
- *
- * @tparam KeyType spanner::Row<Types...> that corresponds to the desired index
- * definition.
- */
-template <typename RowType>
-class KeyRange {
- public:
-  static_assert(internal::IsRow<RowType>::value,
-                "KeyType must be of type spanner::Row<>.");
-
-  // Not default constructible
-  KeyRange() = delete;
-
-  /**
-   * Constructs a `KeyRange` with the given `KeyBound`s.
-   */
-  explicit KeyRange(KeyBound<RowType> start, KeyBound<RowType> end)
-      : start_(std::move(start)), end_(std::move(end)) {}
-
-  // Copy and move constructors and assignment operators.
-  KeyRange(KeyRange const& key_range) = default;
-  KeyRange& operator=(KeyRange const& rhs) = default;
-  KeyRange(KeyRange&& key_range) = default;
-  KeyRange& operator=(KeyRange&& rhs) = default;
-
-  KeyBound<RowType> const& start() const& { return start_; }
-  KeyBound<RowType>&& start() && { return std::move(start_); }
-
-  KeyBound<RowType> const& end() const& { return end_; }
-  KeyBound<RowType>&& end() && { return std::move(end_); }
-
-  friend bool operator==(KeyRange const& lhs, KeyRange const& rhs) {
-    return lhs.start_ == rhs.start_ && lhs.end_ == rhs.end_;
-  }
-  friend bool operator!=(KeyRange const& lhs, KeyRange const& rhs) {
-    return !(lhs == rhs);
-  }
-
- private:
-  KeyBound<RowType> start_;
-  KeyBound<RowType> end_;
-};
+class KeySet;
+namespace internal {
+::google::spanner::v1::KeySet ToProto(KeySet);
+KeySet FromProto(::google::spanner::v1::KeySet);
+}  // namespace internal
 
 /**
- * Helper function to create a `KeyRange` between two keys `spanner::Row`s with
- * both `KeyBound`s closed.
+ * The `KeySet` class is a regular type that represents some collection of `Key`s.
  *
- * @tparam RowType spanner::Row<Types...> that corresponds to the desired index
- * definition.
- * @param start spanner::Row<Types...> of the starting key.
- * @param end spanner::Row<Types...> of the ending key.
- * @return KeyRange<RowType>
- */
-template <typename RowType>
-KeyRange<RowType> MakeKeyRangeClosed(RowType start, RowType end) {
-  return MakeKeyRange(MakeKeyBoundClosed(std::move(start)),
-                      MakeKeyBoundClosed(std::move(end)));
-}
-
-/**
- * Helper function to create a `KeyRange` between the `KeyBound`s provided.
+ * Users can construct a `KeySet` instance, then add `Key`s and and ranges of
+ * `Key`s. Users may also optionally construct an instance that represents all
+ * keys with `KeySet::All()`.
  *
- * @tparam RowType spanner::Row<Types...> that corresponds to the desired index
- * definition.
- * @param start spanner::Row<Types...> of the starting key.
- * @param end spanner::Row<Types...> of the ending key.
- * @return KeyRange<RowType>
- */
-template <typename RowType>
-KeyRange<RowType> MakeKeyRange(KeyBound<RowType> start, KeyBound<RowType> end) {
-  return KeyRange<RowType>(std::move(start), std::move(end));
-}
-
-/**
- * The `KeySet` class is a regular type that represents the collection of
- * `spanner::Row`s necessary to uniquely identify a arbitrary group of rows in
- * its index, or all the keys in an index.
- *
- * Unlike `KeySetBuilder`, `KeySet` stores its keys and key ranges in a type
- * erased fashion.
  *
  */
 class KeySet {
  public:
-  /**
-   * Returns a `KeySet` that represents the set of "All" keys for the index.
-   */
+  /// Returns a `KeySet` that represents the set of "All" keys for the index.
   static KeySet All() {
     KeySet ks;
     ks.proto_.set_all(true);
     return ks;
   }
 
-  /**
-   * Constructs an empty `KeySet`.
-   */
+  /// Constructs an empty `KeySet`.
   KeySet() = default;
 
   // Copy and move constructors and assignment operators.
@@ -235,142 +159,52 @@ class KeySet {
   KeySet(KeySet&& key_range) = default;
   KeySet& operator=(KeySet&& rhs) = default;
 
+  /// Adds the given @p key to the `KeySet`.
+  KeySet& AddKey(Key key) {
+    AppendKey(proto_.add_keys(), std::move(key));
+    return *this;
+  }
+
+  /// Constructs a `Key` from the given args and adds it to the `KeySet`.
+  template <typename... Ts>
+  KeySet& AddKey(Ts&&... ts) {
+    return AddKey(MakeKey(std::forward<Ts>(ts)...));
+  }
+
+  /// Adds a range of keys defined by the given `KeyBound`s.
+  KeySet& AddRange(KeyBound start, KeyBound end) {
+    auto* kr = proto_.add_ranges();
+    auto* start_proto = start.bound() == KeyBound::kClosed
+                            ? kr->mutable_start_closed()
+                            : kr->mutable_start_open();
+    AppendKey(start_proto, std::move(start).key());
+    auto* end_proto = end.bound() == KeyBound::kClosed
+                          ? kr->mutable_end_closed()
+                          : kr->mutable_end_open();
+    AppendKey(end_proto, std::move(end).key());
+    return *this;
+  }
+
   /// @name Equality
-  /// Order of keys and key ranges in the `KeySet` is considered.
   ///@{
-  friend bool operator==(KeySet const& lhs, KeySet const& rhs);
-  friend bool operator!=(KeySet const& lhs, KeySet const& rhs);
+  friend bool operator==(KeySet const& a, KeySet const& b);
+  friend bool operator!=(KeySet const& a, KeySet const& b) { return !(a == b); }
   ///@}
 
  private:
-  explicit KeySet(google::spanner::v1::KeySet key_set)
-      : proto_(std::move(key_set)) {}
-
   friend ::google::spanner::v1::KeySet internal::ToProto(KeySet keyset);
-  friend KeySet internal::FromProto(::google::spanner::v1::KeySet keyset);
-
-  google::spanner::v1::KeySet proto_;
-};
-
-/**
- * The `KeySetBuilder` class is a regular type that represents the collection of
- * `spanner::Row`s necessary to uniquely identify a arbitrary group of rows in
- * its index.
- *
- * A `KeySetBuilder` can consist of multiple `KeyRange` and/or `spanner::Row`
- * instances.
- *
- * If the same key is specified multiple times in the `KeySetBuilder` (for
- * example if two `KeyRange`s, two keys, or a key and a `KeyRange` overlap),
- * Cloud Spanner behaves as if the key were only specified once.
- *
- * @tparam KeyType spanner::Row<Types...> that corresponds to the desired index
- * definition.
- *
- * @par Example
- * @snippet samples.cc key-set-builder
- */
-template <typename RowType>
-class KeySetBuilder {
- public:
-  static_assert(internal::IsRow<RowType>::value,
-                "KeyType must be of type spanner::Row<>.");
-  /**
-   * Constructs an empty `KeySetBuilder`.
-   */
-  KeySetBuilder() = default;
-
-  /// Copy and move constructors and assignment operators.
-  KeySetBuilder(KeySetBuilder const& key_range) = default;
-  KeySetBuilder& operator=(KeySetBuilder const& rhs) = default;
-  KeySetBuilder(KeySetBuilder&& key_range) = default;
-  KeySetBuilder& operator=(KeySetBuilder&& rhs) = default;
-
-  /**
-   * Constructs a `KeySetBuilder` with a single key `spanner::Row`.
-   */
-  explicit KeySetBuilder(RowType key) { keys_.push_back(std::move(key)); }
-
-  /**
-   * Constructs a `KeySetBuilder` with a single `KeyRange`.
-   */
-  explicit KeySetBuilder(KeyRange<RowType> key_range) {
-    key_ranges_.push_back(std::move(key_range));
-  }
-
-  /**
-   * Returns the key `spanner::Row`s in the `KeySetBuilder`.
-   * These keys are separate from the collection of `KeyRange`s.
-   */
-  std::vector<RowType> const& keys() const { return keys_; }
-
-  /**
-   * Returns the `KeyRange`s in the `KeySetBuilder`.
-   * These are separate from the collection of individual key `spanner::Row`s.
-   */
-  std::vector<KeyRange<RowType>> const& key_ranges() const {
-    return key_ranges_;
-  }
-
-  /// Adds a key `spanner::Row` to the `KeySetBuilder`.
-  KeySetBuilder&& Add(RowType key) && {
-    keys_.push_back(std::move(key));
-    return std::move(*this);
-  }
-
-  /// Adds a key `spanner::Row` to the `KeySetBuilder`.
-  KeySetBuilder& Add(RowType key) & {
-    keys_.push_back(std::move(key));
-    return *this;
-  }
-
-  /// Adds a `KeyRange` to the `KeySetBuilder`.
-  KeySetBuilder&& Add(KeyRange<RowType> key_range) && {
-    key_ranges_.push_back(std::move(key_range));
-    return std::move(*this);
-  }
-
-  /// Adds a `KeyRange` to the `KeySetBuilder`.
-  KeySetBuilder& Add(KeyRange<RowType> key_range) & {
-    key_ranges_.push_back(std::move(key_range));
-    return *this;
-  }
-
-  /// Builds a type-erased `KeySet` from the contents of the `KeySetBuilder`.
-  KeySet Build() && {
-    google::spanner::v1::KeySet ks;
-    for (auto& key : keys_) {
-      Append(ks.add_keys(), std::move(key).values());
-    }
-    for (auto& range : key_ranges_) {
-      auto* kr = ks.add_ranges();
-      auto* start = range.start().IsClosed() ? kr->mutable_start_closed()
-                                             : kr->mutable_start_open();
-      Append(start, std::move(range).start().key().values());
-      auto* end = range.end().IsClosed() ? kr->mutable_end_closed()
-                                         : kr->mutable_end_open();
-      Append(end, std::move(range).end().key().values());
-    }
-    return internal::FromProto(std::move(ks));
-  }
-
-  /// Builds a type-erased `KeySet` from the contents of the `KeySetBuilder`.
-  KeySet Build() const& {
-    auto copy = *this;
-    return std::move(copy).Build();
-  }
-
- private:
-  template <std::size_t N>
-  static void Append(google::protobuf::ListValue* lv,
-                     std::array<Value, N>&& a) {
-    for (auto& v : a) {
+  friend KeySet internal::FromProto(::google::spanner::v1::KeySet proto);
+  static void AppendKey(google::protobuf::ListValue* lv,
+                        std::vector<Value>&& values) {
+    for (auto& v : values) {
       *lv->add_values() = internal::ToProto(std::move(v)).second;
     }
   }
 
-  std::vector<RowType> keys_;
-  std::vector<KeyRange<RowType>> key_ranges_;
+  explicit KeySet(google::spanner::v1::KeySet proto)
+      : proto_(std::move(proto)) {}
+
+  google::spanner::v1::KeySet proto_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -56,6 +56,8 @@ TEST(KeyTest, MakeKey) {
   EXPECT_NE(key, Key{});
   EXPECT_EQ(key.size(), 2);
   EXPECT_EQ(key, MakeKey(std::int64_t{123}, std::string("hello")));
+
+  EXPECT_EQ(key, MakeKey(Value(123), Value("hello")));
 }
 
 TEST(KeyBoundTest, ValueSemantics) {
@@ -150,6 +152,10 @@ TEST(KeySetTest, EqualityAll) {
   KeySet empty;
   EXPECT_NE(expected, empty);
   KeySet actual = KeySet::All();
+  EXPECT_EQ(expected, actual);
+
+  // Adding keys to an "all" KeySet still logically represents "all".
+  actual.AddKey(123);
   EXPECT_EQ(expected, actual);
 }
 

--- a/google/cloud/spanner/keys_test.cc
+++ b/google/cloud/spanner/keys_test.cc
@@ -26,116 +26,92 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-TEST(KeyBoundTest, Accessors) {
-  auto row = MakeRow("test");
-  auto bound = MakeKeyBoundClosed(row);
-  EXPECT_EQ(row, bound.key());
-  EXPECT_EQ(row, std::move(bound).key());
+TEST(KeyTest, ConstructionCopyAssign) {
+  Key key1;
+  EXPECT_EQ(key1, key1);
 
-  using RowType = decltype(row);
-  static_assert(std::is_same<RowType const&, decltype(bound.key())>::value, "");
-  static_assert(
-      std::is_same<RowType&&, decltype(std::move(bound).key())>::value, "");
+  Key key2 = MakeKey(123, "hello");
+  EXPECT_EQ(key2, key2);
+  EXPECT_NE(key1, key2);
+
+  key1 = key2;
+  EXPECT_EQ(key1, key2);
+
+  key2 = std::move(key1);
+  EXPECT_EQ(Value(123), key2[0]);
+  EXPECT_EQ(Value("hello"), key2[1]);
 }
 
-TEST(KeyBoundTest, MakeKeyBoundClosed) {
-  std::string key_value("key0");
-  auto bound = MakeKeyBoundClosed(MakeRow(key_value));
-  EXPECT_EQ(key_value, bound.key().get<0>());
-  EXPECT_TRUE(bound.IsClosed());
+TEST(KeyTest, MakeKey) {
+  Key key = MakeKey();
+  EXPECT_EQ(key, Key{});
+  EXPECT_EQ(key.size(), 0);
+
+  key = MakeKey(123);
+  EXPECT_NE(key, Key{});
+  EXPECT_EQ(key.size(), 1);
+  EXPECT_EQ(key, MakeKey(std::int64_t{123}));
+
+  key = MakeKey(123, "hello");
+  EXPECT_NE(key, Key{});
+  EXPECT_EQ(key.size(), 2);
+  EXPECT_EQ(key, MakeKey(std::int64_t{123}, std::string("hello")));
 }
 
-TEST(KeyBoundTest, MakeKeyBoundOpen) {
-  std::string key_value_0("key0");
-  std::int64_t key_value_1(42);
-  auto bound = MakeKeyBoundOpen(MakeRow(key_value_0, key_value_1));
-  EXPECT_EQ(key_value_0, bound.key().get<0>());
-  EXPECT_EQ(key_value_1, bound.key().get<1>());
-  EXPECT_TRUE(bound.IsOpen());
+TEST(KeyBoundTest, ValueSemantics) {
+  KeyBound kb1 = MakeKeyBoundOpen(123);
+  EXPECT_EQ(kb1, kb1);
+
+  KeyBound kb2 = MakeKeyBoundClosed(123);
+  EXPECT_NE(kb1, kb2);
+
+  kb2 = kb1;
+  EXPECT_EQ(kb1, kb2);
+
+  kb2 = std::move(kb1);
+  EXPECT_EQ(kb2.key(), MakeKey(123));
+  EXPECT_EQ(kb2.bound(), KeyBound::kOpen);
 }
 
-TEST(KeyrangeTest, Accessors) {
-  auto start_row = MakeRow("a");
-  auto start_bound = MakeKeyBoundClosed(start_row);
+TEST(KeyBoundTest, Open) {
+  KeyBound kb1 = MakeKeyBoundOpen(123);
+  EXPECT_EQ(kb1, kb1);
+  KeyBound kb2 = MakeKeyBoundOpen(456);
+  EXPECT_NE(kb1, kb2);
 
-  auto end_row = MakeRow("z");
-  auto end_bound = MakeKeyBoundClosed(end_row);
-
-  auto range = MakeKeyRange(start_bound, end_bound);
-  EXPECT_EQ(start_bound, range.start());
-  EXPECT_EQ(end_bound, range.end());
-
-  EXPECT_EQ(start_bound, std::move(range).start());
-  // NOLINTNEXTLINE(bugprone-use-after-move)
-  EXPECT_EQ(end_bound, std::move(range).end());
-
-  using StartType = decltype(start_bound);
-  static_assert(std::is_same<StartType const&, decltype(range.start())>::value,
-                "");
-
-  using EndType = decltype(end_bound);
-  static_assert(
-      std::is_same<EndType&&, decltype(std::move(range).start())>::value, "");
+  EXPECT_EQ(kb1.bound(), KeyBound::kOpen);
+  EXPECT_EQ(kb2.bound(), KeyBound::kOpen);
 }
 
-TEST(KeyRangeTest, ConstructorKeyBoundModeUnspecified) {
-  std::string start_value("key0");
-  std::string end_value("key1");
-  KeyRange<Row<std::string>> closed_range =
-      MakeKeyRangeClosed(MakeRow(start_value), MakeRow(end_value));
+TEST(KeyBoundTest, Closed) {
+  KeyBound kb1 = MakeKeyBoundClosed(123);
+  EXPECT_EQ(kb1, kb1);
+  KeyBound kb2 = MakeKeyBoundClosed(456);
+  EXPECT_NE(kb1, kb2);
 
-  EXPECT_EQ(start_value, closed_range.start().key().get<0>());
-  EXPECT_TRUE(closed_range.start().IsClosed());
-  EXPECT_EQ(end_value, closed_range.end().key().get<0>());
-  EXPECT_TRUE(closed_range.end().IsClosed());
+  EXPECT_EQ(kb1.bound(), KeyBound::kClosed);
+  EXPECT_EQ(kb2.bound(), KeyBound::kClosed);
 }
 
-TEST(KeyRangeTest, ConstructorClosedClosed) {
-  std::string start_value("key0");
-  std::string end_value("key1");
-  auto start_bound = MakeKeyBoundClosed(MakeRow(start_value));
-  auto end_bound = MakeKeyBoundClosed(MakeRow(end_value));
-  auto closed_range = MakeKeyRange(start_bound, end_bound);
-  EXPECT_EQ(start_value, closed_range.start().key().get<0>());
-  EXPECT_TRUE(closed_range.start().IsClosed());
-  EXPECT_EQ(end_value, closed_range.end().key().get<0>());
-  EXPECT_TRUE(closed_range.end().IsClosed());
+TEST(KeyBoundTest, RvalueKeyAccessor) {
+  std::string s = "12345678901234567890";
+  KeyBound kb = MakeKeyBoundClosed(123, s);
+  Key key = std::move(kb).key();
+  EXPECT_EQ(key, MakeKey(123, s));
 }
 
-TEST(KeyRangeTest, ConstructorClosedOpen) {
-  std::string start_value("key0");
-  std::string end_value("key1");
-  auto range =
-      KeyRange<Row<std::string>>(MakeKeyBoundClosed(MakeRow(start_value)),
-                                 MakeKeyBoundOpen(MakeRow(end_value)));
-  EXPECT_EQ(start_value, range.start().key().get<0>());
-  EXPECT_TRUE(range.start().IsClosed());
-  EXPECT_EQ(end_value, range.end().key().get<0>());
-  EXPECT_TRUE(range.end().IsOpen());
-}
+TEST(KeySetTest, ValueSemantics) {
+  KeySet ks1;
+  EXPECT_EQ(ks1, ks1);
 
-TEST(KeyRangeTest, ConstructorOpenClosed) {
-  std::string start_value("key0");
-  std::string end_value("key1");
-  auto range =
-      KeyRange<Row<std::string>>(MakeKeyBoundOpen(MakeRow(start_value)),
-                                 MakeKeyBoundClosed(MakeRow(end_value)));
-  EXPECT_EQ(start_value, range.start().key().get<0>());
-  EXPECT_TRUE(range.start().IsOpen());
-  EXPECT_EQ(end_value, range.end().key().get<0>());
-  EXPECT_TRUE(range.end().IsClosed());
-}
+  KeySet ks2 = ks1;
+  EXPECT_EQ(ks1, ks2);
 
-TEST(KeyRangeTest, ConstructorOpenOpen) {
-  std::string start_value("key0");
-  std::string end_value("key1");
-  auto range =
-      KeyRange<Row<std::string>>(MakeKeyBoundOpen(MakeRow(start_value)),
-                                 MakeKeyBoundOpen(MakeRow(end_value)));
-  EXPECT_EQ(start_value, range.start().key().get<0>());
-  EXPECT_TRUE(range.start().IsOpen());
-  EXPECT_EQ(end_value, range.end().key().get<0>());
-  EXPECT_TRUE(range.end().IsOpen());
+  ks2 = ks1;
+  EXPECT_EQ(ks1, ks2);
+
+  ks2 = std::move(ks1);
+  EXPECT_EQ(ks2, ks2);
 }
 
 TEST(KeySetTest, NoKeys) {
@@ -178,205 +154,60 @@ TEST(KeySetTest, EqualityAll) {
 }
 
 TEST(KeySetTest, EqualityKeys) {
-  auto ksb0 = KeySetBuilder<Row<std::string, std::string>>();
-  ksb0.Add(MakeRow("foo0", "bar0"));
-  ksb0.Add(MakeRow("foo1", "bar1"));
+  auto ks0 = KeySet();
+  ks0.AddKey("foo0", "bar0");
+  ks0.AddKey("foo1", "bar1");
 
-  auto ksb1 = KeySetBuilder<Row<std::string, std::string>>();
-  ksb1.Add(MakeRow("foo0", "bar0"));
-  EXPECT_NE(ksb0.Build(), ksb1.Build());
-  ksb1.Add(MakeRow("foo1", "bar1"));
-  EXPECT_EQ(ksb0.Build(), ksb1.Build());
+  auto ks1 = KeySet();
+  ks1.AddKey("foo0", "bar0");
+  EXPECT_NE(ks0, ks1);
+  ks1.AddKey("foo1", "bar1");
+  EXPECT_EQ(ks0, ks1);
 }
 
 TEST(KeySetTest, EqualityKeyRanges) {
-  auto range0 = MakeKeyRangeClosed(MakeRow("start00", "start01"),
-                                   MakeRow("end00", "end01"));
-  auto range1 = MakeKeyRange(MakeKeyBoundOpen(MakeRow("start10", "start11")),
-                             MakeKeyBoundOpen(MakeRow("end10", "end11")));
-  auto ksb0 = KeySetBuilder<Row<std::string, std::string>>();
-  ksb0.Add(range0).Add(range1);
-  auto ksb1 = KeySetBuilder<Row<std::string, std::string>>();
-  ksb1.Add(range0);
-  EXPECT_NE(ksb0.Build(), ksb1.Build());
-  ksb1.Add(range1);
-  EXPECT_EQ(ksb0.Build(), ksb1.Build());
+  auto range0 = std::make_pair(MakeKeyBoundClosed("start00", "start01"),
+                               MakeKeyBoundClosed("end00", "end01"));
+  auto range1 = std::make_pair(MakeKeyBoundOpen("start10", "start11"),
+                               MakeKeyBoundOpen("end10", "end11"));
+  auto ks0 = KeySet()
+                 .AddRange(range0.first, range0.second)
+                 .AddRange(range1.first, range1.second);
+  auto ks1 = KeySet().AddRange(range0.first, range0.second);
+  EXPECT_NE(ks0, ks1);
+  ks1.AddRange(range1.first, range1.second);
+  EXPECT_EQ(ks0, ks1);
 }
 
 TEST(KeySetTest, RoundTripProtos) {
   auto test_cases = {
-      KeySetBuilder<Row<>>().Build(),                                      //
-      KeySetBuilder<Row<std::int64_t>>()                                   //
-          .Add(MakeRow(42))                                                //
-          .Build(),                                                        //
-      KeySetBuilder<Row<std::int64_t>>()                                   //
-          .Add(MakeRow(42))                                                //
-          .Add(MakeRow(123))                                               //
-          .Build(),                                                        //
-      KeySetBuilder<Row<std::int64_t, std::string>>()                      //
-          .Build(),                                                        //
-      KeySetBuilder<Row<std::int64_t, std::string>>()                      //
-          .Add(MakeRow(42, "hi"))                                          //
-          .Add(MakeRow(123, "bye"))                                        //
-          .Build(),                                                        //
-      KeySetBuilder<Row<std::int64_t, std::string>>()                      //
-          .Add(MakeKeyRangeClosed(MakeRow(42, "hi"), MakeRow(43, "bye")))  //
-          .Build(),                                                        //
+      KeySet(),                                      //
+      KeySet::All(),                                 //
+      KeySet()                                       //
+          .AddKey(42),                               //
+      KeySet()                                       //
+          .AddKey(42)                                //
+          .AddKey(123),                              //
+      KeySet()                                       //
+          .AddKey(42, "hi")                          //
+          .AddKey(123, "bye"),                       //
+      KeySet()                                       //
+          .AddRange(MakeKeyBoundClosed(42, "hi"),    //
+                    MakeKeyBoundClosed(43, "bye")),  //
+      KeySet()                                       //
+          .AddRange(MakeKeyBoundClosed(42, "hi"),    //
+                    MakeKeyBoundOpen(43, "bye")),    //
+      KeySet()                                       //
+          .AddRange(MakeKeyBoundOpen(42, "hi"),      //
+                    MakeKeyBoundOpen(43, "bye")),    //
+      KeySet()                                       //
+          .AddRange(MakeKeyBoundOpen(42, "hi"),      //
+                    MakeKeyBoundClosed(43, "bye")),  //
   };
 
   for (auto const& tc : test_cases) {
     EXPECT_EQ(tc, internal::FromProto(internal::ToProto(tc)));
   }
-}
-
-TEST(KeySetBuilderTest, ConstructorSingleKey) {
-  std::string expected_value("key0");
-  auto key = MakeRow("key0");
-  auto ks = KeySetBuilder<Row<std::string>>(key);
-  EXPECT_EQ(expected_value, ks.keys()[0].get<0>());
-}
-
-TEST(KeySetBuilderTest, ConstructorKeyRange) {
-  std::string start_value("key0");
-  std::string end_value("key1");
-  auto ks = KeySetBuilder<Row<std::string>>(
-      KeyRange<Row<std::string>>(MakeKeyBoundClosed(MakeRow(start_value)),
-                                 MakeKeyBoundClosed(MakeRow(end_value))));
-  EXPECT_EQ(start_value, ks.key_ranges()[0].start().key().get<0>());
-  EXPECT_TRUE(ks.key_ranges()[0].start().IsClosed());
-  EXPECT_EQ(end_value, ks.key_ranges()[0].end().key().get<0>());
-  EXPECT_TRUE(ks.key_ranges()[0].end().IsClosed());
-}
-
-TEST(KeySetBuilderTest, AddKeyToEmptyKeySetBuilder) {
-  auto ks = KeySetBuilder<Row<std::int64_t, std::string>>();
-  ks.Add(MakeRow(42, "key42"));
-  EXPECT_EQ(42, ks.keys()[0].get<0>());
-  EXPECT_EQ("key42", ks.keys()[0].get<1>());
-}
-
-TEST(KeySetBuilderTest, AddKeyToNonEmptyKeySetBuilder) {
-  auto ks = KeySetBuilder<Row<std::int64_t, std::string>>(MakeRow(84, "key84"));
-  ks.Add(MakeRow(42, "key42"));
-  EXPECT_EQ(84, ks.keys()[0].get<0>());
-  EXPECT_EQ("key84", ks.keys()[0].get<1>());
-  EXPECT_EQ(42, ks.keys()[1].get<0>());
-  EXPECT_EQ("key42", ks.keys()[1].get<1>());
-}
-
-TEST(KeySetBuilderTest, AddKeyRangeToEmptyKeySetBuilder) {
-  auto ks = KeySetBuilder<Row<std::string, std::string>>();
-  auto range = KeyRange<Row<std::string, std::string>>(
-      MakeKeyBoundClosed(MakeRow("start00", "start01")),
-      MakeKeyBoundClosed(MakeRow("end00", "end01")));
-  ks.Add(range);
-  EXPECT_EQ("start00", ks.key_ranges()[0].start().key().get<0>());
-  EXPECT_EQ("start01", ks.key_ranges()[0].start().key().get<1>());
-  EXPECT_EQ("end00", ks.key_ranges()[0].end().key().get<0>());
-  EXPECT_EQ("end01", ks.key_ranges()[0].end().key().get<1>());
-  EXPECT_TRUE(ks.key_ranges()[0].start().IsClosed());
-  EXPECT_TRUE(ks.key_ranges()[0].end().IsClosed());
-}
-
-TEST(KeySetBuilderTest, AddKeyRangeToNonEmptyKeySetBuilder) {
-  auto ks = KeySetBuilder<Row<std::string, std::string>>(MakeKeyRangeClosed(
-      MakeRow("start00", "start01"), MakeRow("end00", "end01")));
-  auto range = MakeKeyRange(MakeKeyBoundOpen(MakeRow("start10", "start11")),
-                            MakeKeyBoundOpen(MakeRow("end10", "end11")));
-  ks.Add(range);
-  EXPECT_EQ("start00", ks.key_ranges()[0].start().key().get<0>());
-  EXPECT_EQ("start01", ks.key_ranges()[0].start().key().get<1>());
-  EXPECT_EQ("end00", ks.key_ranges()[0].end().key().get<0>());
-  EXPECT_EQ("end01", ks.key_ranges()[0].end().key().get<1>());
-  EXPECT_TRUE(ks.key_ranges()[0].start().IsClosed());
-  EXPECT_TRUE(ks.key_ranges()[0].end().IsClosed());
-  EXPECT_EQ("start10", ks.key_ranges()[1].start().key().get<0>());
-  EXPECT_EQ("start11", ks.key_ranges()[1].start().key().get<1>());
-  EXPECT_EQ("end10", ks.key_ranges()[1].end().key().get<0>());
-  EXPECT_EQ("end11", ks.key_ranges()[1].end().key().get<1>());
-  EXPECT_TRUE(ks.key_ranges()[1].start().IsOpen());
-  EXPECT_TRUE(ks.key_ranges()[1].end().IsOpen());
-}
-
-TEST(InternalKeySetTest, ToProtoAll) {
-  auto ks = KeySet::All();
-  ::google::spanner::v1::KeySet expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(
-        all: true
-      )pb",
-      &expected));
-
-  ::google::spanner::v1::KeySet result = internal::ToProto(ks);
-  EXPECT_THAT(result, spanner_testing::IsProtoEqual(expected));
-}
-
-TEST(InternalKeySetTest, BuildToProtoTwoKeys) {
-  auto ksb = KeySetBuilder<Row<std::string, std::string>>();
-  ksb.Add(MakeRow("foo0", "bar0"));
-  ksb.Add(MakeRow("foo1", "bar1"));
-
-  KeySet ks = ksb.Build();
-
-  ::google::spanner::v1::KeySet expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(
-        keys: {
-          values: { string_value: "foo0" }
-          values: { string_value: "bar0" }
-        }
-        keys: {
-          values: { string_value: "foo1" }
-          values: { string_value: "bar1" }
-        }
-        all: false
-      )pb",
-      &expected));
-  ::google::spanner::v1::KeySet result = internal::ToProto(ks);
-
-  EXPECT_THAT(result, spanner_testing::IsProtoEqual(expected));
-}
-
-TEST(InternalKeySetTest, BuildToProtoTwoRanges) {
-  auto ksb = KeySetBuilder<Row<std::string, std::string>>(MakeKeyRangeClosed(
-      MakeRow("start00", "start01"), MakeRow("end00", "end01")));
-  auto range = MakeKeyRange(MakeKeyBoundOpen(MakeRow("start10", "start11")),
-                            MakeKeyBoundOpen(MakeRow("end10", "end11")));
-  ksb.Add(range);
-
-  ::google::spanner::v1::KeySet expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(
-        ranges: {
-          start_closed: {
-            values: { string_value: "start00" }
-            values: { string_value: "start01" }
-          }
-
-          end_closed: {
-            values: { string_value: "end00" }
-            values { string_value: "end01" }
-          }
-        }
-
-        ranges: {
-          start_open: {
-            values: { string_value: "start10" }
-            values: { string_value: "start11" }
-          }
-
-          end_open: {
-            values: { string_value: "end10" }
-            values: { string_value: "end11" }
-          }
-        }
-
-        all: false
-      )pb",
-      &expected));
-  ::google::spanner::v1::KeySet result = internal::ToProto(ksb.Build());
-
-  EXPECT_THAT(result, spanner_testing::IsProtoEqual(expected));
 }
 
 }  // namespace

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -306,9 +306,8 @@ TEST(MutationsTest, ReplaceComplex) {
 }
 
 TEST(MutationsTest, DeleteSimple) {
-  auto ksb = KeySetBuilder<Row<std::string>>();
-  ksb.Add(MakeRow("key-to-delete"));
-  Mutation dele = MakeDeleteMutation("table-name", ksb.Build());
+  auto ks = KeySet().AddKey("key-to-delete");
+  Mutation dele = MakeDeleteMutation("table-name", std::move(ks));
   EXPECT_EQ(dele, dele);
 
   Mutation empty;

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -811,7 +811,7 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
   // A helper to read a single album MarketingBudget.
   auto get_current_budget = [](spanner::Client client, spanner::Transaction txn,
                                std::int64_t singer_id, std::int64_t album_id) {
-    auto key = spanner::KeySet().AddKey(spanner::MakeKey(singer_id, album_id));
+    auto key = spanner::KeySet().AddKey(singer_id, album_id);
     auto read = client.Read(std::move(txn), "Albums", std::move(key),
                             {"MarketingBudget"});
     if (!read) throw std::runtime_error(read.status().message());

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -756,11 +756,11 @@ void DeleteData(google::cloud::spanner::Client client) {
                                                    .AddKey(2, 2)
                                                    .AddKey(2, 3))
           .Build();
-  auto delete_singers = spanner::DeleteMutationBuilder(
-                            "Singers", spanner::KeySet().AddRange(
-                                           spanner::MakeKeyBoundClosed(1),
-                                           spanner::MakeKeyBoundClosed(5)))
-                            .Build();
+  auto delete_singers =
+      spanner::DeleteMutationBuilder(
+          "Singers", spanner::KeySet().AddRange(spanner::MakeKeyBoundClosed(1),
+                                                spanner::MakeKeyBoundClosed(5)))
+          .Build();
 
   auto commit_result = client.Commit(spanner::MakeReadWriteTransaction(),
                                      {delete_albums, delete_singers});

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -749,23 +749,18 @@ void DeleteData(google::cloud::spanner::Client client) {
   // Delete each of the albums by individual key, then delete all the singers
   // using a key range.
   auto delete_albums =
-      spanner::DeleteMutationBuilder(
-          "Albums",
-          spanner::KeySetBuilder<spanner::Row<std::int64_t, std::int64_t>>()
-              .Add(spanner::MakeRow(1, 1))
-              .Add(spanner::MakeRow(1, 2))
-              .Add(spanner::MakeRow(2, 1))
-              .Add(spanner::MakeRow(2, 2))
-              .Add(spanner::MakeRow(2, 3))
-              .Build())
+      spanner::DeleteMutationBuilder("Albums", spanner::KeySet()
+                                                   .AddKey(1, 1)
+                                                   .AddKey(1, 2)
+                                                   .AddKey(2, 1)
+                                                   .AddKey(2, 2)
+                                                   .AddKey(2, 3))
           .Build();
-  using SingersKey = spanner::Row<std::int64_t>;
-  auto delete_singers =
-      spanner::DeleteMutationBuilder(
-          "Singers", spanner::KeySetBuilder<SingersKey>(
-                         MakeKeyRangeClosed(SingersKey(1), SingersKey(5)))
-                         .Build())
-          .Build();
+  auto delete_singers = spanner::DeleteMutationBuilder(
+                            "Singers", spanner::KeySet().AddRange(
+                                           spanner::MakeKeyBoundClosed(1),
+                                           spanner::MakeKeyBoundClosed(5)))
+                            .Build();
 
   auto commit_result = client.Commit(spanner::MakeReadWriteTransaction(),
                                      {delete_albums, delete_singers});
@@ -816,9 +811,7 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
   // A helper to read a single album MarketingBudget.
   auto get_current_budget = [](spanner::Client client, spanner::Transaction txn,
                                std::int64_t singer_id, std::int64_t album_id) {
-    auto key = spanner::KeySetBuilder<spanner::Row<std::int64_t, std::int64_t>>(
-                   spanner::MakeRow(singer_id, album_id))
-                   .Build();
+    auto key = spanner::KeySet().AddKey(spanner::MakeKey(singer_id, album_id));
     auto read = client.Read(std::move(txn), "Albums", std::move(key),
                             {"MarketingBudget"});
     if (!read) throw std::runtime_error(read.status().message());
@@ -1138,10 +1131,8 @@ void PartitionRead(google::cloud::spanner::Client client) {
   namespace spanner = google::cloud::spanner;
   RemoteConnectionFake remote_connection;
   //! [key-set-builder]
-  auto key_set = spanner::KeySetBuilder<spanner::Row<int64_t>>()
-                     .Add(spanner::MakeKeyRangeClosed(spanner::MakeRow(1),
-                                                      spanner::MakeRow(10)))
-                     .Build();
+  auto key_set = spanner::KeySet().AddRange(spanner::MakeKeyBoundClosed(1),
+                                            spanner::MakeKeyBoundClosed(10));
   //! [key-set-builder]
 
   //! [partition-read]


### PR DESCRIPTION
Fixes #934 
Related to #387 

This change removes all the class templates from keys.h. We lose the ability to verify at compile time that all the keys in a `KeySet` have the same type, but we gain the following:

* Simpler code. No templates. Fewer abstractions (no "builder" needed; no "Range" type needed either). "Key" is just an alias for `vector<Value>`.
* Simpler call sites
* Callers can use `Value` instances when constructing `KeySet`s