### PR TITLE
chore!: renamed QueryResult -> RowStream

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -28,8 +28,8 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 RowStream Client::Read(std::string table, KeySet keys,
-                         std::vector<std::string> columns,
-                         ReadOptions read_options) {
+                       std::vector<std::string> columns,
+                       ReadOptions read_options) {
   return conn_->Read(
       {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        std::move(table), std::move(keys), std::move(columns),
@@ -37,18 +37,18 @@ RowStream Client::Read(std::string table, KeySet keys,
 }
 
 RowStream Client::Read(Transaction::SingleUseOptions transaction_options,
-                         std::string table, KeySet keys,
-                         std::vector<std::string> columns,
-                         ReadOptions read_options) {
+                       std::string table, KeySet keys,
+                       std::vector<std::string> columns,
+                       ReadOptions read_options) {
   return conn_->Read(
       {internal::MakeSingleUseTransaction(std::move(transaction_options)),
        std::move(table), std::move(keys), std::move(columns),
        std::move(read_options)});
 }
 
-RowStream Client::Read(Transaction transaction, std::string table,
-                         KeySet keys, std::vector<std::string> columns,
-                         ReadOptions read_options) {
+RowStream Client::Read(Transaction transaction, std::string table, KeySet keys,
+                       std::vector<std::string> columns,
+                       ReadOptions read_options) {
   return conn_->Read({std::move(transaction), std::move(table), std::move(keys),
                       std::move(columns), std::move(read_options)});
 }
@@ -81,7 +81,7 @@ RowStream Client::ExecuteQuery(
 }
 
 RowStream Client::ExecuteQuery(Transaction transaction,
-                                 SqlStatement statement) {
+                               SqlStatement statement) {
   return conn_->ExecuteQuery({std::move(transaction), std::move(statement)});
 }
 

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -27,7 +27,7 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
-QueryResult Client::Read(std::string table, KeySet keys,
+RowStream Client::Read(std::string table, KeySet keys,
                          std::vector<std::string> columns,
                          ReadOptions read_options) {
   return conn_->Read(
@@ -36,7 +36,7 @@ QueryResult Client::Read(std::string table, KeySet keys,
        std::move(read_options)});
 }
 
-QueryResult Client::Read(Transaction::SingleUseOptions transaction_options,
+RowStream Client::Read(Transaction::SingleUseOptions transaction_options,
                          std::string table, KeySet keys,
                          std::vector<std::string> columns,
                          ReadOptions read_options) {
@@ -46,14 +46,14 @@ QueryResult Client::Read(Transaction::SingleUseOptions transaction_options,
        std::move(read_options)});
 }
 
-QueryResult Client::Read(Transaction transaction, std::string table,
+RowStream Client::Read(Transaction transaction, std::string table,
                          KeySet keys, std::vector<std::string> columns,
                          ReadOptions read_options) {
   return conn_->Read({std::move(transaction), std::move(table), std::move(keys),
                       std::move(columns), std::move(read_options)});
 }
 
-QueryResult Client::Read(ReadPartition const& read_partition) {
+RowStream Client::Read(ReadPartition const& read_partition) {
   return conn_->Read(internal::MakeReadParams(read_partition));
 }
 
@@ -67,25 +67,25 @@ StatusOr<std::vector<ReadPartition>> Client::PartitionRead(
        std::move(partition_options)});
 }
 
-QueryResult Client::ExecuteQuery(SqlStatement statement) {
+RowStream Client::ExecuteQuery(SqlStatement statement) {
   return conn_->ExecuteQuery(
       {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        std::move(statement)});
 }
 
-QueryResult Client::ExecuteQuery(
+RowStream Client::ExecuteQuery(
     Transaction::SingleUseOptions transaction_options, SqlStatement statement) {
   return conn_->ExecuteQuery(
       {internal::MakeSingleUseTransaction(std::move(transaction_options)),
        std::move(statement)});
 }
 
-QueryResult Client::ExecuteQuery(Transaction transaction,
+RowStream Client::ExecuteQuery(Transaction transaction,
                                  SqlStatement statement) {
   return conn_->ExecuteQuery({std::move(transaction), std::move(statement)});
 }
 
-QueryResult Client::ExecuteQuery(QueryPartition const& partition) {
+RowStream Client::ExecuteQuery(QueryPartition const& partition) {
   return conn_->ExecuteQuery(internal::MakeExecuteSqlParams(partition));
 }
 

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -80,9 +80,9 @@ inline namespace SPANNER_CLIENT_NS {
  * auto conn = cs::MakeConnection(db);
  * auto client = cs::Client(conn);
  *
- * cs::ReadResult result = client.Read(...);
+ * auto rows = client.Read(...);
  * using RowType = std::tuple<std::int64_t, std::string>;
- * for (auto const& row : cs::StreamOf<RowType>(result)) {
+ * for (auto const& row : cs::StreamOf<RowType>(rows)) {
  *   // ...
  * }
  * @endcode
@@ -142,27 +142,27 @@ class Client {
    * @note No individual row in the `ReadResult` can exceed 100 MiB, and no
    *     column value can exceed 10 MiB.
    */
-  QueryResult Read(std::string table, KeySet keys,
-                   std::vector<std::string> columns,
-                   ReadOptions read_options = {});
+  RowStream Read(std::string table, KeySet keys,
+                 std::vector<std::string> columns,
+                 ReadOptions read_options = {});
   /**
    * @copydoc Read
    *
    * @param transaction_options Execute this read in a single-use transaction
    * with these options.
    */
-  QueryResult Read(Transaction::SingleUseOptions transaction_options,
-                   std::string table, KeySet keys,
-                   std::vector<std::string> columns,
-                   ReadOptions read_options = {});
+  RowStream Read(Transaction::SingleUseOptions transaction_options,
+                 std::string table, KeySet keys,
+                 std::vector<std::string> columns,
+                 ReadOptions read_options = {});
   /**
    * @copydoc Read
    *
    * @param transaction Execute this read as part of an existing transaction.
    */
-  QueryResult Read(Transaction transaction, std::string table, KeySet keys,
-                   std::vector<std::string> columns,
-                   ReadOptions read_options = {});
+  RowStream Read(Transaction transaction, std::string table, KeySet keys,
+                 std::vector<std::string> columns,
+                 ReadOptions read_options = {});
   //@}
 
   /**
@@ -178,7 +178,7 @@ class Client {
    * @par Example
    * @snippet samples.cc read-read-partition
    */
-  QueryResult Read(ReadPartition const& partition);
+  RowStream Read(ReadPartition const& partition);
 
   /**
    * Creates a set of partitions that can be used to execute a read
@@ -231,10 +231,10 @@ class Client {
    *
    * @param statement The SQL statement to execute.
    *
-   * @note No individual row in the `ExecuteQueryResult` can exceed 100 MiB, and
-   * no column value can exceed 10 MiB.
+   * @note No individual row in the `RowStream` can exceed 100 MiB, and no
+   *     column value can exceed 10 MiB.
    */
-  QueryResult ExecuteQuery(SqlStatement statement);
+  RowStream ExecuteQuery(SqlStatement statement);
 
   /**
    * @copydoc ExecuteQuery(SqlStatement)
@@ -242,15 +242,15 @@ class Client {
    * @param transaction_options Execute this query in a single-use transaction
    *     with these options.
    */
-  QueryResult ExecuteQuery(Transaction::SingleUseOptions transaction_options,
-                           SqlStatement statement);
+  RowStream ExecuteQuery(Transaction::SingleUseOptions transaction_options,
+                         SqlStatement statement);
 
   /**
    * @copydoc ExecuteQuery(SqlStatement)
    *
    * @param transaction Execute this query as part of an existing transaction.
    */
-  QueryResult ExecuteQuery(Transaction transaction, SqlStatement statement);
+  RowStream ExecuteQuery(Transaction transaction, SqlStatement statement);
   /**
    * Executes a SQL query on a subset of rows in a database. Requires a prior
    * call to `PartitionQuery` to obtain the partition information; see the
@@ -258,13 +258,13 @@ class Client {
    *
    * @param partition A `QueryPartition`, obtained by calling `PartitionRead`.
    *
-   * @note No individual row in the `ExecuteQueryResult` can exceed 100 MiB, and
-   * no column value can exceed 10 MiB.
+   * @note No individual row in the `RowStream` can exceed 100 MiB, and no
+   *     column value can exceed 10 MiB.
    *
    * @par Example
    * @snippet samples.cc execute-sql-query-partition
    */
-  QueryResult ExecuteQuery(QueryPartition const& partition);
+  RowStream ExecuteQuery(QueryPartition const& partition);
   //@}
 
   //@{

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -134,14 +134,14 @@ class Connection {
   //@}
 
   /// Define the interface for a google.spanner.v1.Spanner.Read RPC
-  virtual QueryResult Read(ReadParams) = 0;
+  virtual RowStream Read(ReadParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.PartitionRead RPC
   virtual StatusOr<std::vector<ReadPartition>> PartitionRead(
       PartitionReadParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual QueryResult ExecuteQuery(ExecuteSqlParams) = 0;
+  virtual RowStream ExecuteQuery(ExecuteSqlParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
   virtual StatusOr<DmlResult> ExecuteDml(ExecuteSqlParams) = 0;

--- a/google/cloud/spanner/doc/spanner-mocking.dox
+++ b/google/cloud/spanner/doc/spanner-mocking.dox
@@ -35,9 +35,9 @@ And then verify the results meet your expectations:
 
 @snippet mock_execute_query.cc expected-results
 
-All of this depends on creating a `google::cloud::spanner::QueryResult`
-that simulates the stream of results you want. To do so, you need to mock a
-source that streams `google::cloud::spanner::Values`:
+All of this depends on creating a `google::cloud::spanner::RowStream` that
+simulates the stream of results you want. To do so, you need to mock a source
+that streams `google::cloud::spanner::Row`s:
 
 @snippet mock_execute_query.cc create-streaming-source
 

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -70,7 +70,7 @@ TEST_F(ClientIntegrationTest, InsertAndCommit) {
   ASSERT_NO_FATAL_FAILURE(InsertTwoSingers());
 
   auto rows = client_->Read("Singers", KeySet::All(),
-                              {"SingerId", "FirstName", "LastName"});
+                            {"SingerId", "FirstName", "LastName"});
   using RowType = std::tuple<std::int64_t, std::string, std::string>;
   std::vector<RowType> returned_rows;
   int row_number = 0;
@@ -96,7 +96,7 @@ TEST_F(ClientIntegrationTest, DeleteAndCommit) {
   EXPECT_STATUS_OK(commit_result);
 
   auto rows = client_->Read("Singers", KeySet::All(),
-                              {"SingerId", "FirstName", "LastName"});
+                            {"SingerId", "FirstName", "LastName"});
 
   using RowType = std::tuple<std::int64_t, std::string, std::string>;
   std::vector<RowType> returned_rows;
@@ -139,7 +139,7 @@ TEST_F(ClientIntegrationTest, MultipleInserts) {
   EXPECT_STATUS_OK(commit_result);
 
   auto rows = client_->Read("Singers", KeySet::All(),
-                              {"SingerId", "FirstName", "LastName"});
+                            {"SingerId", "FirstName", "LastName"});
 
   using RowType = std::tuple<std::int64_t, std::string, std::string>;
   std::vector<RowType> returned_rows;
@@ -192,7 +192,7 @@ TEST_F(ClientIntegrationTest, TransactionRollback) {
     ASSERT_STATUS_OK(insert2);
 
     auto rows = client_->Read(txn, "Singers", KeySet::All(),
-                                {"SingerId", "FirstName", "LastName"});
+                              {"SingerId", "FirstName", "LastName"});
 
     std::vector<RowType> returned_rows;
     int row_number = 0;
@@ -214,7 +214,7 @@ TEST_F(ClientIntegrationTest, TransactionRollback) {
 
   std::vector<RowType> returned_rows;
   auto rows = client_->Read("Singers", KeySet::All(),
-                              {"SingerId", "FirstName", "LastName"});
+                            {"SingerId", "FirstName", "LastName"});
   int row_number = 0;
   for (auto& row : StreamOf<RowType>(rows)) {
     EXPECT_STATUS_OK(row);

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -69,12 +69,12 @@ std::unique_ptr<Client> ClientIntegrationTest::client_;
 TEST_F(ClientIntegrationTest, InsertAndCommit) {
   ASSERT_NO_FATAL_FAILURE(InsertTwoSingers());
 
-  auto reader = client_->Read("Singers", KeySet::All(),
+  auto rows = client_->Read("Singers", KeySet::All(),
                               {"SingerId", "FirstName", "LastName"});
   using RowType = std::tuple<std::int64_t, std::string, std::string>;
   std::vector<RowType> returned_rows;
   int row_number = 0;
-  for (auto& row : StreamOf<RowType>(reader)) {
+  for (auto& row : StreamOf<RowType>(rows)) {
     EXPECT_STATUS_OK(row);
     if (!row) break;
     SCOPED_TRACE("Parsing row[" + std::to_string(row_number++) + "]");
@@ -95,13 +95,13 @@ TEST_F(ClientIntegrationTest, DeleteAndCommit) {
   });
   EXPECT_STATUS_OK(commit_result);
 
-  auto reader = client_->Read("Singers", KeySet::All(),
+  auto rows = client_->Read("Singers", KeySet::All(),
                               {"SingerId", "FirstName", "LastName"});
 
   using RowType = std::tuple<std::int64_t, std::string, std::string>;
   std::vector<RowType> returned_rows;
   int row_number = 0;
-  for (auto& row : StreamOf<RowType>(reader)) {
+  for (auto& row : StreamOf<RowType>(rows)) {
     EXPECT_STATUS_OK(row);
     if (!row) break;
     SCOPED_TRACE("Parsing row[" + std::to_string(row_number++) + "]");
@@ -138,13 +138,13 @@ TEST_F(ClientIntegrationTest, MultipleInserts) {
       });
   EXPECT_STATUS_OK(commit_result);
 
-  auto reader = client_->Read("Singers", KeySet::All(),
+  auto rows = client_->Read("Singers", KeySet::All(),
                               {"SingerId", "FirstName", "LastName"});
 
   using RowType = std::tuple<std::int64_t, std::string, std::string>;
   std::vector<RowType> returned_rows;
   int row_number = 0;
-  for (auto& row : StreamOf<RowType>(reader)) {
+  for (auto& row : StreamOf<RowType>(rows)) {
     EXPECT_STATUS_OK(row);
     if (!row) break;
     SCOPED_TRACE("Parsing row[" + std::to_string(row_number++) + "]");
@@ -191,12 +191,12 @@ TEST_F(ClientIntegrationTest, TransactionRollback) {
     if (is_retryable_failure(insert2)) continue;
     ASSERT_STATUS_OK(insert2);
 
-    auto reader = client_->Read(txn, "Singers", KeySet::All(),
+    auto rows = client_->Read(txn, "Singers", KeySet::All(),
                                 {"SingerId", "FirstName", "LastName"});
 
     std::vector<RowType> returned_rows;
     int row_number = 0;
-    for (auto& row : StreamOf<RowType>(reader)) {
+    for (auto& row : StreamOf<RowType>(rows)) {
       if (!row) break;
       SCOPED_TRACE("Parsing row[" + std::to_string(row_number++) + "]");
       returned_rows.push_back(*std::move(row));
@@ -213,10 +213,10 @@ TEST_F(ClientIntegrationTest, TransactionRollback) {
   }
 
   std::vector<RowType> returned_rows;
-  auto reader = client_->Read("Singers", KeySet::All(),
+  auto rows = client_->Read("Singers", KeySet::All(),
                               {"SingerId", "FirstName", "LastName"});
   int row_number = 0;
-  for (auto& row : StreamOf<RowType>(reader)) {
+  for (auto& row : StreamOf<RowType>(rows)) {
     EXPECT_STATUS_OK(row);
     if (!row) break;
     SCOPED_TRACE("Parsing row[" + std::to_string(row_number++) + "]");
@@ -256,8 +256,8 @@ TEST_F(ClientIntegrationTest, Commit) {
   using RowType = std::tuple<std::int64_t>;
   std::vector<std::int64_t> ids;
   auto ks = KeySet().AddRange(MakeKeyBoundClosed(100), MakeKeyBoundOpen(200));
-  auto results = client_->Read("Singers", std::move(ks), {"SingerId"});
-  for (auto& row : StreamOf<RowType>(results)) {
+  auto rows = client_->Read("Singers", std::move(ks), {"SingerId"});
+  for (auto& row : StreamOf<RowType>(rows)) {
     EXPECT_STATUS_OK(row);
     if (row) ids.push_back(std::get<0>(*row));
   }
@@ -310,12 +310,12 @@ TEST_F(ClientIntegrationTest, ExecuteQueryDml) {
       });
   ASSERT_STATUS_OK(commit_result);
 
-  auto reader = client_->ExecuteQuery(
+  auto rows = client_->ExecuteQuery(
       SqlStatement("SELECT SingerId, FirstName, LastName FROM Singers", {}));
 
   std::vector<RowType> actual_rows;
   int row_number = 0;
-  for (auto& row : StreamOf<RowType>(reader)) {
+  for (auto& row : StreamOf<RowType>(rows)) {
     EXPECT_STATUS_OK(row);
     if (!row) break;
     SCOPED_TRACE("Parsing row[" + std::to_string(row_number++) + "]");
@@ -450,14 +450,14 @@ void CheckExecuteQueryWithSingleUseOptions(
       });
   ASSERT_STATUS_OK(commit);
 
-  auto reader = client.ExecuteQuery(
+  auto rows = client.ExecuteQuery(
       options_generator(*commit),
       SqlStatement("SELECT SingerId, FirstName, LastName FROM Singers"));
 
   std::vector<RowValues> actual_rows;
   int row_number = 0;
   for (auto& row :
-       StreamOf<std::tuple<std::int64_t, std::string, std::string>>(reader)) {
+       StreamOf<std::tuple<std::int64_t, std::string, std::string>>(rows)) {
     SCOPED_TRACE("Reading row[" + std::to_string(row_number++) + "]");
     EXPECT_STATUS_OK(row);
     if (!row) break;
@@ -559,10 +559,9 @@ TEST_F(ClientIntegrationTest, PartitionRead) {
     int row_number = 0;
     auto deserialized_partition = DeserializeReadPartition(partition);
     ASSERT_STATUS_OK(deserialized_partition);
-    auto result_set = client_->Read(*deserialized_partition);
+    auto rows = client_->Read(*deserialized_partition);
     for (auto& row :
-         StreamOf<std::tuple<std::int64_t, std::string, std::string>>(
-             result_set)) {
+         StreamOf<std::tuple<std::int64_t, std::string, std::string>>(rows)) {
       SCOPED_TRACE("Reading partition[" + std::to_string(partition_number++) +
                    "] row[" + std::to_string(row_number++) + "]");
       EXPECT_STATUS_OK(row);
@@ -601,10 +600,9 @@ TEST_F(ClientIntegrationTest, PartitionQuery) {
     int row_number = 0;
     auto deserialized_partition = DeserializeQueryPartition(partition);
     ASSERT_STATUS_OK(deserialized_partition);
-    auto result_set = client_->ExecuteQuery(*deserialized_partition);
+    auto rows = client_->ExecuteQuery(*deserialized_partition);
     for (auto& row :
-         StreamOf<std::tuple<std::int64_t, std::string, std::string>>(
-             result_set)) {
+         StreamOf<std::tuple<std::int64_t, std::string, std::string>>(rows)) {
       SCOPED_TRACE("Reading partition[" + std::to_string(partition_number++) +
                    "] row[" + std::to_string(row_number++) + "]");
       EXPECT_STATUS_OK(row);
@@ -652,7 +650,7 @@ TEST_F(ClientIntegrationTest, ExecuteBatchDml) {
   ASSERT_EQ(batch_result->stats[2].row_count, 1);
   ASSERT_EQ(batch_result->stats[3].row_count, 2);
 
-  auto query = client_->ExecuteQuery(SqlStatement(
+  auto rows = client_->ExecuteQuery(SqlStatement(
       "SELECT SingerId, FirstName, LastName FROM Singers ORDER BY SingerId"));
 
   struct Expectation {
@@ -667,7 +665,7 @@ TEST_F(ClientIntegrationTest, ExecuteBatchDml) {
   };
   std::size_t counter = 0;
   for (auto const& row :
-       StreamOf<std::tuple<std::int64_t, std::string, std::string>>(query)) {
+       StreamOf<std::tuple<std::int64_t, std::string, std::string>>(rows)) {
     ASSERT_STATUS_OK(row);
     ASSERT_EQ(std::get<0>(*row), expected[counter].id);
     ASSERT_EQ(std::get<1>(*row), expected[counter].fname);
@@ -728,12 +726,12 @@ TEST_F(ClientIntegrationTest, ExecuteBatchDmlMany) {
     ASSERT_EQ(stats.row_count, 1);
   }
 
-  auto query = client_->ExecuteQuery(SqlStatement(
+  auto rows = client_->ExecuteQuery(SqlStatement(
       "SELECT SingerId, FirstName, LastName FROM Singers ORDER BY SingerId"));
 
   auto counter = 0;
   for (auto const& row :
-       StreamOf<std::tuple<std::int64_t, std::string, std::string>>(query)) {
+       StreamOf<std::tuple<std::int64_t, std::string, std::string>>(rows)) {
     ASSERT_STATUS_OK(row);
     std::string const singer_id = std::to_string(counter);
     std::string const first_name = "Foo" + singer_id;

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -95,14 +95,14 @@ TEST(ClientSqlStressTest, UpsertAndSelect) {
         result.Update(commit.status());
       } else {
         auto size = random_limit(generator);
-        auto reader = client.ExecuteQuery(
+        auto rows = client.ExecuteQuery(
             SqlStatement("SELECT SingerId, FirstName, LastName"
                          "  FROM Singers"
                          " WHERE SingerId >= @min"
                          "   AND SingerId <= @max",
                          {{"min", spanner::Value(key)},
                           {"max", spanner::Value(key + size)}}));
-        for (auto row : reader) {
+        for (auto row : rows) {
           result.Update(row.status());
         }
       }
@@ -166,9 +166,9 @@ TEST(ClientStressTest, UpsertAndRead) {
             spanner::KeySet().AddRange(spanner::MakeKeyBoundClosed(key),
                                        spanner::MakeKeyBoundClosed(key + size));
 
-        auto reader = client.Read("Singers", range,
-                                  {"SingerId", "FirstName", "LastName"});
-        for (auto row : reader) {
+        auto rows = client.Read("Singers", range,
+                                {"SingerId", "FirstName", "LastName"});
+        for (auto row : rows) {
           result.Update(row.status());
         }
       }

--- a/google/cloud/spanner/integration_tests/throughput_benchmark.cc
+++ b/google/cloud/spanner/integration_tests/throughput_benchmark.cc
@@ -270,8 +270,8 @@ class SelectSingleRow : public Experiment {
          WHERE SingerId = @key
          LIMIT 1)sql",
           {{"key", cloud_spanner::Value(key)}});
-      auto reader = client.ExecuteQuery(statement);
-      for (auto& row : reader) {
+      auto rows = client.ExecuteQuery(statement);
+      for (auto& row : rows) {
         samples.push_back(
             {Operation::kSelect, 1, ElapsedTime(start_query), row.ok()});
         break;

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -283,8 +283,8 @@ class DmlResultSetSource : public internal::ResultSourceInterface {
 };
 
 RowStream ConnectionImpl::ReadImpl(SessionHolder& session,
-                                     spanner_proto::TransactionSelector& s,
-                                     ReadParams params) {
+                                   spanner_proto::TransactionSelector& s,
+                                   ReadParams params) {
   if (!session) {
     auto session_or = AllocateSession();
     if (!session_or) {

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -113,7 +113,7 @@ ConnectionImpl::ConnectionImpl(Database db, std::shared_ptr<SpannerStub> stub,
       backoff_policy_(std::move(backoff_policy)),
       session_pool_(this) {}
 
-QueryResult ConnectionImpl::Read(ReadParams params) {
+RowStream ConnectionImpl::Read(ReadParams params) {
   return internal::Visit(
       std::move(params.transaction),
       [this, &params](SessionHolder& session,
@@ -133,7 +133,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionRead(
       });
 }
 
-QueryResult ConnectionImpl::ExecuteQuery(ExecuteSqlParams params) {
+RowStream ConnectionImpl::ExecuteQuery(ExecuteSqlParams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -282,13 +282,13 @@ class DmlResultSetSource : public internal::ResultSourceInterface {
   spanner_proto::ResultSet result_set_;
 };
 
-QueryResult ConnectionImpl::ReadImpl(SessionHolder& session,
+RowStream ConnectionImpl::ReadImpl(SessionHolder& session,
                                      spanner_proto::TransactionSelector& s,
                                      ReadParams params) {
   if (!session) {
     auto session_or = AllocateSession();
     if (!session_or) {
-      return QueryResult(
+      return RowStream(
           google::cloud::internal::make_unique<StatusOnlyResultSetSource>(
               std::move(session_or).status()));
     }
@@ -324,14 +324,14 @@ QueryResult ConnectionImpl::ReadImpl(SessionHolder& session,
       backoff_policy_->clone());
   auto reader = PartialResultSetSource::Create(std::move(rpc));
   if (!reader.ok()) {
-    return QueryResult(
+    return RowStream(
         google::cloud::internal::make_unique<StatusOnlyResultSetSource>(
             std::move(reader).status()));
   }
   if (s.has_begin()) {
     auto metadata = (*reader)->Metadata();
     if (!metadata || metadata->transaction().id().empty()) {
-      return QueryResult(
+      return RowStream(
           google::cloud::internal::make_unique<StatusOnlyResultSetSource>(
               Status(StatusCode::kInternal,
                      "Begin transaction requested but no transaction returned "
@@ -339,7 +339,7 @@ QueryResult ConnectionImpl::ReadImpl(SessionHolder& session,
     }
     s.set_id(metadata->transaction().id());
   }
-  return QueryResult(*std::move(reader));
+  return RowStream(*std::move(reader));
 }
 
 StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
@@ -479,11 +479,11 @@ ResultType ConnectionImpl::CommonQueryImpl(
   return std::move(*ret_val);
 }
 
-QueryResult ConnectionImpl::ExecuteQueryImpl(
+RowStream ConnectionImpl::ExecuteQueryImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
     std::int64_t seqno, ExecuteSqlParams params) {
-  return CommonQueryImpl<QueryResult>(session, s, seqno, std::move(params),
-                                      spanner_proto::ExecuteSqlRequest::NORMAL);
+  return CommonQueryImpl<RowStream>(session, s, seqno, std::move(params),
+                                    spanner_proto::ExecuteSqlRequest::NORMAL);
 }
 
 ProfileQueryResult ConnectionImpl::ProfileQueryImpl(

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -67,10 +67,10 @@ class ConnectionImpl : public Connection,
                        public SessionManager,
                        public std::enable_shared_from_this<ConnectionImpl> {
  public:
-  QueryResult Read(ReadParams) override;
+  RowStream Read(ReadParams) override;
   StatusOr<std::vector<ReadPartition>> PartitionRead(
       PartitionReadParams) override;
-  QueryResult ExecuteQuery(ExecuteSqlParams) override;
+  RowStream ExecuteQuery(ExecuteSqlParams) override;
   StatusOr<DmlResult> ExecuteDml(ExecuteSqlParams) override;
   ProfileQueryResult ProfileQuery(ExecuteSqlParams) override;
   StatusOr<ProfileDmlResult> ProfileDml(ExecuteSqlParams) override;
@@ -92,17 +92,17 @@ class ConnectionImpl : public Connection,
                  std::unique_ptr<RetryPolicy> retry_policy,
                  std::unique_ptr<BackoffPolicy> backoff_policy);
 
-  QueryResult ReadImpl(SessionHolder& session,
-                       google::spanner::v1::TransactionSelector& s,
-                       ReadParams params);
+  RowStream ReadImpl(SessionHolder& session,
+                     google::spanner::v1::TransactionSelector& s,
+                     ReadParams params);
 
   StatusOr<std::vector<ReadPartition>> PartitionReadImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
       ReadParams const& params, PartitionOptions partition_options);
 
-  QueryResult ExecuteQueryImpl(SessionHolder& session,
-                               google::spanner::v1::TransactionSelector& s,
-                               std::int64_t seqno, ExecuteSqlParams params);
+  RowStream ExecuteQueryImpl(SessionHolder& session,
+                             google::spanner::v1::TransactionSelector& s,
+                             std::int64_t seqno, ExecuteSqlParams params);
 
   StatusOr<DmlResult> ExecuteDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -40,10 +40,10 @@ inline namespace SPANNER_CLIENT_NS {
  */
 class MockConnection : public spanner::Connection {
  public:
-  MOCK_METHOD1(Read, spanner::QueryResult(ReadParams));
+  MOCK_METHOD1(Read, spanner::RowStream(ReadParams));
   MOCK_METHOD1(PartitionRead, StatusOr<std::vector<spanner::ReadPartition>>(
                                   PartitionReadParams));
-  MOCK_METHOD1(ExecuteQuery, spanner::QueryResult(ExecuteSqlParams));
+  MOCK_METHOD1(ExecuteQuery, spanner::RowStream(ExecuteSqlParams));
   MOCK_METHOD1(ExecuteDml, StatusOr<spanner::DmlResult>(ExecuteSqlParams));
   MOCK_METHOD1(ProfileQuery, spanner::ProfileQueryResult(ExecuteSqlParams));
   MOCK_METHOD1(ProfileDml,

--- a/google/cloud/spanner/results.cc
+++ b/google/cloud/spanner/results.cc
@@ -65,7 +65,7 @@ optional<spanner::ExecutionPlan> GetExecutionPlan(
 }
 }  // namespace
 
-optional<Timestamp> QueryResult::ReadTimestamp() const {
+optional<Timestamp> RowStream::ReadTimestamp() const {
   return GetReadTimestamp(source_);
 }
 

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -48,36 +48,36 @@ class ResultSourceInterface {
 }  // namespace internal
 
 /**
- * Represents the result of a read operation using `spanner::Client::Read()` or
+ * Represents the stream of `Rows` returned `spanner::Client::Read()` or
  * `spanner::Client::ExecuteQuery()`.
  *
- * A `QueryResult` object is itself a range defined by the [Input
- * Iterators][input-iterator] returned from `begin()` and `end(). Callers may
- * directly iterate a `QueryResult` instance, which will return a sequence of
- * `StatusOr<Row>` objects.
+ * A `RowStream` object is a range defined by the [Input
+ * Iterators][input-iterator] returned from its `begin()` and `end()` members.
+ * Callers may directly iterate a `RowStream` instance, which will return a
+ * sequence of `StatusOr<Row>` objects.
  *
- * For convenience, callers may wrap the `QueryResult` instance in a
+ * For convenience, callers may wrap a `RowStream` instance in a
  * `StreamOf<std::tuple<...>>` object, which will automatically parse each
  * `Row` into a `std::tuple` with the specified types.
  *
  * [input-iterator]: https://en.cppreference.com/w/cpp/named_req/InputIterator
  */
-class QueryResult {
+class RowStream {
  public:
-  QueryResult() = default;
-  explicit QueryResult(std::unique_ptr<internal::ResultSourceInterface> source)
+  RowStream() = default;
+  explicit RowStream(std::unique_ptr<internal::ResultSourceInterface> source)
       : source_(std::move(source)) {}
 
   // This class is movable but not copyable.
-  QueryResult(QueryResult&&) = default;
-  QueryResult& operator=(QueryResult&&) = default;
+  RowStream(RowStream&&) = default;
+  RowStream& operator=(RowStream&&) = default;
 
-  /// Returns a `RowStreamIterator` defining the beginning of this result set.
+  /// Returns a `RowStreamIterator` defining the beginning of this range.
   RowStreamIterator begin() {
     return RowStreamIterator([this]() mutable { return source_->NextRow(); });
   }
 
-  /// Returns a `RowStreamIterator` defining the end of this result set.
+  /// Returns a `RowStreamIterator` defining the end of this range.
   RowStreamIterator end() { return {}; }
 
   /**

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -48,7 +48,7 @@ class ResultSourceInterface {
 }  // namespace internal
 
 /**
- * Represents the stream of `Rows` returned `spanner::Client::Read()` or
+ * Represents the stream of `Rows` returned from `spanner::Client::Read()` or
  * `spanner::Client::ExecuteQuery()`.
  *
  * A `RowStream` object is a range defined by the [Input

--- a/google/cloud/spanner/samples/mock_execute_query.cc
+++ b/google/cloud/spanner/samples/mock_execute_query.cc
@@ -80,8 +80,8 @@ TEST(MockSpannerClient, SuccessfulExecuteQuery) {
   //! [mock-execute-query]
   EXPECT_CALL(*conn, ExecuteQuery(_))
       .WillOnce([&source](spanner::Connection::ExecuteSqlParams const&)
-                    -> spanner::QueryResult {
-        return spanner::QueryResult(std::move(source));
+                    -> spanner::RowStream {
+        return spanner::RowStream(std::move(source));
       });
   //! [mock-execute-query]
 
@@ -92,14 +92,14 @@ TEST(MockSpannerClient, SuccessfulExecuteQuery) {
 
   // Make the request and verify the expected results:
   //! [client-call]
-  auto reader = client.ExecuteQuery(
+  auto rows = client.ExecuteQuery(
       spanner::SqlStatement("SELECT Id, Greeting FROM Greetings"));
   //! [client-call]
 
   //! [expected-results]
   int count = 0;
   using RowType = std::tuple<std::int64_t, std::string>;
-  for (auto row : spanner::StreamOf<RowType>(reader)) {
+  for (auto row : spanner::StreamOf<RowType>(rows)) {
     ASSERT_TRUE(row);
     auto expected_id = ++count;
     EXPECT_EQ(expected_id, std::get<0>(*row));


### PR DESCRIPTION
Fixes #977 

Renames `QueryResult` -> `RowStream` for the reasons described in #977. Also standardized on variable naming: The variable used to store the results of a `client.Read(...)` or `client.ExecuteQuery(...)` is always named `rows` now, which I think reads nicely in the code.

This PR is a semantic no-op. Only a rename.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/978)
<!-- Reviewable:end -->
