### PR TITLE
feat: adds row iterators (and friends); not yet used

### DIFF
--- a/google/cloud/spanner/row.cc
+++ b/google/cloud/spanner/row.cc
@@ -71,6 +71,48 @@ bool operator==(Row const& a, Row const& b) {
   return a.values_ == b.values_ && *a.columns_ == *b.columns_;
 }
 
+//
+// RowStreamIterator
+//
+
+RowStreamIterator::RowStreamIterator() = default;
+
+RowStreamIterator::RowStreamIterator(Source source)
+    : row_(Row{}), source_(std::move(source)) {
+  ++*this;
+}
+
+RowStreamIterator& RowStreamIterator::operator++() {
+  if (!row_) {
+    source_ = nullptr;  // Last row was an error; become "end"
+    return *this;
+  }
+  row_ = source_();
+  if (row_ && row_->size() == 0) {
+    source_ = nullptr;  // No more Rows to consume; become "end"
+    return *this;
+  }
+  return *this;
+}
+
+RowStreamIterator RowStreamIterator::operator++(int) {
+  auto const old = *this;
+  ++*this;
+  return old;
+}
+
+bool operator==(RowStreamIterator const& a, RowStreamIterator const& b) {
+  // Input iterators may only be compared to (copies of) themselves and end.
+  // See https://en.cppreference.com/w/cpp/named_req/InputIterator. Therefore,
+  // by definition, all input iterators are equal unless one is end and the
+  // other is not.
+  return !a.source_ == !b.source_;
+}
+
+bool operator!=(RowStreamIterator const& a, RowStreamIterator const& b) {
+  return !(a == b);
+}
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -210,18 +210,18 @@ class Row {
 Row MakeRow(std::vector<std::pair<std::string, Value>> pairs);
 
 /**
- * A `RowStreamIterator` is an "Input Iterator" that returns a sequence of
- * `StatusOr<Row>` objects.
+ * A `RowStreamIterator` is an [Input Iterator][input-iterator] that returns a
+ * sequence of `StatusOr<Row>` objects.
  *
- * As an Input Iterator, the sequence may only be consumed once. See
- * https://en.cppreference.com/w/cpp/named_req/InputIterator for more details.
- *
- * Default constructing a `RowStreamIterator` creates an instance that
- * represents "end".
+ * As an Input Iterator, the sequence may only be consumed once. Default
+ * constructing a `RowStreamIterator` creates an instance that represents
+ * "end".
  *
  * @note The term "stream" in this name refers to the general nature
  *     of the the data source, and is not intended to suggest any similarity to
  *     C++'s I/O streams library. Syntactically, this class is an "iterator".
+ *
+ * [input-iterator]: https://en.cppreference.com/w/cpp/named_req/InputIterator
  */
 class RowStreamIterator {
  public:

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -238,6 +238,8 @@ class RowStreamIterator {
   using difference_type = std::ptrdiff_t;
   using pointer = value_type*;
   using reference = value_type&;
+  using const_pointer = value_type const*;
+  using const_reference = value_type const&;
   ///@}
 
   /// Default constructs an "end" iterator.
@@ -251,6 +253,9 @@ class RowStreamIterator {
 
   reference operator*() { return row_; }
   pointer operator->() { return &row_; }
+
+  const_reference operator*() const { return row_; }
+  const_pointer operator->() const { return &row_; }
 
   RowStreamIterator& operator++();
   RowStreamIterator operator++(int);
@@ -292,6 +297,8 @@ class TupleStreamIterator {
   using difference_type = std::ptrdiff_t;
   using pointer = value_type*;
   using reference = value_type&;
+  using const_pointer = value_type const*;
+  using const_reference = value_type const&;
   ///@}
 
   /// Default constructs an "end" iterator.
@@ -305,6 +312,9 @@ class TupleStreamIterator {
 
   reference operator*() { return tup_; }
   pointer operator->() { return &tup_; }
+
+  const_reference operator*() const { return tup_; }
+  const_pointer operator->() const { return &tup_; }
 
   TupleStreamIterator& operator++() {
     if (!tup_) {

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -21,9 +21,11 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <functional>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -330,6 +332,37 @@ class TupleStreamIterator {
   value_type tup_;
   RowStreamIterator it_;
   RowStreamIterator end_;
+};
+
+/**
+ * A `TupleRange<Tuple>` defines a range that parses `Tuple` objects from the
+ * given range of `RowStreamIterator`s.
+ *
+ * @tparam Tuple the std::tuple<...> to parse each `Row` into.
+ */
+template <typename Tuple>
+class TupleRange {
+ public:
+  using iterator = TupleStreamIterator<Tuple>;
+
+  /**
+   * Creates a `TupleRange<Tuple>` by wrapping the given @p range. The `Range`
+   * must be a range defined by `RowStreamIterator` objects.
+   */
+  template <typename Range>
+  explicit TupleRange(Range const& range)
+      : begin_(std::begin(range), std::end(range)) {
+    using T = decltype(std::begin(range));
+    static_assert(std::is_same<RowStreamIterator, T>::value,
+                  "TupleRange must be given a RowStreamIterator range.");
+  }
+
+  iterator begin() const { return begin_; }
+  iterator end() const { return end_; }
+
+ private:
+  iterator begin_;
+  iterator end_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -26,6 +26,8 @@ namespace {
 
 namespace {
 
+// Given a `vector<Row>` creates a 'Row::Source' object. This is helpeful for
+// unit testing.
 RowStreamIterator::Source MakeRowStreamIteratorSource(
     std::vector<Row> const& rows) {
   std::size_t index = 0;
@@ -37,9 +39,7 @@ RowStreamIterator::Source MakeRowStreamIteratorSource(
 
 struct RowRange {
   RowStreamIterator::Source source;
-  // NOLINTNEXTLINE(readability-identifier-naming)
   RowStreamIterator begin() const { return RowStreamIterator(source); }
-  // NOLINTNEXTLINE(readability-identifier-naming)
   RowStreamIterator end() const { return {}; }
 };
 

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -398,7 +398,7 @@ TEST(TupleStreamIterator, Error) {
   EXPECT_EQ(it, end);
 }
 
-TEST(TupleRange, Basics) {
+TEST(StreamOf, Basics) {
   std::vector<Row> rows;
   rows.emplace_back(MakeRow({
       {"a", Value(1)},      //
@@ -418,7 +418,7 @@ TEST(TupleRange, Basics) {
 
   using RowType = std::tuple<std::int64_t, std::string, bool>;
   RowRange range{MakeRowStreamIteratorSource(rows)};
-  auto parser = TupleRange<RowType>(range);
+  auto parser = StreamOf<RowType>(range);
   auto it = parser.begin();
   auto end = parser.end();
   EXPECT_EQ(end, end);
@@ -445,7 +445,7 @@ TEST(TupleRange, Basics) {
   EXPECT_EQ(it, end);
 }
 
-TEST(TupleRange, RangeForLoop) {
+TEST(StreamOf, RangeForLoop) {
   std::vector<Row> rows;
   rows.emplace_back(MakeRow({{"num", Value(2)}}));
   rows.emplace_back(MakeRow({{"num", Value(3)}}));
@@ -454,7 +454,7 @@ TEST(TupleRange, RangeForLoop) {
 
   RowRange range{MakeRowStreamIteratorSource(rows)};
   std::int64_t product = 1;
-  for (auto row : TupleRange<RowType>(range)) {
+  for (auto row : StreamOf<RowType>(range)) {
     EXPECT_STATUS_OK(row);
     product *= std::get<0>(*row);
   }

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -246,6 +246,14 @@ TEST(RowStreamIterator, Basics) {
   EXPECT_STATUS_OK(*it);
   EXPECT_EQ(rows[2], **it);
 
+  // Tests const op*() and op->()
+  auto const copy = it;
+  EXPECT_EQ(copy, it);
+  EXPECT_NE(copy, end);
+  EXPECT_STATUS_OK(*copy);
+  EXPECT_EQ(rows[2], **copy);
+  EXPECT_EQ(3, (*copy)->size());
+
   ++it;
   EXPECT_EQ(it, it);
   EXPECT_EQ(it, end);
@@ -384,6 +392,12 @@ TEST(TupleStreamIterator, Basics) {
   EXPECT_NE(it, end);
   EXPECT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(3, "baz", true), **it);
+
+  // Tests const op*(). tuple has no members that we can call to test op->().
+  auto const copy = it;
+  EXPECT_EQ(copy, it);
+  EXPECT_NE(copy, end);
+  EXPECT_STATUS_OK(*copy);
 
   ++it;
   EXPECT_EQ(it, it);

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -251,8 +251,7 @@ TEST(RowStreamIterator, Basics) {
   EXPECT_EQ(copy, it);
   EXPECT_NE(copy, end);
   EXPECT_STATUS_OK(*copy);
-  EXPECT_EQ(rows[2], **copy);
-  EXPECT_EQ(3, (*copy)->size());
+  EXPECT_STATUS_OK(copy->status());
 
   ++it;
   EXPECT_EQ(it, it);
@@ -393,11 +392,12 @@ TEST(TupleStreamIterator, Basics) {
   EXPECT_STATUS_OK(*it);
   EXPECT_EQ(std::make_tuple(3, "baz", true), **it);
 
-  // Tests const op*(). tuple has no members that we can call to test op->().
+  // Tests const op*() and op->()
   auto const copy = it;
   EXPECT_EQ(copy, it);
   EXPECT_NE(copy, end);
   EXPECT_STATUS_OK(*copy);
+  EXPECT_STATUS_OK(copy->status());
 
   ++it;
   EXPECT_EQ(it, it);


### PR DESCRIPTION
This PR is part of #387 

This PR adds two iterator classes and one range class:

- `RowStreamIterator` -- Consumes a "stream" of `Row` objects. Each successively returned `Row` is wrapped as a `StatusOr<Row>`. Users will rarely/never directly use this class, but it's needed to enable other things (like range-for iteration).

- `TupleStreamIteartor<T>` -- Wraps a `RowStreamIterator`, and parses each successive `Row` into a `std::tuple<...>`, and yields it as a `StatusOr<std::tuple<...>>`. Users will rarely/never directly use this class, but it's needed to enable other things.

- `StreamOf<Tuple>` -- A "range" of `TupleStreamIterator<T>`. This is a class that users will (eventually) directly use. Users may use this class as follows:

```cc
auto rows = client.Read(...);
using RowType = std::tuple<...>;
for (auto row : StreamOf<RowType>(rows)) {
  ...
}
```

**NOTE THAT NONE OF THIS CODE IS USED YET**

But I expect in my next PR to actually refactor the exitsing `QueryResults`, and the `PartialResultSetSource` classes to actually use these new classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/971)
<!-- Reviewable:end -->
