### PR TITLE
feat: adds efficient move support to Value::get<string>()

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -287,6 +287,15 @@ StatusOr<std::string> Value::GetValue(std::string const&,
   return pv.string_value();
 }
 
+StatusOr<std::string> Value::GetValue(std::string const&,
+                                      google::protobuf::Value&& pv,
+                                      google::spanner::v1::Type const&) {
+  if (pv.kind_case() != google::protobuf::Value::kStringValue) {
+    return Status(StatusCode::kUnknown, "missing STRING");
+  }
+  return std::move(*pv.mutable_string_value());
+}
+
 StatusOr<Bytes> Value::GetValue(Bytes const&, google::protobuf::Value const& pv,
                                 google::spanner::v1::Type const&) {
   if (pv.kind_case() != google::protobuf::Value::kStringValue) {

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -165,7 +165,7 @@ TEST(Value, BasicSemantics) {
   }
 }
 
-// NOTE: This test relies on unspecified behavior about the moved-frong state
+// NOTE: This test relies on unspecified behavior about the moved-from state
 // of std::string. Specifically, this test relies on the fact that "large"
 // strings, when moved-from, end up empty. And we use this fact to verify that
 // spanner::Value::get<T>() correctly handles moves. If this test ever breaks
@@ -190,7 +190,7 @@ TEST(Value, RvalueGetString) {
   EXPECT_EQ("", *s);
 }
 
-// NOTE: This test relies on unspecified behavior about the moved-frong state
+// NOTE: This test relies on unspecified behavior about the moved-from state
 // of std::string. Specifically, this test relies on the fact that "large"
 // strings, when moved-from, end up empty. And we use this fact to verify that
 // spanner::Value::get<T>() correctly handles moves. If this test ever breaks
@@ -215,7 +215,7 @@ TEST(Value, RvalueGetOptoinalString) {
   EXPECT_EQ("", **s);
 }
 
-// NOTE: This test relies on unspecified behavior about the moved-frong state
+// NOTE: This test relies on unspecified behavior about the moved-from state
 // of std::string. Specifically, this test relies on the fact that "large"
 // strings, when moved-from, end up empty. And we use this fact to verify that
 // spanner::Value::get<T>() correctly handles moves. If this test ever breaks
@@ -240,7 +240,7 @@ TEST(Value, RvalueGetVectorString) {
   EXPECT_EQ(Type(data.size(), ""), *s);
 }
 
-// NOTE: This test relies on unspecified behavior about the moved-frong state
+// NOTE: This test relies on unspecified behavior about the moved-from state
 // of std::string. Specifically, this test relies on the fact that "large"
 // strings, when moved-from, end up empty. And we use this fact to verify that
 // spanner::Value::get<T>() correctly handles moves. If this test ever breaks

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -165,6 +165,107 @@ TEST(Value, BasicSemantics) {
   }
 }
 
+// NOTE: This test relies on unspecified behavior about the moved-frong state
+// of std::string. Specifically, this test relies on the fact that "large"
+// strings, when moved-from, end up empty. And we use this fact to verify that
+// spanner::Value::get<T>() correctly handles moves. If this test ever breaks
+// on some platform, we could probably delete this, unless we can think of a
+// better way to test move semantics.
+TEST(Value, RvalueGetString) {
+  using Type = std::string;
+  Type const data = std::string(128, 'x');
+  Value v(data);
+
+  auto s = v.get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(data, *s);
+
+  s = std::move(v).get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(data, *s);
+
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  s = v.get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ("", *s);
+}
+
+// NOTE: This test relies on unspecified behavior about the moved-frong state
+// of std::string. Specifically, this test relies on the fact that "large"
+// strings, when moved-from, end up empty. And we use this fact to verify that
+// spanner::Value::get<T>() correctly handles moves. If this test ever breaks
+// on some platform, we could probably delete this, unless we can think of a
+// better way to test move semantics.
+TEST(Value, RvalueGetOptoinalString) {
+  using Type = optional<std::string>;
+  Type const data = std::string(128, 'x');
+  Value v(data);
+
+  auto s = v.get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(*data, **s);
+
+  s = std::move(v).get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(*data, **s);
+
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  s = v.get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ("", **s);
+}
+
+// NOTE: This test relies on unspecified behavior about the moved-frong state
+// of std::string. Specifically, this test relies on the fact that "large"
+// strings, when moved-from, end up empty. And we use this fact to verify that
+// spanner::Value::get<T>() correctly handles moves. If this test ever breaks
+// on some platform, we could probably delete this, unless we can think of a
+// better way to test move semantics.
+TEST(Value, RvalueGetVectorString) {
+  using Type = std::vector<std::string>;
+  Type const data(128, std::string(128, 'x'));
+  Value v(data);
+
+  auto s = v.get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(data, *s);
+
+  s = std::move(v).get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(data, *s);
+
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  s = v.get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(Type(data.size(), ""), *s);
+}
+
+// NOTE: This test relies on unspecified behavior about the moved-frong state
+// of std::string. Specifically, this test relies on the fact that "large"
+// strings, when moved-from, end up empty. And we use this fact to verify that
+// spanner::Value::get<T>() correctly handles moves. If this test ever breaks
+// on some platform, we could probably delete this, unless we can think of a
+// better way to test move semantics.
+TEST(Value, RvalueGetStructString) {
+  using Type = std::tuple<std::pair<std::string, std::string>, std::string>;
+  Type data{std::make_pair("name", std::string(128, 'x')),
+            std::string(128, 'x')};
+  Value v(data);
+
+  auto s = v.get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(data, *s);
+
+  s = std::move(v).get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(data, *s);
+
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  s = v.get<Type>();
+  EXPECT_STATUS_OK(s);
+  EXPECT_EQ(Type({"name", ""}, ""), *s);
+}
+
 TEST(Value, DoubleNaN) {
   double const nan = std::nan("NaN");
   Value v{nan};


### PR DESCRIPTION
Fixes #422

Changes `Value::get<T>()` to efficiently move `std::string` values out
of the proto and directly to the caller. `std::string` is the only type
that can do this because it's the only type which is exactly the same in
the proto and outside of it. All other types require some type of
decoding, which necessarily requires some amount of copying from the
proto out to the caller.

Note: the unit tests verifying this behavior rely on unspecified behavior of std::string. Specifically that a moved-from large string ends up empty. This is not guaranteed, but it *appears* to the true in all cases that I've seen. So we rely on this behavior in the unit test. If this turns out to not be true on some platform, we'll have to adjust the unit tests. I've commented the tests about this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/980)
<!-- Reviewable:end -->
