### PR TITLE
feat!: Replace RunTransaction() with Client::Commit(functor)

### DIFF
--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -413,19 +413,19 @@ class Client {
   /**
    * Commits a read-write transaction.
    *
-   * Calls the `@p mutator` in the context of a new read-write transaction.
-   * The `mutator` can execute read/write operations using the transaction,
+   * Calls the @p mutator in the context of a new read-write transaction.
+   * The @p mutator can execute read/write operations using the transaction,
    * and returns any additional `Mutations` to commit.
    *
-   * If the `mutator` returns `StatusCode::kAborted` or the transaction commit
+   * If the @p mutator returns `StatusCode::kAborted` or the transaction commit
    * results in an abort, then that transaction is rolled back and the process
-   * repeats (subject to the given rerun/backoff policies), by building a new
-   * transaction and re-running the `mutator`.  The lock priority of the
+   * repeats (subject to @p rerun_policy and @p backoff_policy), by building a
+   * new transaction and re-running the @p mutator.  The lock priority of the
    * operation increases after each aborted transaction, meaning that the next
    * attempt has a slightly better chance of success.
    *
-   * If the `mutator` and the commit succeed, the `CommitResult` is returned.
-   * Otherwise the error returned by the `mutator` or the commit is returned.
+   * If the @p mutator and the commit succeed, the `CommitResult` is returned.
+   * Otherwise the error returned by the @p mutator or the commit is returned.
    *
    * @param mutator the function called to create mutations
    * @param rerun_policy controls for how long (or how many times) the mutator
@@ -460,7 +460,7 @@ class Client {
    * @note Prefer the previous `Commit` overloads if you want to simply reapply
    *     mutations after a `kAborted` error.
    *
-   * @warning It is an error to call `Commit` with a read-only `transaction`.
+   * @warning It is an error to call `Commit` with a read-only transaction.
    *
    * @param transaction The transaction to commit.
    * @param mutations The mutations to be executed when this transaction
@@ -480,7 +480,7 @@ class Client {
    * that includes  one or more `Read`, `ExecuteQuery`, or `ExecuteDml` requests
    * and ultimately decides not to commit.
    *
-   * @warning It is an error to call `Rollback` with a read-only `transaction`.
+   * @warning It is an error to call `Rollback` with a read-only transaction.
    *
    * @param transaction The transaction to roll back.
    *

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -394,7 +394,7 @@ class Client {
    *
    * As with all read-write transactions, the results will not be visible
    * outside of the transaction until it is committed. For that reason, it is
-   * advisable to run this method with `RunTransaction`.
+   * advisable to run this method from a `Commit` mutator.
    *
    * @warning A returned status of OK from this function does not imply that
    *     all the statements were executed successfully. For that, you need to
@@ -413,11 +413,52 @@ class Client {
   /**
    * Commits a read-write transaction.
    *
-   * The commit might return an `ABORTED` error. This can occur at any time;
-   * commonly, the cause is conflicts with concurrent transactions. However, it
-   * can also happen for a variety of other reasons. If `Commit` returns
-   * `ABORTED`, the caller should re-attempt the transaction from the beginning,
-   * re-using the same session.
+   * Calls the `mutator` in the context of a new read-write transaction.  The
+   * `mutator` can execute read/write operations using the transaction, and
+   * returns any additional `Mutations` to commit.
+   *
+   * If the `mutator` returns `StatusCode::kAborted` or the transaction commit
+   * results in an abort, then that transaction is rolled back and the process
+   * repeats (subject to the given rerun/backoff policies), by building a new
+   * transaction and re-running the `mutator`.  The lock priority of the
+   * operation increases after each aborted transaction, meaning that the next
+   * attempt has a slightly better chance of success.
+   *
+   * If the `mutator` and the commit succeed, the `CommitResult` is returned.
+   * Otherwise the error returned by the `mutator` or the commit is returned.
+   *
+   * @param mutator the function called to create mutations
+   * @param rerun_policy controls for how long (or how many times) the mutator
+   *     will be rerun after the transaction aborts.
+   * @param backoff_policy controls how long `Commit` waits between reruns.
+   */
+  StatusOr<CommitResult> Commit(
+      std::function<StatusOr<Mutations>(Transaction)> const& mutator,
+      std::unique_ptr<TransactionRerunPolicy> rerun_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy);
+
+  /**
+   * Commits a read-write transaction.
+   *
+   * Same as above, but uses the default rerun and backoff policies.
+   *
+   * @param mutator the function called to create mutations
+   */
+  StatusOr<CommitResult> Commit(
+      std::function<StatusOr<Mutations>(Transaction)> const& mutator);
+
+  /**
+   * Commits a read-write transaction.
+   *
+   * The commit might return a `kAborted` error. This can occur at any time;
+   * commonly, the cause is conflicts with concurrent transactions. However,
+   * it can also happen for a variety of other reasons. If `Commit` returns
+   * `kAborted`, the caller may try to reapply the mutations within a new
+   * read-write transaction (which should use the same session to ensure an
+   * increase it lock priority).
+   *
+   * @note Prefer the previous `Commit` overloads if you want to simply reapply
+   *     mutations after a `kAborted` error.
    *
    * @warning It is an error to call `Commit` with a read-only `transaction`.
    *
@@ -485,66 +526,6 @@ class Client {
  */
 std::shared_ptr<Connection> MakeConnection(
     Database const& db, ConnectionOptions const& options = ConnectionOptions());
-
-namespace internal {
-/**
- * Execute a function in the context of a read-write transaction, with
- * automatic retries if the transaction commit results in an abort.
- *
- * The caller-provided function will be passed the `Client` argument and a
- * newly created read-write `Transaction`. It should use these objects to
- * issue any `Read()`s, `ExecuteQuery()`s, `ExecuteDml()`s, etc., and return the
- * `Mutation`s to commit, or an error (which causes the transaction to be rolled
- * back).
- *
- * The lock priority of the transaction increases after each prior aborted
- * transaction, meaning that the next attempt has a slightly better chance
- * of success than before.
- *
- * @param client how to contact Cloud Spanner
- * @param opts options for the transaction created by this function
- * @param f the function to call in the transaction.
- * @param retry_policy controls for how long (or how many times) will the
- *     function retry the operation when there is a retryable failure.
- * @param backoff_policy controls how long does the function wait between
- *     retries.
- */
-StatusOr<CommitResult> RunTransactionWithPolicies(
-    Client client, Transaction::ReadWriteOptions const& opts,
-    std::function<StatusOr<Mutations>(Client, Transaction)> const& f,
-    std::unique_ptr<TransactionRerunPolicy> rerun_policy,
-    std::unique_ptr<BackoffPolicy> backoff_policy);
-
-/// The default rerun policy for RunTransaction()
-std::unique_ptr<TransactionRerunPolicy> DefaultRunTransactionRerunPolicy();
-
-/// The default backoff policy for RunTransaction()
-std::unique_ptr<BackoffPolicy> DefaultRunTransactionBackoffPolicy();
-
-}  // namespace internal
-
-/**
- * Execute a function in the context of a read-write transaction, with
- * automatic retries if the transaction commit results in an abort.
- *
- * The caller-provided function will be passed the `Client` argument and a
- * newly created read-write `Transaction`. It should use these objects to
- * issue any `Read()`s, `ExecuteQuery()`s, `ExecuteDml()`s, etc., and return
- * the `Mutation`s to commit, or an error (which causes the transaction to be
- * rolled back).
- *
- * The lock priority of the transaction increases after each prior aborted
- * transaction, meaning that the next attempt has a slightly better chance
- * of success than before.
- */
-inline StatusOr<CommitResult> RunTransaction(
-    Client client, Transaction::ReadWriteOptions const& opts,
-    std::function<StatusOr<Mutations>(Client, Transaction)> f) {
-  return internal::RunTransactionWithPolicies(
-      std::move(client), opts, std::move(f),
-      internal::DefaultRunTransactionRerunPolicy(),
-      internal::DefaultRunTransactionBackoffPolicy());
-}
 
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -413,9 +413,9 @@ class Client {
   /**
    * Commits a read-write transaction.
    *
-   * Calls the `mutator` in the context of a new read-write transaction.  The
-   * `mutator` can execute read/write operations using the transaction, and
-   * returns any additional `Mutations` to commit.
+   * Calls the `@p mutator` in the context of a new read-write transaction.
+   * The `mutator` can execute read/write operations using the transaction,
+   * and returns any additional `Mutations` to commit.
    *
    * If the `mutator` returns `StatusCode::kAborted` or the transaction commit
    * results in an abort, then that transaction is rolled back and the process

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -398,7 +398,7 @@ TEST(ClientTest, MakeConnectionOptionalArguments) {
   EXPECT_NE(conn, nullptr);
 }
 
-TEST(ClientTest, RunTransactionCommit) {
+TEST(ClientTest, CommitMutatorSuccess) {
   auto timestamp = internal::TimestampFromString("2019-08-14T21:16:21.123Z");
   ASSERT_STATUS_OK(timestamp);
 
@@ -432,8 +432,9 @@ TEST(ClientTest, RunTransactionCommit) {
       .WillOnce(DoAll(SaveArg<0>(&actual_commit_params),
                       Return(CommitResult{*timestamp})));
 
+  Client client(conn);
   auto mutation = MakeDeleteMutation("table", KeySet::All());
-  auto f = [&mutation](Client client, Transaction txn) -> StatusOr<Mutations> {
+  auto mutator = [&client, &mutation](Transaction txn) -> StatusOr<Mutations> {
     auto read = client.Read(std::move(txn), "T", KeySet::All(), {"C"});
     for (auto& row : read.Rows<std::tuple<std::string>>()) {
       if (!row) return row.status();
@@ -441,8 +442,7 @@ TEST(ClientTest, RunTransactionCommit) {
     return Mutations{mutation};
   };
 
-  Client client(conn);
-  auto result = RunTransaction(client, Transaction::ReadWriteOptions{}, f);
+  auto result = client.Commit(mutator);
   EXPECT_STATUS_OK(result);
   EXPECT_EQ(*timestamp, result->commit_timestamp);
 
@@ -452,7 +452,7 @@ TEST(ClientTest, RunTransactionCommit) {
   EXPECT_THAT(actual_commit_params.mutations, ElementsAre(mutation));
 }
 
-TEST(ClientTest, RunTransactionRollback) {
+TEST(ClientTest, CommitMutatorRollback) {
   auto conn = std::make_shared<MockConnection>();
   Transaction txn = MakeReadWriteTransaction();  // dummy
   Connection::ReadParams actual_read_params{txn, {}, {}, {}, {}};
@@ -479,8 +479,9 @@ TEST(ClientTest, RunTransactionRollback) {
                       Return(ByMove(std::move(result_set)))));
   EXPECT_CALL(*conn, Rollback(_)).WillOnce(Return(Status()));
 
+  Client client(conn);
   auto mutation = MakeDeleteMutation("table", KeySet::All());
-  auto f = [&mutation](Client client, Transaction txn) -> StatusOr<Mutations> {
+  auto mutator = [&client, &mutation](Transaction txn) -> StatusOr<Mutations> {
     auto read = client.Read(std::move(txn), "T", KeySet::All(), {"C"});
     for (auto& row : read.Rows<std::tuple<std::string>>()) {
       if (!row) return row.status();
@@ -488,8 +489,7 @@ TEST(ClientTest, RunTransactionRollback) {
     return Mutations{mutation};
   };
 
-  Client client(conn);
-  auto result = RunTransaction(client, Transaction::ReadWriteOptions{}, f);
+  auto result = client.Commit(mutator);
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(StatusCode::kInvalidArgument, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("blah"));
@@ -499,7 +499,7 @@ TEST(ClientTest, RunTransactionRollback) {
   EXPECT_THAT(actual_read_params.columns, ElementsAre("C"));
 }
 
-TEST(ClientTest, RunTransactionRollbackError) {
+TEST(ClientTest, CommitMutatorRollbackError) {
   auto conn = std::make_shared<MockConnection>();
   Transaction txn = MakeReadWriteTransaction();  // dummy
   Connection::ReadParams actual_read_params{txn, {}, {}, {}, {}};
@@ -527,8 +527,9 @@ TEST(ClientTest, RunTransactionRollbackError) {
   EXPECT_CALL(*conn, Rollback(_))
       .WillOnce(Return(Status(StatusCode::kInternal, "oops")));
 
+  Client client(conn);
   auto mutation = MakeDeleteMutation("table", KeySet::All());
-  auto f = [&mutation](Client client, Transaction txn) -> StatusOr<Mutations> {
+  auto mutator = [&client, &mutation](Transaction txn) -> StatusOr<Mutations> {
     auto read = client.Read(std::move(txn), "T", KeySet::All(), {"C"});
     for (auto& row : read.Rows<std::tuple<std::string>>()) {
       if (!row) return row.status();
@@ -536,8 +537,7 @@ TEST(ClientTest, RunTransactionRollbackError) {
     return Mutations{mutation};
   };
 
-  Client client(conn);
-  auto result = RunTransaction(client, Transaction::ReadWriteOptions{}, f);
+  auto result = client.Commit(mutator);
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(StatusCode::kInvalidArgument, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("blah"));
@@ -548,7 +548,7 @@ TEST(ClientTest, RunTransactionRollbackError) {
 }
 
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-TEST(ClientTest, RunTransactionException) {
+TEST(ClientTest, CommitMutatorException) {
   auto conn = std::make_shared<MockConnection>();
 
   auto source = make_unique<MockResultSetSource>();
@@ -571,8 +571,9 @@ TEST(ClientTest, RunTransactionException) {
   EXPECT_CALL(*conn, Read(_)).WillOnce(Return(ByMove(std::move(result_set))));
   EXPECT_CALL(*conn, Rollback(_)).WillOnce(Return(Status()));
 
+  Client client(conn);
   auto mutation = MakeDeleteMutation("table", KeySet::All());
-  auto f = [&mutation](Client client, Transaction txn) -> StatusOr<Mutations> {
+  auto mutator = [&client, &mutation](Transaction txn) -> StatusOr<Mutations> {
     auto read = client.Read(std::move(txn), "T", KeySet::All(), {"C"});
     for (auto& row : read.Rows<std::tuple<std::string>>()) {
       if (!row) throw "Read() error";
@@ -581,8 +582,7 @@ TEST(ClientTest, RunTransactionException) {
   };
 
   try {
-    Client client(conn);
-    auto result = RunTransaction(client, Transaction::ReadWriteOptions{}, f);
+    auto result = client.Commit(mutator);
     FAIL();
   } catch (char const* e) {
     EXPECT_STREQ(e, "Read() error");
@@ -592,7 +592,7 @@ TEST(ClientTest, RunTransactionException) {
 }
 #endif
 
-TEST(ClientTest, RunTransaction_RetryTransientFailures) {
+TEST(ClientTest, CommitMutatorRerunTransientFailures) {
   auto timestamp = internal::TimestampFromString("2019-08-14T21:16:21.123Z");
   ASSERT_STATUS_OK(timestamp);
 
@@ -605,58 +605,66 @@ TEST(ClientTest, RunTransaction_RetryTransientFailures) {
         return CommitResult{*timestamp};
       }));
 
-  auto f = [](Client const&, Transaction const&) -> StatusOr<Mutations> {
+  auto mutator = [](Transaction const&) -> StatusOr<Mutations> {
     return Mutations{MakeDeleteMutation("table", KeySet::All())};
   };
 
   Client client(conn);
-  auto result = RunTransaction(client, Transaction::ReadWriteOptions{}, f);
+  auto result = client.Commit(mutator);
   EXPECT_STATUS_OK(result);
   EXPECT_EQ(*timestamp, result->commit_timestamp);
 }
 
-TEST(ClientTest, RunTransaction_TooManyFailures) {
+TEST(ClientTest, CommitMutatorTooManyFailures) {
+  int commit_attempts = 0;
+  int const maximum_failures = 2;
+
   auto conn = std::make_shared<MockConnection>();
   EXPECT_CALL(*conn, Commit(_))
-      .WillRepeatedly(Invoke([](Connection::CommitParams const&) {
-        return Status(StatusCode::kAborted, "Aborted transaction");
-      }));
+      .WillRepeatedly(
+          Invoke([&commit_attempts](Connection::CommitParams const&) {
+            ++commit_attempts;
+            return Status(StatusCode::kAborted, "Aborted transaction");
+          }));
 
-  auto f = [](Client const&, Transaction const&) -> StatusOr<Mutations> {
+  auto mutator = [](Transaction const&) -> StatusOr<Mutations> {
     return Mutations{MakeDeleteMutation("table", KeySet::All())};
   };
 
   Client client(conn);
-  // Use a retry policy with a limited number of errors, or this will wait for a
+  // Use a rerun policy with a limited number of errors, or this will wait for a
   // long time, also change the backoff policy to sleep for very short periods,
   // so the unit tests run faster.
-  auto result = internal::RunTransactionWithPolicies(
-      client, Transaction::ReadWriteOptions{}, f,
-      LimitedErrorCountTransactionRerunPolicy(2).clone(),
+  auto result = client.Commit(
+      mutator,
+      LimitedErrorCountTransactionRerunPolicy(maximum_failures).clone(),
       ExponentialBackoffPolicy(std::chrono::microseconds(10),
                                std::chrono::microseconds(10), 2.0)
           .clone());
   EXPECT_EQ(StatusCode::kAborted, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("Aborted transaction"));
-  EXPECT_THAT(result.status().message(), HasSubstr("Too many failures "));
+  EXPECT_EQ(maximum_failures + 1, commit_attempts);  // one too many
 }
 
-TEST(ClientTest, RunTransaction_PermanentFailure) {
+TEST(ClientTest, CommitMutatorPermanentFailure) {
+  int commit_attempts = 0;
+
   auto conn = std::make_shared<MockConnection>();
   EXPECT_CALL(*conn, Commit(_))
-      .WillOnce(Invoke([](Connection::CommitParams const&) {
+      .WillOnce(Invoke([&commit_attempts](Connection::CommitParams const&) {
+        ++commit_attempts;
         return Status(StatusCode::kPermissionDenied, "uh-oh");
       }));
 
-  auto f = [](Client const&, Transaction const&) -> StatusOr<Mutations> {
+  auto mutator = [](Transaction const&) -> StatusOr<Mutations> {
     return Mutations{MakeDeleteMutation("table", KeySet::All())};
   };
 
   Client client(conn);
-  auto result = RunTransaction(client, Transaction::ReadWriteOptions{}, f);
+  auto result = client.Commit(mutator);
   EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("uh-oh"));
-  EXPECT_THAT(result.status().message(), HasSubstr("Permanent failure "));
+  EXPECT_EQ(1, commit_attempts);  // no reruns
 }
 
 }  // namespace

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -85,10 +85,8 @@ TEST(ClientSqlStressTest, UpsertAndSelect) {
       auto action = static_cast<Action>(random_action(generator));
 
       if (action == kInsert) {
-        auto commit = spanner::RunTransaction(
-            client, {},
-            [key](Client const&,
-                  Transaction const&) -> StatusOr<spanner::Mutations> {
+        auto commit = client.Commit(
+            [key](Transaction const&) -> StatusOr<spanner::Mutations> {
               auto s = std::to_string(key);
               return Mutations{spanner::MakeInsertOrUpdateMutation(
                   "Singers", {"SingerId", "FirstName", "LastName"}, key,
@@ -155,10 +153,8 @@ TEST(ClientStressTest, UpsertAndRead) {
       auto action = static_cast<Action>(random_action(generator));
 
       if (action == kInsert) {
-        auto commit = spanner::RunTransaction(
-            client, {},
-            [key](Client const&,
-                  Transaction const&) -> StatusOr<spanner::Mutations> {
+        auto commit = client.Commit(
+            [key](Transaction const&) -> StatusOr<spanner::Mutations> {
               auto s = std::to_string(key);
               return Mutations{spanner::MakeInsertOrUpdateMutation(
                   "Singers", {"SingerId", "FirstName", "LastName"}, key,

--- a/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
@@ -124,9 +124,8 @@ Result RunExperiment(Database const& db, int iterations) {
   int const report = iterations / 5;
   for (int i = 0; i != iterations; ++i) {
     if (i % report == 0) std::cout << '.' << std::flush;
-    auto delete_status = RunTransaction(
-        client, Transaction::ReadWriteOptions{},
-        [&](Client client, Transaction const& txn) -> StatusOr<Mutations> {
+    auto delete_status =
+        client.Commit([&client](Transaction const& txn) -> StatusOr<Mutations> {
           auto status = client.ExecuteDml(
               txn, SqlStatement("DELETE FROM Singers WHERE true"));
           if (!status) return std::move(status).status();

--- a/google/cloud/spanner/mutations.h
+++ b/google/cloud/spanner/mutations.h
@@ -88,7 +88,7 @@ class Mutation {
 
 /**
  * An ordered sequence of mutations to pass to `Client::Commit()` or return
- * from the `Client::RunTransaction()` functor.
+ * from the `Client::Commit()` mutator.
  */
 using Mutations = std::vector<Mutation>;
 

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -821,7 +821,7 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
                             {"MarketingBudget"});
     for (auto row : read.Rows<std::tuple<std::int64_t>>()) {
       // Return the error (as opposed to throwing an exception) because
-      // RunTransaction() only retries on StatusCode::kAborted.
+      // Commit() only retries on StatusCode::kAborted.
       if (!row) return std::move(row).status();
       // We expect at most one result from the `Read()` request. Return
       // the first one.
@@ -832,10 +832,8 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
                              "," + std::to_string(album_id) + ")");
   };
 
