### PR TITLE
feat!: Removed Row<> from mutations API

### DIFF
--- a/google/cloud/spanner/mutations.h
+++ b/google/cloud/spanner/mutations.h
@@ -113,10 +113,9 @@ class WriteMutationBuilder {
   Mutation Build() const& { return Mutation(m_); }
   Mutation Build() && { return Mutation(std::move(m_)); }
 
-  template <typename... Ts>
-  WriteMutationBuilder& AddRow(Row<Ts...> row) {
+  WriteMutationBuilder& AddRow(std::vector<Value> values) {
     auto& lv = *Op::mutable_field(m_).add_values();
-    for (auto& v : std::move(row).values()) {
+    for (auto& v : values) {
       std::tie(std::ignore, *lv.add_values()) = internal::ToProto(std::move(v));
     }
     return *this;
@@ -124,7 +123,7 @@ class WriteMutationBuilder {
 
   template <typename... Ts>
   WriteMutationBuilder& EmplaceRow(Ts&&... values) {
-    return AddRow(MakeRow(std::forward<Ts>(values)...));
+    return AddRow({Value(std::forward<Ts>(values))...});
   }
 
  private:

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -83,7 +83,7 @@ TEST(MutationsTest, InsertComplex) {
   Mutation empty;
   auto builder =
       InsertMutationBuilder("table-name", {"col1", "col2", "col3"})
-          .AddRow(MakeRow(std::int64_t(42), std::string("foo"), false))
+          .AddRow({Value(42), Value("foo"), Value(false)})
           .EmplaceRow(optional<std::int64_t>(), "bar", optional<bool>{});
   Mutation insert = builder.Build();
   Mutation moved = std::move(builder).Build();
@@ -146,7 +146,7 @@ TEST(MutationsTest, UpdateComplex) {
   Mutation empty;
   auto builder =
       UpdateMutationBuilder("table-name", {"col_a", "col_b"})
-          .AddRow(MakeRow(std::vector<std::string>{}, 7.0))
+          .AddRow({Value(std::vector<std::string>{}), Value(7.0)})
           .EmplaceRow(std::vector<std::string>{"a", "b"}, optional<double>{});
   Mutation update = builder.Build();
   Mutation moved = std::move(builder).Build();
@@ -210,7 +210,7 @@ TEST(MutationsTest, InsertOrUpdateSimple) {
 TEST(MutationsTest, InsertOrUpdateComplex) {
   Mutation empty;
   auto builder = InsertOrUpdateMutationBuilder("table-name", {"col_a", "col_b"})
-                     .AddRow(MakeRow(std::make_tuple("a", 7.0)))
+                     .AddRow({Value(std::make_tuple("a", 7.0))})
                      .EmplaceRow(std::make_tuple("b", 8.0));
   Mutation update = builder.Build();
   Mutation moved = std::move(builder).Build();
@@ -278,7 +278,7 @@ TEST(MutationsTest, ReplaceComplex) {
   Mutation empty;
   auto builder = ReplaceMutationBuilder("table-name", {"col_a", "col_b"})
                      .EmplaceRow("a", 7.0)
-                     .AddRow(MakeRow("b", 8.0));
+                     .AddRow({Value("b"), Value(8.0)});
   Mutation update = builder.Build();
   Mutation moved = std::move(builder).Build();
   EXPECT_EQ(update, moved);


### PR DESCRIPTION
Part of preparing for #387 

BREAKING CHANGE: This PR removes the `AddRow(Row<Ts...>)` member function on the WriteMutation API because the `Row<Ts...>` type will be removed. In place of this method there is now an `AddRow(std::vector<Value>)` method. This change enables a new feature, which is that callers can now construct Mutations from `Value` objects, which they could not previously.

Note that some of the refactoring in the integration tests exists as an intermediate step. Once the full "select *" refactoring is finished (#387), much of the integration test code could be cleaned up more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/938)
<!-- Reviewable:end -->
