### PR TITLE
refactor: prepare for "SELECT * ..." changes

### DIFF
--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -66,7 +66,8 @@ StatusOr<optional<Value>> PartialResultSetSource::NextValue() {
                   "response metadata is missing row type information");
   }
 
-  auto t = fields.Get(index_++ % fields.size()).type();
+  auto t = fields.Get(index_).type();
+  index_ = (index_ + 1) % fields.size();
   auto v = std::move(values_.front());
   values_.pop_front();
   return {FromProto(std::move(t), std::move(v))};

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -102,7 +102,7 @@ Status PartialResultSetSource::ReadFromStream() {
     if (metadata_) {
       GCP_LOG(WARNING) << "Unexpectedly received two sets of metadata";
     } else {
-      metadata_ = *result_set->release_metadata();
+      metadata_ = std::move(*result_set->mutable_metadata());
     }
   }
 
@@ -111,7 +111,7 @@ Status PartialResultSetSource::ReadFromStream() {
     if (stats_) {
       GCP_LOG(WARNING) << "Unexpectedly received two sets of stats";
     }
-    stats_ = *result_set->release_stats();
+    stats_ = std::move(*result_set->mutable_stats());
   }
 
   auto& new_values = *result_set->mutable_values();

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -66,8 +66,8 @@ StatusOr<optional<Value>> PartialResultSetSource::NextValue() {
                   "response metadata is missing row type information");
   }
 
-  auto t = fields.Get(index_).type();
-  index_ = (index_ + 1) % fields.size();
+  auto t = fields.Get(field_index_).type();
+  field_index_ = (field_index_ + 1) % fields.size();
   auto v = std::move(values_.front());
   values_.pop_front();
   return {FromProto(std::move(t), std::move(v))};

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -159,7 +159,7 @@ Status PartialResultSetSource::ReadFromStream() {
     new_values.RemoveLast();
   }
 
-  // Copies all the remaining in new_values to values_
+  // Moves all the remaining in new_values to values_
   for (auto& value_proto : new_values) {
     values_.push_back(std::move(value_proto));
   }

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -70,7 +70,6 @@ StatusOr<optional<Value>> PartialResultSetSource::NextValue() {
 
   // The metadata tells us the sequence of types for the field Values;
   // when we reach the end of the sequence start over at the beginning.
-  /* auto const& fields = last_result_.metadata().row_type().fields(); */
   auto const& fields = metadata_->row_type().fields();
   if (next_value_type_index_ >= fields.size()) {
     next_value_type_index_ = 0;

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -121,9 +121,6 @@ Status PartialResultSetSource::ReadFromStream() {
     stats_ = *result_set->release_stats();
   }
 
-  last_result_.mutable_resume_token()->swap(
-      *result_set->mutable_resume_token());
-
   last_result_.mutable_values()->Swap(result_set->mutable_values());
 
   // Merge values if necessary, as described in:

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -67,7 +67,7 @@ class PartialResultSetSource : public internal::ResultSourceInterface {
   optional<google::spanner::v1::ResultSetStats> stats_;
   std::deque<google::protobuf::Value> values_;
   optional<google::protobuf::Value> chunk_;
-  int index_ = 0;
+  int field_index_ = 0;
   bool finished_ = false;
 };
 

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -46,17 +46,11 @@ class PartialResultSetSource : public internal::ResultSourceInterface {
 
   StatusOr<optional<Value>> NextValue() override;
   optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
-    if (last_result_.has_metadata()) {
-      return last_result_.metadata();
-    }
-    return {};
+    return metadata_;
   }
 
   optional<google::spanner::v1::ResultSetStats> Stats() const override {
-    if (last_result_.has_stats()) {
-      return last_result_.stats();
-    }
-    return {};
+    return stats_;
   }
 
  private:
@@ -65,6 +59,9 @@ class PartialResultSetSource : public internal::ResultSourceInterface {
       : reader_(std::move(reader)) {}
 
   Status ReadFromStream();
+
+  optional<google::spanner::v1::ResultSetMetadata> metadata_;
+  optional<google::spanner::v1::ResultSetStats> stats_;
 
   std::unique_ptr<PartialResultSetReader> reader_;
   google::spanner::v1::PartialResultSet last_result_;

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -24,8 +24,8 @@
 #include <google/spanner/v1/spanner.grpc.pb.h>
 #include <google/spanner/v1/spanner.pb.h>
 #include <grpcpp/grpcpp.h>
-#include <memory>
 #include <deque>
+#include <memory>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -25,6 +25,7 @@
 #include <google/spanner/v1/spanner.pb.h>
 #include <grpcpp/grpcpp.h>
 #include <memory>
+#include <deque>
 
 namespace google {
 namespace cloud {
@@ -45,6 +46,7 @@ class PartialResultSetSource : public internal::ResultSourceInterface {
   ~PartialResultSetSource() override;
 
   StatusOr<optional<Value>> NextValue() override;
+
   optional<google::spanner::v1::ResultSetMetadata> Metadata() override {
     return metadata_;
   }
@@ -60,15 +62,13 @@ class PartialResultSetSource : public internal::ResultSourceInterface {
 
   Status ReadFromStream();
 
+  std::unique_ptr<PartialResultSetReader> reader_;
   optional<google::spanner::v1::ResultSetMetadata> metadata_;
   optional<google::spanner::v1::ResultSetStats> stats_;
-
-  std::unique_ptr<PartialResultSetReader> reader_;
-  google::spanner::v1::PartialResultSet last_result_;
-  optional<google::protobuf::Value> partial_chunked_value_;
+  std::deque<google::protobuf::Value> values_;
+  optional<google::protobuf::Value> chunk_;
+  int index_ = 0;
   bool finished_ = false;
-  int next_value_index_ = 0;
-  int next_value_type_index_ = 0;
 };
 
 }  // namespace internal


### PR DESCRIPTION
In preparation for #387 we need to get ready for the partial result set source to return a full "row" (i.e., a `vector<Value>`) at a time. This refactoring is an attempt to break up an upcoming huge PR into a a slightly smaller ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/959)
<!-- Reviewable:end -->