-  auto commit = spanner::RunTransaction(
-      std::move(client), {},
-      [&get_current_budget](spanner::Client const& client,
-                            spanner::Transaction const& txn)
+  auto commit = client.Commit(
+      [&client, &get_current_budget](spanner::Transaction const& txn)
           -> google::cloud::StatusOr<spanner::Mutations> {
         auto b1 = get_current_budget(client, txn, 1, 1);
         if (!b1) return std::move(b1).status();
@@ -860,10 +858,8 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
 void DmlStandardInsert(google::cloud::spanner::Client client) {
   using google::cloud::StatusOr;
   namespace spanner = google::cloud::spanner;
-  auto commit_result = spanner::RunTransaction(
-      std::move(client), spanner::Transaction::ReadWriteOptions{},
-      [](spanner::Client client,
-         spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
+  auto commit_result = client.Commit(
+      [&client](spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
         auto insert = client.ExecuteDml(
             std::move(txn),
             spanner::SqlStatement(
@@ -884,10 +880,8 @@ void DmlStandardInsert(google::cloud::spanner::Client client) {
 void DmlStandardUpdate(google::cloud::spanner::Client client) {
   using google::cloud::StatusOr;
   namespace spanner = google::cloud::spanner;
-  auto commit_result = spanner::RunTransaction(
-      std::move(client), spanner::Transaction::ReadWriteOptions{},
-      [](spanner::Client client,
-         spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
+  auto commit_result = client.Commit(
+      [&client](spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
         auto update = client.ExecuteDml(
             std::move(txn),
             spanner::SqlStatement(
@@ -908,17 +902,14 @@ void DmlStandardUpdate(google::cloud::spanner::Client client) {
 void DmlStandardDelete(google::cloud::spanner::Client client) {
   using google::cloud::StatusOr;
   namespace spanner = google::cloud::spanner;
-  auto commit_result = spanner::RunTransaction(
-      std::move(client), spanner::Transaction::ReadWriteOptions{},
-      [](spanner::Client client,
-         spanner::Transaction txn) -> StatusOr<spanner::Mutations> {
-        auto dele = client.ExecuteDml(
-            std::move(txn),
-            spanner::SqlStatement(
-                "DELETE FROM Singers WHERE FirstName = 'Alice'"));
-        if (!dele) return dele.status();
-        return spanner::Mutations{};
-      });
+  auto commit_result = client.Commit([&client](spanner::Transaction txn)
+                                         -> StatusOr<spanner::Mutations> {
+    auto dele = client.ExecuteDml(
+        std::move(txn),
+        spanner::SqlStatement("DELETE FROM Singers WHERE FirstName = 'Alice'"));
+    if (!dele) return dele.status();
+    return spanner::Mutations{};
+  });
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());
   }


### PR DESCRIPTION
Replace `g:c:s:RunTransaction()` with a new `g:c:s:Client::Commit()`
overload.  This is similar to the existing `Commit()`, but you
specify how to create the mutations, instead of passing them
directly, which is what is needed to create the rerun loop.

The "mutator" callback no longer receives the target `Client` as
an argument because many mutators don't need it.  If you want
a client in your callback, you will need to bind it yourself.

The `Transaction::ReadWriteOptions` have been removed as there
are no options, and being able to preallocate RW transactions
pretty much requires that remains the case.

Session affinity over reruns is still to be addressed.

BREAKING CHANGE

Fixes #557.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/975)
<!-- Reviewable:end -->
