### PR TITLE
chore: a little more naming cleanup for consistency

### DIFF
--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -105,7 +105,7 @@ TEST(ClientTest, ReadSuccess) {
       .WillOnce(Return(ByMove(RowStream(std::move(source)))));
 
   KeySet keys = KeySet::All();
-  auto result = client.Read("table", std::move(keys), {"column1", "column2"});
+  auto rows = client.Read("table", std::move(keys), {"column1", "column2"});
 
   using RowType = std::tuple<std::string, std::int64_t>;
   auto expected = std::vector<RowType>{
@@ -113,7 +113,7 @@ TEST(ClientTest, ReadSuccess) {
       RowType("Ann", 42),
   };
   int row_number = 0;
-  for (auto& row : StreamOf<RowType>(result)) {
+  for (auto& row : StreamOf<RowType>(rows)) {
     EXPECT_STATUS_OK(row);
     EXPECT_EQ(*row, expected[row_number]);
     ++row_number;
@@ -147,16 +147,16 @@ TEST(ClientTest, ReadFailure) {
       .WillOnce(Return(ByMove(RowStream(std::move(source)))));
 
   KeySet keys = KeySet::All();
-  auto result = client.Read("table", std::move(keys), {"column1"});
+  auto rows = client.Read("table", std::move(keys), {"column1"});
 
-  auto rows = StreamOf<std::tuple<std::string>>(result);
-  auto iter = rows.begin();
-  EXPECT_NE(iter, rows.end());
+  auto tups = StreamOf<std::tuple<std::string>>(rows);
+  auto iter = tups.begin();
+  EXPECT_NE(iter, tups.end());
   EXPECT_STATUS_OK(*iter);
   EXPECT_EQ(std::get<0>(**iter), "Steve");
 
   ++iter;
-  EXPECT_NE(iter, rows.end());
+  EXPECT_NE(iter, tups.end());
   EXPECT_STATUS_OK(*iter);
   EXPECT_EQ(std::get<0>(**iter), "Ann");
 

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -369,14 +369,13 @@ void CheckReadWithOptions(
       });
   ASSERT_STATUS_OK(commit);
 
-  auto reader =
-      client.Read(options_generator(*commit), "Singers", KeySet::All(),
-                  {"SingerId", "FirstName", "LastName"});
+  auto rows = client.Read(options_generator(*commit), "Singers", KeySet::All(),
+                          {"SingerId", "FirstName", "LastName"});
 
   std::vector<RowValues> actual_rows;
   int row_number = 0;
   for (auto& row :
-       StreamOf<std::tuple<std::int64_t, std::string, std::string>>(reader)) {
+       StreamOf<std::tuple<std::int64_t, std::string, std::string>>(rows)) {
     SCOPED_TRACE("Reading row[" + std::to_string(row_number++) + "]");
     EXPECT_STATUS_OK(row);
     if (!row) break;

--- a/google/cloud/spanner/integration_tests/spanner_install_test.cc
+++ b/google/cloud/spanner/integration_tests/spanner_install_test.cc
@@ -107,10 +107,10 @@ int main(int argc, char* argv[]) try {
 
   spanner::Client client(spanner::MakeConnection(database));
 
-  auto reader =
+  auto rows =
       client.ExecuteQuery(spanner::SqlStatement("SELECT 'Hello World'"));
 
-  for (auto const& row : spanner::StreamOf<std::tuple<std::string>>(reader)) {
+  for (auto const& row : spanner::StreamOf<std::tuple<std::string>>(rows)) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << std::get<0>(*row) << "\n";
   }

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -668,11 +668,11 @@ void Quickstart(std::string const& project_id, std::string const& instance_id,
   spanner::Client client(spanner::MakeConnection(
       spanner::Database(project_id, instance_id, database_id)));
 
-  auto reader =
+  auto rows =
       client.ExecuteQuery(spanner::SqlStatement("SELECT 'Hello World'"));
 
   using RowType = std::tuple<std::string>;
-  for (auto const& row : spanner::StreamOf<RowType>(reader)) {
+  for (auto const& row : spanner::StreamOf<RowType>(rows)) {
     if (!row) throw std::runtime_error(row.status().message());
     std::cout << std::get<0>(*row) << "\n";
   }


### PR DESCRIPTION
By convention, we name the result of `Client::Read` and
`Client::ExecuteQuery` `rows`. There were a few places where this wasn't
happening, mostly be because the variable was declared on a different
line from the function call, so my previous greps missed these.

No semantic change. Just a rename.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/982)
<!-- Reviewable:end -->
