### PR TITLE
chore: upgrade to Bazel 1.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,3 +38,11 @@ google_cloud_cpp_common_deps()
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
+
+# Call the workspace dependency functions defined, but not invoked, in grpc_deps.bzl.
+load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+upb_deps()
+load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+apple_rules_dependencies()
+load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+apple_support_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,8 +41,13 @@ grpc_deps()
 
 # Call the workspace dependency functions defined, but not invoked, in grpc_deps.bzl.
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+
 upb_deps()
+
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+
 apple_rules_dependencies()
+
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+
 apple_support_dependencies()

--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -27,6 +27,17 @@ def google_cloud_cpp_spanner_deps():
     they want to use.
     """
 
+    # Load rules_cc, used by googletest
+    if "rules_cc" not in native.existing_rules():
+        http_archive(
+            name = "rules_cc",
+            strip_prefix = "rules_cc-a508235df92e71d537fcbae0c7c952ea6957a912",
+            urls = [
+                "https://github.com/bazelbuild/rules_cc/archive/a508235df92e71d537fcbae0c7c952ea6957a912.tar.gz",
+            ],
+            sha256 = "d21d38c4b8e81eed8fa95ede48dd69aba01a3b938be6ac03d2b9dc61886a7183",
+        )
+
     # Load google-cloud-cpp-common.
     if "com_github_googleapis_google_cloud_cpp_common" not in native.existing_rules():
         http_archive(
@@ -38,15 +49,15 @@ def google_cloud_cpp_spanner_deps():
             sha256 = "ea7f8f64ee8a6964f8755d1024b908bf13170e505f54b57ffc72c0002d478b8c",
         )
 
-    # Load a newer version of google test than what gRPC does.
+    # Load a version of googletest that we know works.
     if "com_google_googletest" not in native.existing_rules():
         http_archive(
             name = "com_google_googletest",
-            strip_prefix = "googletest-b6cd405286ed8635ece71c72f118e659f4ade3fb",
+            strip_prefix = "googletest-release-1.10.0",
             urls = [
-                "https://github.com/google/googletest/archive/b6cd405286ed8635ece71c72f118e659f4ade3fb.tar.gz",
+                "https://github.com/google/googletest/archive/release-1.10.0.tar.gz",
             ],
-            sha256 = "8d9aa381a6885fe480b7d0ce8ef747a0b8c6ee92f99d74ab07e3503434007cb0",
+            sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
         )
 
     # Load the googleapis dependency.
@@ -66,19 +77,19 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-1.22.0",
+            strip_prefix = "grpc-1.24.2",
             urls = [
-                "https://github.com/grpc/grpc/archive/v1.22.0.tar.gz",
-                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.22.0.tar.gz",
+                "https://github.com/grpc/grpc/archive/v1.24.2.tar.gz",
+                "https://mirror.bazel.build/github.com/grpc/grpc/archive/v1.24.2.tar.gz",
             ],
-            sha256 = "11ac793c562143d52fd440f6549588712badc79211cdc8c509b183cb69bddad8",
+            sha256 = "fd040f5238ff1e32b468d9d38e50f0d7f8da0828019948c9001e9a03093e1d8f",
         )
 
     # We use the cc_proto_library() rule from @com_google_protobuf, which
     # assumes that grpc_cpp_plugin and grpc_lib are in the //external: module
     native.bind(
         name = "grpc_cpp_plugin",
-        actual = "@com_github_grpc_grpc//:grpc_cpp_plugin",
+        actual = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
     )
 
     native.bind(

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -18,7 +18,7 @@ set -eu
 readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" \
   |  tr '[:upper:]' '[:lower:]')
 
-readonly BAZEL_VERSION="1.0.0"
+readonly BAZEL_VERSION="0.28.0"
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"

--- a/ci/install-bazel.sh
+++ b/ci/install-bazel.sh
@@ -18,7 +18,7 @@ set -eu
 readonly PLATFORM=$(printf "%s-%s" "$(uname -s)" "$(uname -m)" \
   |  tr '[:upper:]' '[:lower:]')
 
-readonly BAZEL_VERSION="0.28.0"
+readonly BAZEL_VERSION="1.0.0"
 readonly GITHUB_DL="https://github.com/bazelbuild/bazel/releases/download"
 readonly SCRIPT_NAME="bazel-${BAZEL_VERSION}-installer-${PLATFORM}.sh"
 wget -q "${GITHUB_DL}/${BAZEL_VERSION}/${SCRIPT_NAME}"

--- a/ci/kokoro/Dockerfile.centos
+++ b/ci/kokoro/Dockerfile.centos
@@ -15,14 +15,12 @@
 ARG DISTRO_VERSION=7
 FROM centos:${DISTRO_VERSION}
 
-RUN yum makecache && yum install -y \
-    gcc \
-    gcc-c++ \
-    git \
-    unzip \
-    wget \
-    which
+# We need to install cmake3, which on CentOS-7 requires an extra source
+RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y centos-release-scl
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 
-WORKDIR /var/tmp/ci
-COPY install-bazel.sh /var/tmp/ci
-RUN /var/tmp/ci/install-bazel.sh
+RUN yum makecache && \
+    yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
+        make openssl-devel pkgconfig tar wget which zlib-devel
+RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -141,6 +141,8 @@ elif [[ "${BUILD_NAME}" = "gcc-4.8" ]]; then
   # (and its commercial cousin: RHEL 7).
   export DISTRO=centos
   export DISTRO_VERSION=7
+  export CMAKE_SOURCE_DIR="super"
+  in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "clang-3.8" ]]; then
   # The oldest version of Clang we actively test is 3.8. There is nothing
   # particularly interesting about that version. It is simply the version
@@ -150,6 +152,7 @@ elif [[ "${BUILD_NAME}" = "clang-3.8" ]]; then
   export DISTRO_VERSION=16.04
   export CC=clang
   export CXX=clang++
+  in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "cxx17" ]]; then
   export GOOGLE_CLOUD_CPP_CXX_STANDARD=17
   export DISTRO=fedora-install

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -152,7 +152,6 @@ elif [[ "${BUILD_NAME}" = "clang-3.8" ]]; then
   export DISTRO_VERSION=16.04
   export CC=clang
   export CXX=clang++
-  in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "cxx17" ]]; then
   export GOOGLE_CLOUD_CPP_CXX_STANDARD=17
   export DISTRO=fedora-install

--- a/ci/test-install/WORKSPACE
+++ b/ci/test-install/WORKSPACE
@@ -59,8 +59,13 @@ grpc_deps()
 
 # Call the workspace dependency functions defined, but not invoked, in grpc_deps.bzl.
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+
 upb_deps()
+
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+
 apple_rules_dependencies()
+
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+
 apple_support_dependencies()

--- a/ci/test-install/WORKSPACE
+++ b/ci/test-install/WORKSPACE
@@ -56,3 +56,11 @@ google_cloud_cpp_common_deps()
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
+
+# Call the workspace dependency functions defined, but not invoked, in grpc_deps.bzl.
+load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+upb_deps()
+load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+apple_rules_dependencies()
+load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
+apple_support_dependencies()

--- a/google/cloud/spanner/keys.h
+++ b/google/cloud/spanner/keys.h
@@ -155,10 +155,10 @@ class KeySet {
   KeySet() = default;
 
   // Copy and move constructors and assignment operators.
-  KeySet(KeySet const& key_range) = default;
-  KeySet& operator=(KeySet const& rhs) = default;
-  KeySet(KeySet&& key_range) = default;
-  KeySet& operator=(KeySet&& rhs) = default;
+  KeySet(KeySet const&) = default;
+  KeySet& operator=(KeySet const&) = default;
+  KeySet(KeySet&&) = default;
+  KeySet& operator=(KeySet&&) = default;
 
   /// Adds the given @p key to the `KeySet`.
   KeySet& AddKey(Key key);


### PR DESCRIPTION
Install Bazel 1.0 for the builds. We need a newer version of gRPC to
compile with this version of Bazel, so change that too.  Likewise, it
seems that some of the Bazel rules we use (indirectly) depend on
features of `git` that are not available on CentOS:7. I chose to move
the GCC-4.8 build to CMake instead of debugging those problems.

Fixes #950 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/951)
<!-- Reviewable:end -->
