### PR TITLE
chore: simplifies tuple_utils; adds IsTuple metafunction

### DIFF
--- a/cmake/EnableDoxygen.cmake
+++ b/cmake/EnableDoxygen.cmake
@@ -65,7 +65,7 @@ else ()
         set(DOXYGEN_SOURCE_BROWSER YES)
         set(DOXYGEN_GENERATE_TAGFILE
             "${CMAKE_CURRENT_BINARY_DIR}/${GOOGLE_CLOUD_CPP_SUBPROJECT}.tag")
-        set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "spanner_testing" "GetElement")
+        set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "spanner_testing")
         set(DOXYGEN_PREDEFINED
             "SPANNER_CLIENT_NS=v${SPANNER_CLIENT_VERSION_MAJOR}")
         set(DOXYGEN_EXCLUDE_PATTERNS

--- a/google/cloud/spanner/internal/tuple_utils.h
+++ b/google/cloud/spanner/internal/tuple_utils.h
@@ -25,6 +25,22 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
+// The implementation for `IsTuple<T>` (below).
+template <typename T>
+struct IsTupleImpl : std::false_type {};
+template <typename... Ts>
+struct IsTupleImpl<std::tuple<Ts...>> : std::true_type {};
+
+// Decays the given type `T` and determines whether it is a `std::tuple<...>`.
+//
+// Example:
+//
+//     using Type = std::tuple<...>;
+//     static_assert(IsTuple<Type>::value, "");
+//
+template <typename T>
+using IsTuple = IsTupleImpl<typename std::decay<T>::type>;
+
 // Decays the tuple `T` and returns its size as in the ::value member.
 template <typename T>
 using TupleSize = std::tuple_size<typename std::decay<T>::type>;

--- a/google/cloud/spanner/internal/tuple_utils.h
+++ b/google/cloud/spanner/internal/tuple_utils.h
@@ -25,50 +25,23 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-// A metafunction that returns the number of elements in any class template
-// that takes a variable number of arguments.
-//
-// Example:
-//
-//     using Type = std::tuple<int, char, bool>;
-//     assert(NumElements<Type>::value == 3);
-//
+// Decays the tuple `T` and returns its size as in the ::value member.
 template <typename T>
-struct NumElementsImpl;
-template <template <typename...> class T, typename... Ts>
-struct NumElementsImpl<T<Ts...>> {
-  static const std::size_t value = sizeof...(Ts);
-};
-template <template <typename...> class T, typename... Ts>
-std::size_t const NumElementsImpl<T<Ts...>>::value;  // Declares storage
-template <typename T>
-using NumElements = NumElementsImpl<typename std::decay<T>::type>;
-
-// Similar to `std::get<I>(std::tuple)`, except that this function is an
-// extension point for `ForEach` (below) that callers can define in their own
-// namespace for their own types to add support for `ForEach`. This overload
-// simply forwards to `std::get`.
-template <std::size_t I, typename Tup>
-auto GetElement(Tup&& tup) -> decltype(std::get<I>(std::forward<Tup>(tup))) {
-  using std::get;
-  return get<I>(std::forward<Tup>(tup));
-}
+using TupleSize = std::tuple_size<typename std::decay<T>::type>;
 
 // Base case of `ForEach` that is called at the end of iterating a tuple.
 // See the docs for the next overload to see how to use `ForEach`.
 template <std::size_t I = 0, typename T, typename F, typename... Args>
-typename std::enable_if<I == NumElements<T>::value, void>::type ForEach(
+typename std::enable_if<I == TupleSize<T>::value, void>::type ForEach(
     T&&, F&&, Args&&...) {}
 
-// This function template iterates the elements of a tuple-like type, calling
-// the given functor with each element of the container as well as any
-// additional arguments that were provided. A tuple-like type is any fixed-size
-// heterogeneous container that has a `GetElement<I>(T)` function that can be
-// found via ADL. The given functor should be able to accept each type in the
-// container. All arguments are perfect-forwarded to the functor, so the
-// functor may choose to accept the tuple arguments by value, const-ref, or
-// even non-const reference, in which case the elements inside the tuple may be
-// modified.
+// This function template iterates the elements of a tuple, calling the given
+// functor with each of the tuple's elements as well as any additional
+// (optional) caller-provided arguments. The given functor should be able to
+// accept each type in the container. All arguments are perfect-forwarded to
+// the functor, so the functor may choose to accept the tuple arguments by
+// value, const-ref, or even non-const reference, in which case the elements
+// inside the tuple may be modified.
 //
 // Example:
 //
@@ -84,9 +57,9 @@ typename std::enable_if<I == NumElements<T>::value, void>::type ForEach(
 //     EXPECT_THAT(v, testing::ElementsAre("1", "42"));
 //
 template <std::size_t I = 0, typename T, typename F, typename... Args>
-typename std::enable_if<(I < NumElements<T>::value), void>::type ForEach(
+typename std::enable_if<(I < TupleSize<T>::value), void>::type ForEach(
     T&& t, F&& f, Args&&... args) {
-  auto&& e = GetElement<I>(std::forward<T>(t));
+  auto&& e = std::get<I>(std::forward<T>(t));
   std::forward<F>(f)(std::forward<decltype(e)>(e), std::forward<Args>(args)...);
   ForEach<I + 1>(std::forward<T>(t), std::forward<F>(f),
                  std::forward<Args>(args)...);

--- a/google/cloud/spanner/internal/tuple_utils_test.cc
+++ b/google/cloud/spanner/internal/tuple_utils_test.cc
@@ -22,13 +22,6 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-TEST(TupleUtils, NumElements) {
-  EXPECT_EQ(internal::NumElements<std::vector<int>>::value, 2);
-  EXPECT_EQ(internal::NumElements<std::tuple<>>::value, 0);
-  EXPECT_EQ(internal::NumElements<std::tuple<int>>::value, 1);
-  EXPECT_EQ((internal::NumElements<std::tuple<int, int>>::value), 2);
-}
-
 // Helper functor used to test the `ForEach` function. Uses a templated
 // `operator()`.
 struct Stringify {
@@ -50,30 +43,6 @@ TEST(TupleUtils, ForEachMutate) {
   auto tup = std::make_tuple(1, 2, 3);
   internal::ForEach(tup, add_one);
   EXPECT_EQ(tup, std::make_tuple(2, 3, 4));
-}
-
-namespace ns {
-// A type that looks like a tuple (i.e., a heterogeneous container), but is not
-// a tuple. This will verify that `ForEach` works with tuple-like types. In a
-// separate namespace to make sure that `ForEach` works with types in another
-// namespace.
-template <typename... Ts>
-struct NotATuple {
-  std::tuple<Ts...> data;
-};
-
-// Required ADL extension point to make `NotATuple` iterable like a tuple.
-template <std::size_t I, typename... Ts>
-auto GetElement(NotATuple<Ts...>& nat) -> decltype(std::get<I>(nat.data)) {
-  return std::get<I>(nat.data);
-}
-}  // namespace ns
-
-TEST(TupleUtils, ForEachStruct) {
-  auto not_a_tuple = ns::NotATuple<bool, int>{std::make_tuple(true, 42)};
-  std::vector<std::string> v;
-  internal::ForEach(not_a_tuple, Stringify{}, v);
-  EXPECT_THAT(v, testing::ElementsAre("1", "42"));
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/tuple_utils_test.cc
+++ b/google/cloud/spanner/internal/tuple_utils_test.cc
@@ -22,6 +22,27 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
+TEST(TupleUtils, IsTuple) {
+  using T0 = std::tuple<>;
+  static_assert(internal::IsTuple<T0>::value, "");
+  static_assert(internal::IsTuple<T0 const>::value, "");
+  static_assert(internal::IsTuple<T0 const&>::value, "");
+
+  using T1 = std::tuple<int>;
+  static_assert(internal::IsTuple<T1>::value, "");
+  static_assert(internal::IsTuple<T1 const>::value, "");
+  static_assert(internal::IsTuple<T1 const&>::value, "");
+
+  using TN = std::tuple<int, bool, char>;
+  static_assert(internal::IsTuple<TN>::value, "");
+  static_assert(internal::IsTuple<TN const>::value, "");
+  static_assert(internal::IsTuple<TN const&>::value, "");
+
+  static_assert(!internal::IsTuple<int>::value, "");
+  static_assert(!internal::IsTuple<char>::value, "");
+  static_assert(!internal::IsTuple<std::vector<int>>::value, "");
+}
+
 // Helper functor used to test the `ForEach` function. Uses a templated
 // `operator()`.
 struct Stringify {


### PR DESCRIPTION
Now that `Row<...>` is no longer a variadic template, we can now simplify the `internal::ForEach` function to restrict it to only working with `std::tuple` rather than any tuple-like object. This allows us to remove the `GetElement` extension point, which is not used anywhere anymore.

I also added an `IsTuple<T>` metafunction, which I need in my next PR. It's pretty straight-forward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/970)
<!-- Reviewable:end -->
