### PR TITLE
ci: configure generator for ci/kokoro/install

### DIFF
--- a/ci/etc/install-config.sh
+++ b/ci/etc/install-config.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+GOOGLE_CLOUD_CPP_BAZEL_VERSION="1.0.0"
+readonly GOOGLE_CLOUD_CPP_BAZEL_VERSION
+
+GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION="266.0.0"
+readonly GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION
+
+GOOGLE_CLOUD_CPP_SDK_SHA256="e2b2cd5e49e1dc73ffe1d57ba2bcc1b76620ae9549d2aa27ece05d819a8f4bbc"
+readonly GOOGLE_CLOUD_CPP_SDK_SHA256

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -53,7 +53,7 @@ FROM devtools AS install
 WORKDIR /home/build/project
 COPY . /home/build/project
 RUN cmake -H. -B/o
-RUN cmake --build /o -- -j ${NCPU:-4}
+RUN cmake --build /o -- -j "${NCPU:-4}"
 WORKDIR /o
 RUN ctest -LE integration-tests --output-on-failure
 WORKDIR /home/build/project
@@ -70,6 +70,6 @@ COPY ci/test-install /home/build/test-install-cmake
 COPY google/cloud/spanner/integration_tests/spanner_install_test.cc /home/build/test-install-cmake
 # Disable pkg-config with CMake to verify it is not used in package discovery.
 RUN env -u PKG_CONFIG_PATH cmake -H. -B/i
-RUN cmake --build /i -- -j ${NCPU:-4}
+RUN cmake --build /i -- -j "${NCPU:-4}"
 _EOF_
 )

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BUILD_AND_TEST_PROJECT_FRAGMENT=$(replace_fragments \
+      "INSTALL_CPP_CMAKEFILES_FROM_SOURCE" \
+      "INSTALL_GOOGLETEST_FROM_SOURCE" \
+      "INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE" <<'_EOF_'
+# #### googleapis
+
+# We need a recent version of the Google Cloud Platform proto C++ libraries:
+
+# ```bash
+@INSTALL_CPP_CMAKEFILES_FROM_SOURCE@
+# ```
+
+# #### googletest
+
+# We need a recent version of GoogleTest to compile the unit and integration
+# tests.
+
+# ```bash
+@INSTALL_GOOGLETEST_FROM_SOURCE@
+# ```
+
+# #### google-cloud-cpp-common
+
+# The project also depends on google-cloud-cpp-common, the libraries shared by
+# all the Google Cloud C++ client libraries:
+
+# ```bash
+@INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE@
+# ```
+
+FROM devtools AS install
+
+# #### Compile and install the main project
+
+# We can now compile, test, and install `@GOOGLE_CLOUD_CPP_REPOSITORY@`.
+
+# ```bash
+WORKDIR /home/build/project
+COPY . /home/build/project
+RUN cmake -H. -B/o
+RUN cmake --build /o -- -j ${NCPU:-4}
+WORKDIR /o
+RUN ctest -LE integration-tests --output-on-failure
+WORKDIR /home/build/project
+RUN cmake --build /o --target install
+# ```
+
+## [END INSTALL.md]
+
+ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
+
+# Verify that the installed files are actually usable
+WORKDIR /home/build/test-install-cmake
+COPY ci/test-install /home/build/test-install-cmake
+COPY google/cloud/spanner/integration_tests/spanner_install_test.cc /home/build/test-install-cmake
+# Disable pkg-config with CMake to verify it is not used in package discovery.
+RUN env -u PKG_CONFIG_PATH cmake -H. -B/i
+RUN cmake --build /i -- -j ${NCPU:-4}
+_EOF_
+)

--- a/ci/etc/kokoro/install/run-installed-programs.sh
+++ b/ci/etc/kokoro/install/run-installed-programs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CONFIG_DIRECTORY="${KOKORO_GFILE_DIR:-/dev/shm}"
+readonly CONFIG_DIRECTORY
+if [[ -f "${CONFIG_DIRECTORY}/spanner-integration-tests-config.sh" ]]; then
+  source "${CONFIG_DIRECTORY}/spanner-integration-tests-config.sh"
+
+  run_args=(
+    # Remove the container after running
+    "--rm"
+
+    # Set the environment variables for the test program.
+    "--env" "GOOGLE_APPLICATION_CREDENTIALS=/c/spanner-credentials.json"
+    "--env" "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
+    "--env" "RUN_SLOW_INTEGRATION_TESTS=${RUN_SLOW_INTEGRATION_TESTS:-no}"
+    "--env" "GOOGLE_CLOUD_CPP_SPANNER_INSTANCE=${GOOGLE_CLOUD_CPP_SPANNER_INSTANCE}"
+    "--env" "GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA=${GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA}"
+
+    # Mount the config directory as a volumne in `/c`
+    "--volume" "${CONFIG_DIRECTORY}:/c"
+  )
+  echo "================================================================"
+  echo "Run test program against installed libraries ${DISTRO}."
+  docker run "${run_args[@]}" "${INSTALL_RUN_IMAGE}" "/i/spanner_install_test"
+  echo "================================================================"
+fi

--- a/ci/etc/publish-refdocs.sh
+++ b/ci/etc/publish-refdocs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# This script is meant to source from ci/kokoro/docker/publish_refdocs.sh.
+
+upload_docs "google-cloud-spanner" "${BUILD_OUTPUT}/google/cloud/spanner/html" \
+  "cloud.tag" "${BRANCH}" "${CREDENTIALS_FILE}" "${STAGING_BUCKET}"

--- a/ci/etc/repo-config.sh
+++ b/ci/etc/repo-config.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# This script is sourced from several other scripts in `ci/` to configure the
+# repository name (and short name). It makes those scripts portable across
+# `google-cloud-cpp*` repositories.
+
+GOOGLE_CLOUD_CPP_REPOSITORY="google-cloud-cpp-spanner"
+readonly GOOGLE_CLOUD_CPP_REPOSITORY
+
+GOOGLE_CLOUD_CPP_REPOSITORY_SHORT="spanner"
+readonly GOOGLE_CLOUD_CPP_REPOSITORY_SHORT


### PR DESCRIPTION
This PR introduces the configuration files to automatically generate
`ci/kokoro/install`. I decided to *not* generate that directory in the
same PR so folks can examine the configuration files and decide if they
are worth the trouble.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/974)
<!-- Reviewable:end -->
