### PR TITLE
fix: fix branch detection in the document publishing script

### DIFF
--- a/ci/kokoro/docker/publish-refdocs.sh
+++ b/ci/kokoro/docker/publish-refdocs.sh
@@ -53,12 +53,16 @@ fi
 # branch as an enviroment variable, like other CI systems do). We use the
 # following trick:
 # - Find out the current commit using git rev-parse HEAD.
-# - Find out what branches contain that commit.
 # - Exclude "HEAD detached" branches (they are not really branches).
-# - Typically this is the single branch that was checked out by Kokoro.
-BRANCH="$(git branch --no-color --contains "$(git rev-parse HEAD)" | \
-    grep -v 'HEAD detached' || exit 0)"
-BRANCH="${BRANCH/  /}"
+# - Choose the branch from the bottom of the list.
+# - Typically this is the branch that was checked out by Kokoro.
+BRANCH="$(git branch --all --no-color --contains "$(git rev-parse HEAD)" | \
+  grep -v 'HEAD' | tail -1 || exit 0)"
+# Enable extglob if not enabled
+shopt -q extglob || shopt -s extglob
+BRANCH="${BRANCH##*( )}"
+BRANCH="${BRANCH%%*( )}"
+BRANCH="${BRANCH##remotes/origin/}"
 readonly BRANCH
 
 echo "================================================================"


### PR DESCRIPTION
Theoretically it will work, but there's no easy way to test it before the actual release process.

Maybe we can backport this change and try this with the v0.2.x branch?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/947)
<!-- Reviewable:end -->
