### PR TITLE
cleanup: depend on google-cloud-cpp-common

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,9 +31,9 @@ switched_rules_by_language(
 # gRPC:
 #   https://github.com/bazelbuild/bazel/issues/1550
 
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_common_deps.bzl", "google_cloud_cpp_common_deps")
 
-google_cloud_cpp_deps()
+google_cloud_cpp_common_deps()
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 

--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -27,8 +27,8 @@ def google_cloud_cpp_spanner_deps():
     they want to use.
     """
 
-    # Load a newer version of google test than what gRPC does.
-    if "com_github_googleapis_google_cloud_cpp" not in native.existing_rules():
+    # Load google-cloud-cpp-common.
+    if "com_github_googleapis_google_cloud_cpp_common" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp_common",
             strip_prefix = "google-cloud-cpp-common-0.13.0",

--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -30,12 +30,12 @@ def google_cloud_cpp_spanner_deps():
     # Load a newer version of google test than what gRPC does.
     if "com_github_googleapis_google_cloud_cpp" not in native.existing_rules():
         http_archive(
-            name = "com_github_googleapis_google_cloud_cpp",
-            strip_prefix = "google-cloud-cpp-0.13.0",
+            name = "com_github_googleapis_google_cloud_cpp_common",
+            strip_prefix = "google-cloud-cpp-common-0.13.0",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz",
             ],
-            sha256 = "35058ff14e4f9f49f78da2f1bbf1c03f27e8e40ec65c51f62720346e99803392",
+            sha256 = "ea7f8f64ee8a6964f8755d1024b908bf13170e505f54b57ffc72c0002d478b8c",
         )
 
     # Load a newer version of google test than what gRPC does.

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -78,9 +78,9 @@ RUN cmake --build cmake-out --target install
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz
 RUN tar -xf v0.13.0.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-0.13.0
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.13.0
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -64,9 +64,9 @@ RUN cmake --build cmake-out --target install
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz
 RUN tar -xf v0.13.0.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-0.13.0
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.13.0
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/windows/CMakeLists.txt
+++ b/ci/kokoro/windows/CMakeLists.txt
@@ -33,7 +33,7 @@ set(
     "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz"
     )
 set(GOOGLE_CLOUD_CPP_SHA256
-    "35058ff14e4f9f49f78da2f1bbf1c03f27e8e40ec65c51f62720346e99803392")
+    "ea7f8f64ee8a6964f8755d1024b908bf13170e505f54b57ffc72c0002d478b8c")
 google_cloud_cpp_set_prefix_vars()
 
 ExternalProject_Add(

--- a/ci/kokoro/windows/CMakeLists.txt
+++ b/ci/kokoro/windows/CMakeLists.txt
@@ -28,8 +28,10 @@ include(external/external-project-helpers)
 google_cloud_cpp_set_prefix_vars()
 
 include(ExternalProject)
-set(GOOGLE_CLOUD_CPP_URL
-    "https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz")
+set(
+    GOOGLE_CLOUD_CPP_URL
+    "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz"
+    )
 set(GOOGLE_CLOUD_CPP_SHA256
     "35058ff14e4f9f49f78da2f1bbf1c03f27e8e40ec65c51f62720346e99803392")
 google_cloud_cpp_set_prefix_vars()

--- a/ci/super/CMakeLists.txt
+++ b/ci/super/CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(GOOGLE_CLOUD_CPP_SPANNER_ROOT "${PROJECT_SOURCE_DIR}/../..")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
-include(external/google-cloud-cpp)
+include(external/google-cloud-cpp-common)
 include(external/googletest)
 include(external/external-project-helpers)
 
@@ -34,7 +34,7 @@ set_external_project_build_parallel_level(PARALLEL)
 include(ExternalProject)
 ExternalProject_Add(
     google-cloud-cpp-spanner-as-external
-    DEPENDS google-cloud-cpp-project googletest-project
+    DEPENDS google-cloud-cpp-common-project googletest-project
     EXCLUDE_FROM_ALL OFF
     BUILD_ALWAYS 1
     PREFIX "${CMAKE_BINARY_DIR}/build/google-cloud-cpp-spanner"
@@ -64,5 +64,5 @@ ExternalProject_Add(
 
 # This makes it easy to compile the dependencies before the code.
 add_custom_target(google-cloud-cpp-spanner-dependencies)
-add_dependencies(google-cloud-cpp-spanner-dependencies google-cloud-cpp-project
-                 googletest-project)
+add_dependencies(google-cloud-cpp-spanner-dependencies
+                 google-cloud-cpp-common-project googletest-project)

--- a/ci/super/external/google-cloud-cpp-common.cmake
+++ b/ci/super/external/google-cloud-cpp-common.cmake
@@ -16,33 +16,29 @@
 
 include(ExternalProject)
 include(external/external-project-helpers)
-include(external/curl)
-include(external/crc32c)
 include(external/grpc)
 include(external/googleapis)
 include(external/googletest)
 
-if (NOT TARGET google-cloud-cpp-project)
+if (NOT TARGET google-cloud-cpp-common-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
-    set(GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp/archive/v0.13.0.tar.gz")
+    set(
+        GOOGLE_CLOUD_CPP_URL
+        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.13.0.tar.gz"
+        )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "35058ff14e4f9f49f78da2f1bbf1c03f27e8e40ec65c51f62720346e99803392")
+        "ea7f8f64ee8a6964f8755d1024b908bf13170e505f54b57ffc72c0002d478b8c")
 
     google_cloud_cpp_set_prefix_vars()
 
     set_external_project_build_parallel_level(PARALLEL)
 
     ExternalProject_Add(
-        google-cloud-cpp-project
-        DEPENDS googleapis-project
-                googletest-project
-                grpc-project
-                curl-project
-                crc32c-project
+        google-cloud-cpp-common-project
+        DEPENDS googleapis-project googletest-project grpc-project
         EXCLUDE_FROM_ALL ON
-        PREFIX "${CMAKE_BINARY_DIR}/external/google-cloud-cpp"
+        PREFIX "${CMAKE_BINARY_DIR}/external/google-cloud-cpp-common"
         INSTALL_DIR "${GOOGLE_CLOUD_CPP_EXTERNAL_PREFIX}"
         URL ${GOOGLE_CLOUD_CPP_URL}
         URL_HASH SHA256=${GOOGLE_CLOUD_CPP_SHA256}

--- a/ci/test-install/WORKSPACE
+++ b/ci/test-install/WORKSPACE
@@ -47,7 +47,7 @@ switched_rules_by_language(
     grpc = True,
 )
 
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/ci/test-install/WORKSPACE
+++ b/ci/test-install/WORKSPACE
@@ -47,9 +47,9 @@ switched_rules_by_language(
     grpc = True,
 )
 
-load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_common_deps.bzl", "google_cloud_cpp_common_deps")
 
-google_cloud_cpp_deps()
+google_cloud_cpp_common_deps()
 
 # Have to manually call the corresponding function for gRPC:
 #   https://github.com/bazelbuild/bazel/issues/1550

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -42,8 +42,8 @@ cc_library(
         ":generate_build_info",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/grpc_utils:google_cloud_cpp_grpc_utils",
         "@com_google_googleapis//:bigtable_protos",
         "@com_google_googleapis//:spanner_protos",
     ],
@@ -57,8 +57,8 @@ cc_library(
     hdrs = spanner_client_mocks_hdrs,
     deps = [
         ":spanner_client",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",
     ],
 )
@@ -72,8 +72,8 @@ cc_library(
     deps = [
         ":spanner_client",
         ":spanner_client_mocks",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",
     ],
 )
@@ -87,8 +87,8 @@ load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
         ":spanner_client",
         ":spanner_client_mocks",
         ":spanner_client_testing",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",
     ],
 ) for test in spanner_client_unit_tests]

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -134,7 +134,7 @@ switched_rules_by_language(
 
 # You have to manually call the corresponding function for google-cloud-cpp and
 # gRPC:  https://github.com/bazelbuild/bazel/issues/1550
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -28,8 +28,8 @@ load(":spanner_client_install_tests.bzl", "spanner_client_install_tests")
         "//google/cloud/spanner:spanner_client",
         "//google/cloud/spanner:spanner_client_mocks",
         "//google/cloud/spanner:spanner_client_testing",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",
     ],
 ) for test in spanner_client_integration_tests]
@@ -41,6 +41,6 @@ load(":spanner_client_install_tests.bzl", "spanner_client_install_tests")
     deps = [
         "//google/cloud/spanner:spanner_client",
         "//google/cloud/spanner:spanner_client_testing",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
     ],
 ) for test in spanner_client_install_tests]

--- a/google/cloud/spanner/samples/BUILD
+++ b/google/cloud/spanner/samples/BUILD
@@ -29,8 +29,8 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
     deps = [
         "//google/cloud/spanner:spanner_client",
         "//google/cloud/spanner:spanner_client_testing",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",
     ],
 ) for test in spanner_client_integration_samples]
@@ -41,8 +41,8 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
     deps = [
         "//google/cloud/spanner:spanner_client",
         "//google/cloud/spanner:spanner_client_testing",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud:google_cloud_cpp_common",
-        "@com_github_googleapis_google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
+        "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest",
     ],
 ) for test in spanner_client_unit_samples]


### PR DESCRIPTION
Declare independence from the Cloud Bigtable and Google Cloud Storage
clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/940)
<!-- Reviewable:end -->
