### PR TITLE
fix: fixes a bug in TupleStreamIterator<>

### DIFF
--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -344,7 +344,8 @@ class TupleStreamIterator {
 
  private:
   void ParseTuple() {
-    if (it_ != end_) tup_ = (*it_)->template get<Tuple>();
+    if (it_ == end_) return;
+    tup_ = *it_ ? (*it_)->template get<Tuple>() : it_->status();
   }
 
   value_type tup_;


### PR DESCRIPTION
This bug showed up when `TupleStreamIterator<>` was consuming a stream
that  not just failed to parse, but totally failed to return any `Row`
data at all. In that case, the input iterator's `*it_` held a `StatusOr`
that was not OK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/973)
<!-- Reviewable:end -->
