### PR TITLE
refactor: use non-streaming RPC for ExecuteDml

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -220,8 +220,6 @@ class StatusOnlyResultSetSource : public internal::ResultSourceInterface {
 
 class DmlResultSetSource : public internal::ResultSourceInterface {
  public:
-  explicit DmlResultSetSource(google::cloud::Status status)
-      : status_(std::move(status)) {}
   explicit DmlResultSetSource(spanner_proto::ResultSet result_set)
       : result_set_(std::move(result_set)) {}
   ~DmlResultSetSource() override = default;
@@ -234,6 +232,7 @@ class DmlResultSetSource : public internal::ResultSourceInterface {
     }
     return {};
   }
+
   optional<google::spanner::v1::ResultSetStats> Stats() const override {
     if (result_set_.has_stats()) {
       return result_set_.stats();
@@ -242,7 +241,6 @@ class DmlResultSetSource : public internal::ResultSourceInterface {
   }
 
  private:
-  google::cloud::Status status_;
   spanner_proto::ResultSet result_set_;
 };
 

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -543,8 +543,8 @@ TEST(ConnectionImplTest, ExecuteDmlDelete_PermanentFailure) {
       &response));
 
   EXPECT_CALL(*mock, ExecuteSql(_, _))
-      .WillOnce(Return(
-          Status(StatusCode::kPermissionDenied, "uh-oh in ExecuteDml")));
+      .WillOnce(
+          Return(Status(StatusCode::kPermissionDenied, "uh-oh in ExecuteDml")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
@@ -571,15 +571,14 @@ TEST(ConnectionImplTest, ExecuteDmlDelete_TooManyTransientFailures) {
 
   EXPECT_CALL(*mock, ExecuteSql(_, _))
       .Times(AtLeast(2))
-      .WillRepeatedly(Return(
-          Status(StatusCode::kUnavailable, "try-again in ExecuteDml")));
+      .WillRepeatedly(
+          Return(Status(StatusCode::kUnavailable, "try-again in ExecuteDml")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
 
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
-  EXPECT_THAT(result.status().message(),
-              HasSubstr("try-again in ExecuteDml"));
+  EXPECT_THAT(result.status().message(), HasSubstr("try-again in ExecuteDml"));
 }
 
 TEST(ConnectionImplTest, ExecuteBatchDmlSuccess) {

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -500,63 +500,25 @@ TEST(ConnectionImplTest, ExecuteDmlGetSessionFailure) {
   EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in GetSession"));
 }
 
-TEST(ConnectionImplTest, ExecuteDmlStreamingReadFailure) {
-  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-
-  auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(::testing::Invoke(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          }));
-
-  auto grpc_reader = make_unique<MockGrpcReader>();
-  EXPECT_CALL(*grpc_reader, Read(_)).WillOnce(Return(false));
-  grpc::Status finish_status(grpc::StatusCode::PERMISSION_DENIED,
-                             "uh-oh in GrpcReader::Finish");
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(finish_status));
-  EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
-
-  Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
-
-  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
-  EXPECT_THAT(result.status().message(),
-              HasSubstr("uh-oh in GrpcReader::Finish"));
-}
-
 TEST(ConnectionImplTest, ExecuteDmlDeleteSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
-
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(db, mock);
-  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(::testing::Invoke(
-          [&db](grpc::ClientContext&,
-                spanner_proto::BatchCreateSessionsRequest const& request) {
-            EXPECT_EQ(db.FullName(), request.database());
-            return MakeSessionsResponse({"test-session-name"});
-          }));
 
-  auto grpc_reader = make_unique<MockGrpcReader>();
-  spanner_proto::PartialResultSet response;
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+      .WillOnce(Return(MakeSessionsResponse({"session-name"})));
+
+  spanner_proto::ResultSet response;
   ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         metadata: { transaction: { id: "1234567890" } }
         stats: { row_count_exact: 42 }
       )pb",
       &response));
-  EXPECT_CALL(*grpc_reader, Read(_))
-      .WillOnce(DoAll(SetArgPointee<0>(response), Return(true)));
-  // TODO(#511): .WillOnce(Return(false));
-  EXPECT_CALL(*grpc_reader, Finish()).WillOnce(Return(grpc::Status()));
-  EXPECT_CALL(*mock, ExecuteStreamingSql(_, _))
-      .WillOnce(Return(ByMove(std::move(grpc_reader))));
 
+  EXPECT_CALL(*mock, ExecuteSql(_, _))
+      .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
+      .WillOnce(Return(response));
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
   auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
 


### PR DESCRIPTION
fixes #929 

I've get kept the implementation similar to the streaming rpc as I believe there may be some opportunity to factor out common code as I add the ProfileQuery and ProfileDml methods in a separate PR.

I'm unsure if ExecuteDml needs to support Begin Transaction functionality, so I left it in for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/952)
<!-- Reviewable:end -->
