### PR TITLE
feat: configurable strategy for background threads

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -95,6 +95,7 @@ endif ()
 configure_file(version_info.h.in ${CMAKE_CURRENT_SOURCE_DIR}/version_info.h)
 add_library(spanner_client
             ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
+            background_threads.h
             backoff_policy.h
             batch_dml_result.h
             bytes.cc
@@ -122,6 +123,8 @@ add_library(spanner_client
             instance_admin_connection.h
             internal/api_client_header.cc
             internal/api_client_header.h
+            internal/background_threads_impl.cc
+            internal/background_threads_impl.h
             internal/build_info.h
             internal/compiler_info.cc
             internal/compiler_info.h
@@ -300,6 +303,7 @@ function (spanner_client_define_tests)
         instance_admin_connection_test.cc
         instance_test.cc
         internal/api_client_header_test.cc
+        internal/background_threads_test.cc
         internal/build_info_test.cc
         internal/compiler_info_test.cc
         internal/connection_impl_test.cc

--- a/google/cloud/spanner/background_threads.h
+++ b/google/cloud/spanner/background_threads.h
@@ -1,0 +1,45 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_BACKGROUND_THREADS_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_BACKGROUND_THREADS_H_
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/grpc_utils/completion_queue.h"
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+/**
+ * A object representing the background threads available to a Client.
+ */
+class BackgroundThreads {
+ public:
+  virtual ~BackgroundThreads() = default;
+
+  /// The completion queue used for the background operations.
+  virtual grpc_utils::CompletionQueue cq() const = 0;
+
+  /// Terminate any automatically created threads.
+  virtual void Shutdown() = 0;
+};
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_BACKGROUND_THREADS_H_

--- a/google/cloud/spanner/background_threads.h
+++ b/google/cloud/spanner/background_threads.h
@@ -32,9 +32,6 @@ class BackgroundThreads {
 
   /// The completion queue used for the background operations.
   virtual grpc_utils::CompletionQueue cq() const = 0;
-
-  /// Terminate any automatically created threads.
-  virtual void Shutdown() = 0;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -161,7 +161,9 @@ class ConnectionOptions {
    * Connections need to perform background work on behalf of the application.
    * Normally they just create a background thread and a `CompletionQueue` for
    * this work, but the application may need more fine-grained control of their
-   * threads. In this case the application can provide the
+   * threads. In this case the application can provide the `CompletionQueue` and
+   * it assumes responsibility for creating one or more threads blocked on
+   * `CompletionQueue::Run()`.
    */
   ConnectionOptions& DisableBackgroundThreads(
       google::cloud::grpc_utils::CompletionQueue const& cq);

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -15,12 +15,15 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_OPTIONS_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_CONNECTION_OPTIONS_H_
 
+#include "google/cloud/spanner/background_threads.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/grpc_utils/completion_queue.h"
 #include "google/cloud/status_or.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.grpc.pb.h>
 #include <google/spanner/v1/spanner.pb.h>
 #include <grpcpp/grpcpp.h>
 #include <cstdint>
+#include <functional>
 #include <set>
 #include <string>
 
@@ -152,6 +155,23 @@ class ConnectionOptions {
    */
   grpc::ChannelArguments CreateChannelArguments() const;
 
+  /**
+   * Configure the connection to use @p cq for all background work.
+   *
+   * Connections need to perform background work on behalf of the application.
+   * Normally they just create a background thread and a `CompletionQueue` for
+   * this work, but the application may need more fine-grained control of their
+   * threads. In this case the application can provide the
+   */
+  ConnectionOptions& DisableBackgroundThreads(
+      google::cloud::grpc_utils::CompletionQueue const& cq);
+
+  using BackgroundThreadsFactory =
+      std::function<std::unique_ptr<BackgroundThreads>()>;
+  BackgroundThreadsFactory background_threads_factory() {
+    return background_threads_factory_;
+  }
+
  private:
   std::shared_ptr<grpc::ChannelCredentials> credentials_;
   std::string endpoint_;
@@ -159,6 +179,7 @@ class ConnectionOptions {
   std::string channel_pool_domain_;
 
   std::string user_agent_prefix_;
+  BackgroundThreadsFactory background_threads_factory_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -152,7 +152,7 @@ TEST(ConnectionOptionsTest, DefaultBackgroundThreads) {
 
   using ms = std::chrono::milliseconds;
 
-  // Verify the background thread is not the main thread.
+  // Verify the background thread is not this thread.
   auto background_thread_id = background->cq().MakeRelativeTimer(ms(0)).then(
       [](future<std::chrono::system_clock::time_point>) {
         return std::this_thread::get_id();

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -147,12 +147,11 @@ TEST(ConnectionOptionsTest, CreateChannelArguments_WithChannelPool) {
 }
 
 TEST(ConnectionOptionsTest, DefaultBackgroundThreads) {
-  ConnectionOptions options;
+  auto options = ConnectionOptions(grpc::InsecureChannelCredentials());
   auto background = options.background_threads_factory()();
 
   using ms = std::chrono::milliseconds;
 
-  auto expired = background->cq().MakeRelativeTimer(ms(0));
   // Verify the background thread is not the main thread.
   auto background_thread_id = background->cq().MakeRelativeTimer(ms(0)).then(
       [](future<std::chrono::system_clock::time_point>) {
@@ -168,7 +167,8 @@ TEST(ConnectionOptionsTest, CustomBackgroundThreads) {
   grpc_utils::CompletionQueue cq;
   std::thread t([&cq] { cq.Run(); });
 
-  auto options = ConnectionOptions{}.DisableBackgroundThreads(cq);
+  auto options = ConnectionOptions(grpc::InsecureChannelCredentials())
+                     .DisableBackgroundThreads(cq);
   auto background = options.background_threads_factory()();
 
   using ms = std::chrono::milliseconds;

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -146,6 +146,47 @@ TEST(ConnectionOptionsTest, CreateChannelArguments_WithChannelPool) {
               StartsWith(options.user_agent_prefix()));
 }
 
+TEST(ConnectionOptionsTest, DefaultBackgroundThreads) {
+  ConnectionOptions options;
+  auto background = options.background_threads_factory()();
+
+  using ms = std::chrono::milliseconds;
+
+  auto expired = background->cq().MakeRelativeTimer(ms(0));
+  // Verify the background thread is not the main thread.
+  auto background_thread_id = background->cq().MakeRelativeTimer(ms(0)).then(
+      [](future<std::chrono::system_clock::time_point>) {
+        return std::this_thread::get_id();
+      });
+  EXPECT_EQ(std::future_status::ready, background_thread_id.wait_for(ms(100)));
+
+  auto actual = background_thread_id.get();
+  EXPECT_NE(std::this_thread::get_id(), actual);
+}
+
+TEST(ConnectionOptionsTest, CustomBackgroundThreads) {
+  grpc_utils::CompletionQueue cq;
+  std::thread t([&cq] { cq.Run(); });
+
+  auto options = ConnectionOptions{}.DisableBackgroundThreads(cq);
+  auto background = options.background_threads_factory()();
+
+  using ms = std::chrono::milliseconds;
+
+  /// Verify the background thread is the thread provided above.
+  auto background_thread_id = background->cq().MakeRelativeTimer(ms(0)).then(
+      [](future<std::chrono::system_clock::time_point>) {
+        return std::this_thread::get_id();
+      });
+  EXPECT_EQ(std::future_status::ready, background_thread_id.wait_for(ms(100)));
+
+  auto actual = background_thread_id.get();
+  EXPECT_EQ(t.get_id(), actual);
+
+  cq.Shutdown();
+  t.join();
+}
+
 }  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/internal/background_threads_impl.cc
+++ b/google/cloud/spanner/internal/background_threads_impl.cc
@@ -1,0 +1,40 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/internal/background_threads_impl.h"
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+
+AutomaticallyCreatedBackgroundThreads::AutomaticallyCreatedBackgroundThreads()
+    : runner_([](grpc_utils::CompletionQueue cq) { cq.Run(); }, cq_) {}
+
+AutomaticallyCreatedBackgroundThreads::
+    ~AutomaticallyCreatedBackgroundThreads() {
+  Shutdown();
+}
+
+void AutomaticallyCreatedBackgroundThreads::Shutdown() {
+  cq_.Shutdown();
+  if (runner_.joinable()) runner_.join();
+}
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/internal/background_threads_impl.h
+++ b/google/cloud/spanner/internal/background_threads_impl.h
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_BACKGROUND_THREADS_IMPL_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_BACKGROUND_THREADS_IMPL_H_
+
+#include "google/cloud/spanner/background_threads.h"
+#include "google/cloud/grpc_utils/completion_queue.h"
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+
+/// Assume the user has provided the background threads and use them.
+class CustomerSuppliedBackgroundThreads : public BackgroundThreads {
+ public:
+  explicit CustomerSuppliedBackgroundThreads(grpc_utils::CompletionQueue cq)
+      : cq_(std::move(cq)) {}
+  ~CustomerSuppliedBackgroundThreads() override = default;
+
+  grpc_utils::CompletionQueue cq() const override { return cq_; }
+  void Shutdown() override {}
+
+ private:
+  grpc_utils::CompletionQueue cq_;
+};
+
+/// Create a background thread to perform background operations.
+class AutomaticallyCreatedBackgroundThreads : public BackgroundThreads {
+ public:
+  AutomaticallyCreatedBackgroundThreads();
+  ~AutomaticallyCreatedBackgroundThreads() override;
+
+  grpc_utils::CompletionQueue cq() const override { return cq_; }
+  void Shutdown() override;
+
+ private:
+  grpc_utils::CompletionQueue cq_;
+  std::thread runner_;
+};
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_BACKGROUND_THREADS_IMPL_H_

--- a/google/cloud/spanner/internal/background_threads_impl.h
+++ b/google/cloud/spanner/internal/background_threads_impl.h
@@ -33,7 +33,6 @@ class CustomerSuppliedBackgroundThreads : public BackgroundThreads {
   ~CustomerSuppliedBackgroundThreads() override = default;
 
   grpc_utils::CompletionQueue cq() const override { return cq_; }
-  void Shutdown() override {}
 
  private:
   grpc_utils::CompletionQueue cq_;
@@ -46,7 +45,7 @@ class AutomaticallyCreatedBackgroundThreads : public BackgroundThreads {
   ~AutomaticallyCreatedBackgroundThreads() override;
 
   grpc_utils::CompletionQueue cq() const override { return cq_; }
-  void Shutdown() override;
+  void Shutdown();
 
  private:
   grpc_utils::CompletionQueue cq_;

--- a/google/cloud/spanner/internal/background_threads_test.cc
+++ b/google/cloud/spanner/internal/background_threads_test.cc
@@ -79,8 +79,8 @@ TEST(AutomaticallyCreatedBackgroundThreads, IsActive) {
   EXPECT_EQ(std::future_status::ready, expired.wait_for(ms(100)));
 }
 
-/// @test Verify the background thread is not the main thread.
-TEST(AutomaticallyCreatedBackgroundThreads, IsNotMain) {
+/// @test Verify the background thread is not the thread the current thread.
+TEST(AutomaticallyCreatedBackgroundThreads, IsNotCurrentThread) {
   AutomaticallyCreatedBackgroundThreads actual;
 
   using ms = std::chrono::milliseconds;

--- a/google/cloud/spanner/internal/background_threads_test.cc
+++ b/google/cloud/spanner/internal/background_threads_test.cc
@@ -1,0 +1,104 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/internal/background_threads_impl.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+namespace {
+
+/// @test Verify we can create and use a CustomerSuppliedBackgroundThreads
+/// without impacting the completion queue
+TEST(CustomerSuppliedBackgroundThreads, LifecycleNoShutdown) {
+  grpc_utils::CompletionQueue cq;
+  promise<void> p;
+  std::thread t([&cq, &p] {
+    cq.Run();
+    p.set_value();
+  });
+
+  {
+    CustomerSuppliedBackgroundThreads actual(cq);
+    actual.Shutdown();
+  }
+
+  using ms = std::chrono::milliseconds;
+
+  auto has_shutdown = p.get_future();
+  EXPECT_NE(std::future_status::ready, has_shutdown.wait_for(ms(2)));
+
+  auto expired = cq.MakeRelativeTimer(ms(0));
+  EXPECT_EQ(std::future_status::ready, expired.wait_for(ms(100)));
+
+  cq.Shutdown();
+  EXPECT_EQ(std::future_status::ready, has_shutdown.wait_for(ms(100)));
+
+  t.join();
+}
+
+/// @test Verify that users can supply their own queue and threads.
+TEST(CustomerSuppliedBackgroundThreads, SharesCompletionQueue) {
+  grpc_utils::CompletionQueue cq;
+
+  CustomerSuppliedBackgroundThreads actual(cq);
+
+  // Verify the completion queue is shared, scheduling work in actual.cq() works
+  // if our thread is blocked in cq.Run().
+  std::thread t([&cq] { cq.Run(); });
+  using ms = std::chrono::milliseconds;
+  future<std::thread::id> id = actual.cq().MakeRelativeTimer(ms(0)).then(
+      [](future<std::chrono::system_clock::time_point>) {
+        return std::this_thread::get_id();
+      });
+  EXPECT_EQ(std::future_status::ready, id.wait_for(ms(100)));
+  EXPECT_EQ(t.get_id(), id.get());
+
+  cq.Shutdown();
+  t.join();
+}
+
+/// @test Verify that automatically created completion queues are usable.
+TEST(AutomaticallyCreatedBackgroundThreads, IsActive) {
+  AutomaticallyCreatedBackgroundThreads actual;
+
+  using ms = std::chrono::milliseconds;
+
+  auto expired = actual.cq().MakeRelativeTimer(ms(0));
+  EXPECT_EQ(std::future_status::ready, expired.wait_for(ms(100)));
+}
+
+/// @test Verify the background thread is not the main thread.
+TEST(AutomaticallyCreatedBackgroundThreads, IsNotMain) {
+  AutomaticallyCreatedBackgroundThreads actual;
+
+  using ms = std::chrono::milliseconds;
+
+  future<std::thread::id> id = actual.cq().MakeRelativeTimer(ms(0)).then(
+      [](future<std::chrono::system_clock::time_point>) {
+        return std::this_thread::get_id();
+      });
+  EXPECT_EQ(std::future_status::ready, id.wait_for(ms(100)));
+  EXPECT_NE(std::this_thread::get_id(), id.get());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/internal/background_threads_test.cc
+++ b/google/cloud/spanner/internal/background_threads_test.cc
@@ -32,10 +32,7 @@ TEST(CustomerSuppliedBackgroundThreads, LifecycleNoShutdown) {
     p.set_value();
   });
 
-  {
-    CustomerSuppliedBackgroundThreads actual(cq);
-    actual.Shutdown();
-  }
+  { CustomerSuppliedBackgroundThreads actual(cq); }
 
   using ms = std::chrono::milliseconds;
 

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for spanner_client - DO NOT EDIT."""
 
 spanner_client_hdrs = [
+    "background_threads.h",
     "backoff_policy.h",
     "batch_dml_result.h",
     "bytes.h",
@@ -33,6 +34,7 @@ spanner_client_hdrs = [
     "instance_admin_client.h",
     "instance_admin_connection.h",
     "internal/api_client_header.h",
+    "internal/background_threads_impl.h",
     "internal/build_info.h",
     "internal/compiler_info.h",
     "internal/connection_impl.h",
@@ -92,6 +94,7 @@ spanner_client_srcs = [
     "instance_admin_client.cc",
     "instance_admin_connection.cc",
     "internal/api_client_header.cc",
+    "internal/background_threads_impl.cc",
     "internal/compiler_info.cc",
     "internal/connection_impl.cc",
     "internal/database_admin_logging.cc",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -27,6 +27,7 @@ spanner_client_unit_tests = [
     "instance_admin_connection_test.cc",
     "instance_test.cc",
     "internal/api_client_header_test.cc",
+    "internal/background_threads_test.cc",
     "internal/build_info_test.cc",
     "internal/compiler_info_test.cc",
     "internal/connection_impl_test.cc",


### PR DESCRIPTION
This change introduces an interface to represent the background
thread(s) used by a connection. I included two implementations in this
PR, one that automatically creates a single background thread, and
another that uses one or more threads provided by the application.

The ConnectionOptions class provides a factory for `BackgroundThreads`,
for those (we expect few) applications that will want to control the
background threads.

This fixes #606

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/955)
<!-- Reviewable:end -->
