### PR TITLE
doc: Add example PR for bumping spanner version numbers.

### DIFF
--- a/doc/cutting-a-release.md
+++ b/doc/cutting-a-release.md
@@ -119,7 +119,8 @@ uploaded documentation will generally be live in an hour at the following URLs:
 
 Working in your fork of `gooogle-cloud-cpp-spanner`: bump the version numbers
 to the *next* version (i.e., one version past the release you just did above),
-and send the PR for review against `master`.
+and send the PR for review against `master`. For an example, look at
+[#943](https://github.com/googleapis/google-cloud-cpp-spanner/pull/943)
 
 ## Review the branch protections
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/944)
<!-- Reviewable:end -->
