### PR TITLE
refactor!: split `ExecuteSqlParams` into Query/DML

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -86,7 +86,7 @@ QueryResult Client::ExecuteQuery(Transaction transaction,
 }
 
 QueryResult Client::ExecuteQuery(QueryPartition const& partition) {
-  return conn_->ExecuteQuery(internal::MakeExecuteSqlParams(partition));
+  return conn_->ExecuteQuery(internal::MakeExecuteQueryParams(partition));
 }
 
 StatusOr<std::vector<QueryPartition>> Client::PartitionQuery(

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -108,10 +108,6 @@ class Connection {
   struct ExecuteDmlParams {
     Transaction transaction;
     SqlStatement statement;
-
-    ExecuteDmlParams(Transaction transaction, SqlStatement statement)
-        : transaction(std::move(transaction)),
-          statement(std::move(statement)) {}
   };
 
   /// Wrap the arguments to `ExecutePartitionedDmlParams()`.

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -90,17 +90,28 @@ class Connection {
     PartitionOptions partition_options;
   };
 
-  /// Wrap the arguments to `ExecuteSql()`.
-  struct ExecuteSqlParams {
+  /// Wrap the arguments to `ExecuteQuery()`.
+  struct ExecuteQueryParams {
     Transaction transaction;
     SqlStatement statement;
     google::cloud::optional<std::string> partition_token;
 
-    ExecuteSqlParams(Transaction transaction, SqlStatement statement,
-                     google::cloud::optional<std::string> partition_token = {})
+    ExecuteQueryParams(
+        Transaction transaction, SqlStatement statement,
+        google::cloud::optional<std::string> partition_token = {})
         : transaction(std::move(transaction)),
           statement(std::move(statement)),
           partition_token(std::move(partition_token)) {}
+  };
+
+  /// Wrap the arguments to `ExecuteDml()`.
+  struct ExecuteDmlParams {
+    Transaction transaction;
+    SqlStatement statement;
+
+    ExecuteDmlParams(Transaction transaction, SqlStatement statement)
+        : transaction(std::move(transaction)),
+          statement(std::move(statement)) {}
   };
 
   /// Wrap the arguments to `ExecutePartitionedDmlParams()`.
@@ -110,7 +121,7 @@ class Connection {
 
   /// Wrap the arguments to `PartitionQuery()`.
   struct PartitionQueryParams {
-    ExecuteSqlParams sql_params;
+    ExecuteQueryParams query_params;
     PartitionOptions partition_options;
   };
 
@@ -140,10 +151,10 @@ class Connection {
       PartitionReadParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual QueryResult ExecuteQuery(ExecuteSqlParams) = 0;
+  virtual QueryResult ExecuteQuery(ExecuteQueryParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual StatusOr<DmlResult> ExecuteDml(ExecuteSqlParams) = 0;
+  virtual StatusOr<DmlResult> ExecuteDml(ExecuteDmlParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecutePartitionedDml
   /// RPC

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -70,8 +70,8 @@ class ConnectionImpl : public Connection,
   QueryResult Read(ReadParams) override;
   StatusOr<std::vector<ReadPartition>> PartitionRead(
       PartitionReadParams) override;
-  QueryResult ExecuteQuery(ExecuteSqlParams) override;
-  StatusOr<DmlResult> ExecuteDml(ExecuteSqlParams) override;
+  QueryResult ExecuteQuery(ExecuteQueryParams) override;
+  StatusOr<DmlResult> ExecuteDml(ExecuteDmlParams) override;
   StatusOr<PartitionedDmlResult> ExecutePartitionedDml(
       ExecutePartitionedDmlParams) override;
   StatusOr<std::vector<QueryPartition>> PartitionQuery(
@@ -99,11 +99,11 @@ class ConnectionImpl : public Connection,
 
   QueryResult ExecuteQueryImpl(SessionHolder& session,
                                google::spanner::v1::TransactionSelector& s,
-                               std::int64_t seqno, ExecuteSqlParams params);
+                               std::int64_t seqno, ExecuteQueryParams params);
 
   StatusOr<DmlResult> ExecuteDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteSqlParams params);
+      std::int64_t seqno, ExecuteDmlParams params);
 
   StatusOr<PartitionedDmlResult> ExecutePartitionedDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
@@ -111,7 +111,7 @@ class ConnectionImpl : public Connection,
 
   StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      ExecuteSqlParams const& params, PartitionOptions partition_options);
+      ExecuteQueryParams const& params, PartitionOptions partition_options);
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -42,8 +42,8 @@ class MockConnection : public spanner::Connection {
   MOCK_METHOD1(Read, spanner::QueryResult(ReadParams));
   MOCK_METHOD1(PartitionRead, StatusOr<std::vector<spanner::ReadPartition>>(
                                   PartitionReadParams));
-  MOCK_METHOD1(ExecuteQuery, spanner::QueryResult(ExecuteSqlParams));
-  MOCK_METHOD1(ExecuteDml, StatusOr<spanner::DmlResult>(ExecuteSqlParams));
+  MOCK_METHOD1(ExecuteQuery, spanner::QueryResult(ExecuteQueryParams));
+  MOCK_METHOD1(ExecuteDml, StatusOr<spanner::DmlResult>(ExecuteDmlParams));
   MOCK_METHOD1(ExecutePartitionedDml, StatusOr<spanner::PartitionedDmlResult>(
                                           ExecutePartitionedDmlParams));
   MOCK_METHOD1(PartitionQuery, StatusOr<std::vector<spanner::QueryPartition>>(

--- a/google/cloud/spanner/query_partition.cc
+++ b/google/cloud/spanner/query_partition.cc
@@ -96,7 +96,7 @@ QueryPartition MakeQueryPartition(std::string const& transaction_id,
                         sql_statement);
 }
 
-Connection::ExecuteSqlParams MakeExecuteSqlParams(
+Connection::ExecuteQueryParams MakeExecuteQueryParams(
     QueryPartition const& query_partition) {
   return {internal::MakeTransactionFromIds(query_partition.session_id(),
                                            query_partition.transaction_id()),

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -60,7 +60,7 @@ QueryPartition MakeQueryPartition(std::string const& transaction_id,
                                   std::string const& session_id,
                                   std::string const& partition_token,
                                   SqlStatement const& sql_statement);
-Connection::ExecuteSqlParams MakeExecuteSqlParams(
+Connection::ExecuteQueryParams MakeExecuteQueryParams(
     QueryPartition const& query_partition);
 }  // namespace internal
 
@@ -106,7 +106,7 @@ class QueryPartition {
   friend QueryPartition internal::MakeQueryPartition(
       std::string const& transaction_id, std::string const& session_id,
       std::string const& partition_token, SqlStatement const& sql_statement);
-  friend Connection::ExecuteSqlParams internal::MakeExecuteSqlParams(
+  friend Connection::ExecuteQueryParams internal::MakeExecuteQueryParams(
       QueryPartition const& query_partition);
   friend StatusOr<std::string> SerializeQueryPartition(
       QueryPartition const& query_partition);

--- a/google/cloud/spanner/query_partition_test.cc
+++ b/google/cloud/spanner/query_partition_test.cc
@@ -128,14 +128,14 @@ TEST(QueryPartitionTest, FailedDeserialize) {
   EXPECT_FALSE(partition.ok());
 }
 
-TEST(QueryPartitionTest, MakeExecuteSqlParams) {
+TEST(QueryPartitionTest, MakeExecuteQueryParams) {
   QueryPartitionTester expected_partition(internal::MakeQueryPartition(
       "foo", "session", "token",
       SqlStatement("select * from foo where name = @name",
                    {{"name", Value("Bob")}})));
 
-  Connection::ExecuteSqlParams params =
-      internal::MakeExecuteSqlParams(expected_partition.Partition());
+  Connection::ExecuteQueryParams params =
+      internal::MakeExecuteQueryParams(expected_partition.Partition());
 
   EXPECT_EQ(params.statement,
             SqlStatement("select * from foo where name = @name",

--- a/google/cloud/spanner/samples/mock_execute_query.cc
+++ b/google/cloud/spanner/samples/mock_execute_query.cc
@@ -77,7 +77,7 @@ TEST(MockSpannerClient, SuccessfulExecuteQuery) {
   // Setup the connection mock to return the results previously setup:
   //! [mock-execute-sql]
   EXPECT_CALL(*conn, ExecuteQuery(_))
-      .WillOnce([&source](spanner::Connection::ExecuteSqlParams const&)
+      .WillOnce([&source](spanner::Connection::ExecuteQueryParams const&)
                     -> spanner::QueryResult {
         return spanner::QueryResult(std::move(source));
       });


### PR DESCRIPTION
DML Queries cannot be partitioned; splitting these allows us to remove
the partition token from the DML variant so we don't have to worry about
handling it or not in the method bodies.

BREAKING CHANGE: This changes the `Connection` API which is public for testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/963)
<!-- Reviewable:end -->
