### PR TITLE
chore: avoids range-for copies when possible

### DIFF
--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -377,7 +377,7 @@ TEST(DatabaseAdminClientTest, ListDatabases) {
 
   auto conn = CreateTestingConnection(std::move(mock));
   std::vector<std::string> actual_names;
-  for (auto database : conn->ListDatabases({in})) {
+  for (auto const& database : conn->ListDatabases({in})) {
     ASSERT_STATUS_OK(database);
     actual_names.push_back(database->name());
   }

--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -382,7 +382,8 @@ TEST(InstanceAdminConnectionTest, ListInstanceConfigs_Success) {
 
   auto conn = MakeTestConnection(mock);
   std::vector<std::string> actual_names;
-  for (auto instance_config : conn->ListInstanceConfigs({"test-project"})) {
+  for (auto const& instance_config :
+       conn->ListInstanceConfigs({"test-project"})) {
     ASSERT_STATUS_OK(instance_config);
     actual_names.push_back(instance_config->name());
   }
@@ -452,7 +453,7 @@ TEST(InstanceAdminConnectionTest, ListInstances_Success) {
 
   auto conn = MakeTestConnection(mock);
   std::vector<std::string> actual_names;
-  for (auto instance :
+  for (auto const& instance :
        conn->ListInstances({"test-project", "labels.test-key:test-value"})) {
     ASSERT_STATUS_OK(instance);
     actual_names.push_back(instance->name());

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -257,7 +257,7 @@ TEST_F(ClientIntegrationTest, Commit) {
   std::vector<std::int64_t> ids;
   auto ks = KeySet().AddRange(MakeKeyBoundClosed(100), MakeKeyBoundOpen(200));
   auto rows = client_->Read("Singers", std::move(ks), {"SingerId"});
-  for (auto& row : StreamOf<RowType>(rows)) {
+  for (auto const& row : StreamOf<RowType>(rows)) {
     EXPECT_STATUS_OK(row);
     if (row) ids.push_back(std::get<0>(*row));
   }
@@ -547,7 +547,7 @@ TEST_F(ClientIntegrationTest, PartitionRead) {
   ASSERT_STATUS_OK(read_partitions);
 
   std::vector<std::string> serialized_partitions;
-  for (auto& partition : *read_partitions) {
+  for (auto const& partition : *read_partitions) {
     auto serialized_partition = SerializeReadPartition(partition);
     ASSERT_STATUS_OK(serialized_partition);
     serialized_partitions.push_back(*serialized_partition);
@@ -555,7 +555,7 @@ TEST_F(ClientIntegrationTest, PartitionRead) {
 
   std::vector<std::vector<Value>> actual_rows;
   int partition_number = 0;
-  for (auto& partition : serialized_partitions) {
+  for (auto const& partition : serialized_partitions) {
     int row_number = 0;
     auto deserialized_partition = DeserializeReadPartition(partition);
     ASSERT_STATUS_OK(deserialized_partition);
@@ -588,7 +588,7 @@ TEST_F(ClientIntegrationTest, PartitionQuery) {
   ASSERT_STATUS_OK(query_partitions);
 
   std::vector<std::string> serialized_partitions;
-  for (auto& partition : *query_partitions) {
+  for (auto const& partition : *query_partitions) {
     auto serialized_partition = SerializeQueryPartition(partition);
     ASSERT_STATUS_OK(serialized_partition);
     serialized_partitions.push_back(*serialized_partition);
@@ -596,7 +596,7 @@ TEST_F(ClientIntegrationTest, PartitionQuery) {
 
   std::vector<std::vector<Value>> actual_rows;
   int partition_number = 0;
-  for (auto& partition : serialized_partitions) {
+  for (auto const& partition : serialized_partitions) {
     int row_number = 0;
     auto deserialized_partition = DeserializeQueryPartition(partition);
     ASSERT_STATUS_OK(deserialized_partition);

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -102,7 +102,7 @@ TEST(ClientSqlStressTest, UpsertAndSelect) {
                          "   AND SingerId <= @max",
                          {{"min", spanner::Value(key)},
                           {"max", spanner::Value(key + size)}}));
-        for (auto row : rows) {
+        for (auto const& row : rows) {
           result.Update(row.status());
         }
       }
@@ -168,7 +168,7 @@ TEST(ClientStressTest, UpsertAndRead) {
 
         auto rows = client.Read("Singers", range,
                                 {"SingerId", "FirstName", "LastName"});
-        for (auto row : rows) {
+        for (auto const& row : rows) {
           result.Update(row.status());
         }
       }

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -60,7 +60,7 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
   // which is nice.
   auto get_current_databases = [&client, in] {
     std::vector<std::string> names;
-    for (auto database : client.ListDatabases(in)) {
+    for (auto const& database : client.ListDatabases(in)) {
       EXPECT_STATUS_OK(database);
       if (!database) return names;
       names.push_back(database->name());

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -70,7 +70,7 @@ class InstanceAdminClientTestWithCleanup : public InstanceAdminClientTest {
     // Deletes leaked temporary instances.
     std::vector<std::string> instance_ids = [this]() mutable {
       std::vector<std::string> instance_ids;
-      for (auto instance : client_.ListInstances(project_id_, "")) {
+      for (auto const& instance : client_.ListInstances(project_id_, "")) {
         EXPECT_STATUS_OK(instance);
         if (!instance) break;
         auto name = instance->name();
@@ -116,7 +116,7 @@ TEST_F(InstanceAdminClientTest, InstanceReadOperations) {
 
   std::vector<std::string> instance_names = [this]() mutable {
     std::vector<std::string> names;
-    for (auto instance : client_.ListInstances(project_id_, "")) {
+    for (auto const& instance : client_.ListInstances(project_id_, "")) {
       EXPECT_STATUS_OK(instance);
       if (!instance) break;
       names.push_back(instance->name());
@@ -145,7 +145,8 @@ TEST_F(InstanceAdminClientTestWithCleanup, InstanceCRUDOperations) {
   EXPECT_TRUE(std::regex_match(full_name, m, instance_name_regex_));
   std::vector<std::string> instance_config_names = [this]() mutable {
     std::vector<std::string> names;
-    for (auto instance_config : client_.ListInstanceConfigs(project_id_)) {
+    for (auto const& instance_config :
+         client_.ListInstanceConfigs(project_id_)) {
       EXPECT_STATUS_OK(instance_config);
       if (!instance_config) break;
       names.push_back(instance_config->name());
@@ -193,7 +194,8 @@ TEST_F(InstanceAdminClientTest, InstanceConfig) {
 
   std::vector<std::string> instance_config_names = [this]() mutable {
     std::vector<std::string> names;
-    for (auto instance_config : client_.ListInstanceConfigs(project_id_)) {
+    for (auto const& instance_config :
+         client_.ListInstanceConfigs(project_id_)) {
       EXPECT_STATUS_OK(instance_config);
       if (!instance_config) break;
       names.push_back(instance_config->name());

--- a/google/cloud/spanner/integration_tests/spanner_install_test.cc
+++ b/google/cloud/spanner/integration_tests/spanner_install_test.cc
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) try {
     spanner::InstanceAdminClient instance_admin{
         spanner::MakeInstanceAdminConnection()};
     std::vector<std::string> names;
-    for (auto instance : instance_admin.ListInstances(project_id, {})) {
+    for (auto const& instance : instance_admin.ListInstances(project_id, {})) {
       if (!instance) throw std::runtime_error("Error reading instance list");
       auto full_name = instance->name();
       names.push_back(full_name.substr(full_name.rfind('/') + 1));
@@ -110,7 +110,7 @@ int main(int argc, char* argv[]) try {
   auto reader =
       client.ExecuteQuery(spanner::SqlStatement("SELECT 'Hello World'"));
 
-  for (auto&& row : spanner::StreamOf<std::tuple<std::string>>(reader)) {
+  for (auto const& row : spanner::StreamOf<std::tuple<std::string>>(reader)) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << std::get<0>(*row) << "\n";
   }

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -380,7 +380,7 @@ class TupleStreamIterator {
  * @code
  * auto row_range = ...
  * using RowType = std::tuple<std::int64_t, std::string, bool>;
- * for (auto row : StreamOf<RowType>(row_range)) {
+ * for (auto const& row : StreamOf<RowType>(row_range)) {
  *   if (!row) {
  *     // Handle error;
  *   }

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -311,7 +311,7 @@ TEST(RowStreamIterator, RangeForLoop) {
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   std::int64_t product = 1;
-  for (auto row : range) {
+  for (auto const& row : range) {
     EXPECT_STATUS_OK(row);
     auto num = row->get<std::int64_t>("num");
     EXPECT_STATUS_OK(num);
@@ -450,7 +450,7 @@ TEST(StreamOf, RangeForLoop) {
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   std::int64_t product = 1;
-  for (auto row : StreamOf<RowType>(range)) {
+  for (auto const& row : StreamOf<RowType>(range)) {
     EXPECT_STATUS_OK(row);
     product *= std::get<0>(*row);
   }

--- a/google/cloud/spanner/samples/mock_execute_query.cc
+++ b/google/cloud/spanner/samples/mock_execute_query.cc
@@ -99,7 +99,7 @@ TEST(MockSpannerClient, SuccessfulExecuteQuery) {
   //! [expected-results]
   int count = 0;
   using RowType = std::tuple<std::int64_t, std::string>;
-  for (auto row : spanner::StreamOf<RowType>(rows)) {
+  for (auto const& row : spanner::StreamOf<RowType>(rows)) {
     ASSERT_TRUE(row);
     auto expected_id = ++count;
     EXPECT_EQ(expected_id, std::get<0>(*row));

--- a/google/cloud/spanner/testing/pick_random_instance.cc
+++ b/google/cloud/spanner/testing/pick_random_instance.cc
@@ -33,7 +33,7 @@ StatusOr<std::string> PickRandomInstance(
    * "test-instance-" here for isolation.
    */
   std::vector<std::string> instance_ids;
-  for (auto instance : client.ListInstances(project_id, "")) {
+  for (auto& instance : client.ListInstances(project_id, "")) {
     if (!instance) return std::move(instance).status();
     auto name = instance->name();
     std::string const sep = "/instances/";


### PR DESCRIPTION
In many cases we were using range-for loops like `for (auto row : x)`,
which makes a copy in `row` for each element. In most cases, we do not
want/need this copy. If we only read from the value, we want a `const&`.
if we want to move from the element, we may want a non-const reference.
Only rarely would we actually want a copy.

This PR updates all the cases that I could find.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/981)
<!-- Reviewable:end -->
