### PR TITLE
chore: makes bazel build ... work

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+ci/
+cmake-out/
+cmake-build-*/


### PR DESCRIPTION
Adds `.bazelignore` file to make `bazel build ...` work

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/965)
<!-- Reviewable:end -->
