### PR TITLE
chore!: rename ExecuteSqlParams -> SqlParams

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -86,7 +86,7 @@ RowStream Client::ExecuteQuery(Transaction transaction,
 }
 
 RowStream Client::ExecuteQuery(QueryPartition const& partition) {
-  return conn_->ExecuteQuery(internal::MakeExecuteSqlParams(partition));
+  return conn_->ExecuteQuery(internal::MakeSqlparams(partition));
 }
 
 ProfileQueryResult Client::ProfileQuery(SqlStatement statement) {

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -86,7 +86,7 @@ RowStream Client::ExecuteQuery(Transaction transaction,
 }
 
 RowStream Client::ExecuteQuery(QueryPartition const& partition) {
-  return conn_->ExecuteQuery(internal::MakeSqlparams(partition));
+  return conn_->ExecuteQuery(internal::MakeSqlParams(partition));
 }
 
 ProfileQueryResult Client::ProfileQuery(SqlStatement statement) {

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -92,13 +92,13 @@ class Connection {
 
   /// Wrap the arguments to `ExecuteQuery()`, `ExecuteDml()`, `ProfileQuery()`,
   /// or `ProfileDml()`.
-  struct ExecuteSqlParams {
+  struct Sqlparams {
     Transaction transaction;
     SqlStatement statement;
     google::cloud::optional<std::string> partition_token;
 
-    ExecuteSqlParams(Transaction transaction, SqlStatement statement,
-                     google::cloud::optional<std::string> partition_token = {})
+    Sqlparams(Transaction transaction, SqlStatement statement,
+              google::cloud::optional<std::string> partition_token = {})
         : transaction(std::move(transaction)),
           statement(std::move(statement)),
           partition_token(std::move(partition_token)) {}
@@ -111,7 +111,7 @@ class Connection {
 
   /// Wrap the arguments to `PartitionQuery()`.
   struct PartitionQueryParams {
-    ExecuteSqlParams sql_params;
+    Sqlparams sql_params;
     PartitionOptions partition_options;
   };
 
@@ -141,19 +141,19 @@ class Connection {
       PartitionReadParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual RowStream ExecuteQuery(ExecuteSqlParams) = 0;
+  virtual RowStream ExecuteQuery(Sqlparams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual StatusOr<DmlResult> ExecuteDml(ExecuteSqlParams) = 0;
+  virtual StatusOr<DmlResult> ExecuteDml(Sqlparams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual ProfileQueryResult ProfileQuery(ExecuteSqlParams) = 0;
+  virtual ProfileQueryResult ProfileQuery(Sqlparams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual StatusOr<ProfileDmlResult> ProfileDml(ExecuteSqlParams) = 0;
+  virtual StatusOr<ProfileDmlResult> ProfileDml(Sqlparams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual StatusOr<ExecutionPlan> AnalyzeSql(ExecuteSqlParams) = 0;
+  virtual StatusOr<ExecutionPlan> AnalyzeSql(Sqlparams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecutePartitionedDml
   /// RPC

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -92,12 +92,12 @@ class Connection {
 
   /// Wrap the arguments to `ExecuteQuery()`, `ExecuteDml()`, `ProfileQuery()`,
   /// or `ProfileDml()`.
-  struct Sqlparams {
+  struct SqlParams {
     Transaction transaction;
     SqlStatement statement;
     google::cloud::optional<std::string> partition_token;
 
-    Sqlparams(Transaction transaction, SqlStatement statement,
+    SqlParams(Transaction transaction, SqlStatement statement,
               google::cloud::optional<std::string> partition_token = {})
         : transaction(std::move(transaction)),
           statement(std::move(statement)),
@@ -111,7 +111,7 @@ class Connection {
 
   /// Wrap the arguments to `PartitionQuery()`.
   struct PartitionQueryParams {
-    Sqlparams sql_params;
+    SqlParams sql_params;
     PartitionOptions partition_options;
   };
 
@@ -141,19 +141,19 @@ class Connection {
       PartitionReadParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual RowStream ExecuteQuery(Sqlparams) = 0;
+  virtual RowStream ExecuteQuery(SqlParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual StatusOr<DmlResult> ExecuteDml(Sqlparams) = 0;
+  virtual StatusOr<DmlResult> ExecuteDml(SqlParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual ProfileQueryResult ProfileQuery(Sqlparams) = 0;
+  virtual ProfileQueryResult ProfileQuery(SqlParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual StatusOr<ProfileDmlResult> ProfileDml(Sqlparams) = 0;
+  virtual StatusOr<ProfileDmlResult> ProfileDml(SqlParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecuteSql RPC
-  virtual StatusOr<ExecutionPlan> AnalyzeSql(Sqlparams) = 0;
+  virtual StatusOr<ExecutionPlan> AnalyzeSql(SqlParams) = 0;
 
   /// Define the interface for a google.spanner.v1.Spanner.ExecutePartitionedDml
   /// RPC

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -133,7 +133,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionRead(
       });
 }
 
-RowStream ConnectionImpl::ExecuteQuery(ExecuteSqlParams params) {
+RowStream ConnectionImpl::ExecuteQuery(Sqlparams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -143,7 +143,7 @@ RowStream ConnectionImpl::ExecuteQuery(ExecuteSqlParams params) {
                          });
 }
 
-StatusOr<DmlResult> ConnectionImpl::ExecuteDml(ExecuteSqlParams params) {
+StatusOr<DmlResult> ConnectionImpl::ExecuteDml(Sqlparams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -153,7 +153,7 @@ StatusOr<DmlResult> ConnectionImpl::ExecuteDml(ExecuteSqlParams params) {
                          });
 }
 
-ProfileQueryResult ConnectionImpl::ProfileQuery(ExecuteSqlParams params) {
+ProfileQueryResult ConnectionImpl::ProfileQuery(Sqlparams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -163,7 +163,7 @@ ProfileQueryResult ConnectionImpl::ProfileQuery(ExecuteSqlParams params) {
                          });
 }
 
-StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDml(ExecuteSqlParams params) {
+StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDml(Sqlparams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -173,7 +173,7 @@ StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDml(ExecuteSqlParams params) {
                          });
 }
 
-StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSql(ExecuteSqlParams params) {
+StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSql(Sqlparams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -395,7 +395,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
     SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-    std::int64_t seqno, ExecuteSqlParams params,
+    std::int64_t seqno, Sqlparams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
     std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
         google::spanner::v1 ::ExecuteSqlRequest& request)> const&
@@ -440,7 +440,7 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
 template <typename ResultType>
 ResultType ConnectionImpl::CommonQueryImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, ExecuteSqlParams params,
+    std::int64_t seqno, Sqlparams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   // Capture a copy of of these member variables to ensure the `shared_ptr<>`
   // remains valid through the lifetime of the lambda. Note that the local
@@ -481,14 +481,14 @@ ResultType ConnectionImpl::CommonQueryImpl(
 
 RowStream ConnectionImpl::ExecuteQueryImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, ExecuteSqlParams params) {
+    std::int64_t seqno, Sqlparams params) {
   return CommonQueryImpl<RowStream>(session, s, seqno, std::move(params),
                                     spanner_proto::ExecuteSqlRequest::NORMAL);
 }
 
 ProfileQueryResult ConnectionImpl::ProfileQueryImpl(
     SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-    std::int64_t seqno, ExecuteSqlParams params) {
+    std::int64_t seqno, Sqlparams params) {
   return CommonQueryImpl<ProfileQueryResult>(
       session, s, seqno, std::move(params),
       spanner_proto::ExecuteSqlRequest::PROFILE);
@@ -497,7 +497,7 @@ ProfileQueryResult ConnectionImpl::ProfileQueryImpl(
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, ExecuteSqlParams params,
+    std::int64_t seqno, Sqlparams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   auto function_name = __func__;
   // Capture a copy of of these member variables to ensure the `shared_ptr<>`
@@ -529,14 +529,14 @@ StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
 
 StatusOr<DmlResult> ConnectionImpl::ExecuteDmlImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, ExecuteSqlParams params) {
+    std::int64_t seqno, Sqlparams params) {
   return CommonDmlImpl<DmlResult>(session, s, seqno, std::move(params),
                                   spanner_proto::ExecuteSqlRequest::NORMAL);
 }
 
 StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDmlImpl(
     SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-    std::int64_t seqno, ExecuteSqlParams params) {
+    std::int64_t seqno, Sqlparams params) {
   return CommonDmlImpl<ProfileDmlResult>(
       session, s, seqno, std::move(params),
       spanner_proto::ExecuteSqlRequest::PROFILE);
@@ -544,7 +544,7 @@ StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDmlImpl(
 
 StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
     SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-    std::int64_t seqno, ExecuteSqlParams params) {
+    std::int64_t seqno, Sqlparams params) {
   auto result =
       CommonDmlImpl<ProfileDmlResult>(session, s, seqno, std::move(params),
                                       spanner_proto::ExecuteSqlRequest::PLAN);
@@ -556,7 +556,7 @@ StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
 
 StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    ExecuteSqlParams const& params, PartitionOptions partition_options) {
+    Sqlparams const& params, PartitionOptions partition_options) {
   if (!session) {
     // Since the session may be sent to other machines, it should not be
     // returned to the pool when the Transaction is destroyed.

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -133,7 +133,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionRead(
       });
 }
 
-RowStream ConnectionImpl::ExecuteQuery(Sqlparams params) {
+RowStream ConnectionImpl::ExecuteQuery(SqlParams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -143,7 +143,7 @@ RowStream ConnectionImpl::ExecuteQuery(Sqlparams params) {
                          });
 }
 
-StatusOr<DmlResult> ConnectionImpl::ExecuteDml(Sqlparams params) {
+StatusOr<DmlResult> ConnectionImpl::ExecuteDml(SqlParams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -153,7 +153,7 @@ StatusOr<DmlResult> ConnectionImpl::ExecuteDml(Sqlparams params) {
                          });
 }
 
-ProfileQueryResult ConnectionImpl::ProfileQuery(Sqlparams params) {
+ProfileQueryResult ConnectionImpl::ProfileQuery(SqlParams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -163,7 +163,7 @@ ProfileQueryResult ConnectionImpl::ProfileQuery(Sqlparams params) {
                          });
 }
 
-StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDml(Sqlparams params) {
+StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDml(SqlParams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -173,7 +173,7 @@ StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDml(Sqlparams params) {
                          });
 }
 
-StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSql(Sqlparams params) {
+StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSql(SqlParams params) {
   return internal::Visit(std::move(params.transaction),
                          [this, &params](SessionHolder& session,
                                          spanner_proto::TransactionSelector& s,
@@ -395,7 +395,7 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionReadImpl(
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
     SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-    std::int64_t seqno, Sqlparams params,
+    std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
     std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
         google::spanner::v1 ::ExecuteSqlRequest& request)> const&
@@ -440,7 +440,7 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
 template <typename ResultType>
 ResultType ConnectionImpl::CommonQueryImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, Sqlparams params,
+    std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   // Capture a copy of of these member variables to ensure the `shared_ptr<>`
   // remains valid through the lifetime of the lambda. Note that the local
@@ -481,14 +481,14 @@ ResultType ConnectionImpl::CommonQueryImpl(
 
 RowStream ConnectionImpl::ExecuteQueryImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, Sqlparams params) {
+    std::int64_t seqno, SqlParams params) {
   return CommonQueryImpl<RowStream>(session, s, seqno, std::move(params),
                                     spanner_proto::ExecuteSqlRequest::NORMAL);
 }
 
 ProfileQueryResult ConnectionImpl::ProfileQueryImpl(
     SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-    std::int64_t seqno, Sqlparams params) {
+    std::int64_t seqno, SqlParams params) {
   return CommonQueryImpl<ProfileQueryResult>(
       session, s, seqno, std::move(params),
       spanner_proto::ExecuteSqlRequest::PROFILE);
@@ -497,7 +497,7 @@ ProfileQueryResult ConnectionImpl::ProfileQueryImpl(
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, Sqlparams params,
+    std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   auto function_name = __func__;
   // Capture a copy of of these member variables to ensure the `shared_ptr<>`
@@ -529,14 +529,14 @@ StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
 
 StatusOr<DmlResult> ConnectionImpl::ExecuteDmlImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    std::int64_t seqno, Sqlparams params) {
+    std::int64_t seqno, SqlParams params) {
   return CommonDmlImpl<DmlResult>(session, s, seqno, std::move(params),
                                   spanner_proto::ExecuteSqlRequest::NORMAL);
 }
 
 StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDmlImpl(
     SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-    std::int64_t seqno, Sqlparams params) {
+    std::int64_t seqno, SqlParams params) {
   return CommonDmlImpl<ProfileDmlResult>(
       session, s, seqno, std::move(params),
       spanner_proto::ExecuteSqlRequest::PROFILE);
@@ -544,7 +544,7 @@ StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDmlImpl(
 
 StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
     SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-    std::int64_t seqno, Sqlparams params) {
+    std::int64_t seqno, SqlParams params) {
   auto result =
       CommonDmlImpl<ProfileDmlResult>(session, s, seqno, std::move(params),
                                       spanner_proto::ExecuteSqlRequest::PLAN);
@@ -556,7 +556,7 @@ StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
 
 StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    Sqlparams const& params, PartitionOptions partition_options) {
+    SqlParams const& params, PartitionOptions partition_options) {
   if (!session) {
     // Since the session may be sent to other machines, it should not be
     // returned to the pool when the Transaction is destroyed.

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -70,11 +70,11 @@ class ConnectionImpl : public Connection,
   RowStream Read(ReadParams) override;
   StatusOr<std::vector<ReadPartition>> PartitionRead(
       PartitionReadParams) override;
-  RowStream ExecuteQuery(ExecuteSqlParams) override;
-  StatusOr<DmlResult> ExecuteDml(ExecuteSqlParams) override;
-  ProfileQueryResult ProfileQuery(ExecuteSqlParams) override;
-  StatusOr<ProfileDmlResult> ProfileDml(ExecuteSqlParams) override;
-  StatusOr<ExecutionPlan> AnalyzeSql(ExecuteSqlParams) override;
+  RowStream ExecuteQuery(Sqlparams) override;
+  StatusOr<DmlResult> ExecuteDml(Sqlparams) override;
+  ProfileQueryResult ProfileQuery(Sqlparams) override;
+  StatusOr<ProfileDmlResult> ProfileDml(Sqlparams) override;
+  StatusOr<ExecutionPlan> AnalyzeSql(Sqlparams) override;
   StatusOr<PartitionedDmlResult> ExecutePartitionedDml(
       ExecutePartitionedDmlParams) override;
   StatusOr<std::vector<QueryPartition>> PartitionQuery(
@@ -102,23 +102,23 @@ class ConnectionImpl : public Connection,
 
   RowStream ExecuteQueryImpl(SessionHolder& session,
                              google::spanner::v1::TransactionSelector& s,
-                             std::int64_t seqno, ExecuteSqlParams params);
+                             std::int64_t seqno, Sqlparams params);
 
   StatusOr<DmlResult> ExecuteDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteSqlParams params);
+      std::int64_t seqno, Sqlparams params);
 
   ProfileQueryResult ProfileQueryImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteSqlParams params);
+      std::int64_t seqno, Sqlparams params);
 
   StatusOr<ProfileDmlResult> ProfileDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteSqlParams params);
+      std::int64_t seqno, Sqlparams params);
 
   StatusOr<ExecutionPlan> AnalyzeSqlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteSqlParams params);
+      std::int64_t seqno, Sqlparams params);
 
   StatusOr<PartitionedDmlResult> ExecutePartitionedDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
@@ -126,7 +126,7 @@ class ConnectionImpl : public Connection,
 
   StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      ExecuteSqlParams const& params, PartitionOptions partition_options);
+      Sqlparams const& params, PartitionOptions partition_options);
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
@@ -165,7 +165,7 @@ class ConnectionImpl : public Connection,
   template <typename ResultType>
   StatusOr<ResultType> ExecuteSqlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteSqlParams params,
+      std::int64_t seqno, Sqlparams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
       std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
           google::spanner::v1 ::ExecuteSqlRequest& request)> const&
@@ -174,13 +174,13 @@ class ConnectionImpl : public Connection,
   template <typename ResultType>
   ResultType CommonQueryImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteSqlParams params,
+      std::int64_t seqno, Sqlparams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 
   template <typename ResultType>
   StatusOr<ResultType> CommonDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, ExecuteSqlParams params,
+      std::int64_t seqno, Sqlparams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 
   Database db_;

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -70,11 +70,11 @@ class ConnectionImpl : public Connection,
   RowStream Read(ReadParams) override;
   StatusOr<std::vector<ReadPartition>> PartitionRead(
       PartitionReadParams) override;
-  RowStream ExecuteQuery(Sqlparams) override;
-  StatusOr<DmlResult> ExecuteDml(Sqlparams) override;
-  ProfileQueryResult ProfileQuery(Sqlparams) override;
-  StatusOr<ProfileDmlResult> ProfileDml(Sqlparams) override;
-  StatusOr<ExecutionPlan> AnalyzeSql(Sqlparams) override;
+  RowStream ExecuteQuery(SqlParams) override;
+  StatusOr<DmlResult> ExecuteDml(SqlParams) override;
+  ProfileQueryResult ProfileQuery(SqlParams) override;
+  StatusOr<ProfileDmlResult> ProfileDml(SqlParams) override;
+  StatusOr<ExecutionPlan> AnalyzeSql(SqlParams) override;
   StatusOr<PartitionedDmlResult> ExecutePartitionedDml(
       ExecutePartitionedDmlParams) override;
   StatusOr<std::vector<QueryPartition>> PartitionQuery(
@@ -102,23 +102,23 @@ class ConnectionImpl : public Connection,
 
   RowStream ExecuteQueryImpl(SessionHolder& session,
                              google::spanner::v1::TransactionSelector& s,
-                             std::int64_t seqno, Sqlparams params);
+                             std::int64_t seqno, SqlParams params);
 
   StatusOr<DmlResult> ExecuteDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, Sqlparams params);
+      std::int64_t seqno, SqlParams params);
 
   ProfileQueryResult ProfileQueryImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, Sqlparams params);
+      std::int64_t seqno, SqlParams params);
 
   StatusOr<ProfileDmlResult> ProfileDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, Sqlparams params);
+      std::int64_t seqno, SqlParams params);
 
   StatusOr<ExecutionPlan> AnalyzeSqlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, Sqlparams params);
+      std::int64_t seqno, SqlParams params);
 
   StatusOr<PartitionedDmlResult> ExecutePartitionedDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
@@ -126,7 +126,7 @@ class ConnectionImpl : public Connection,
 
   StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      Sqlparams const& params, PartitionOptions partition_options);
+      SqlParams const& params, PartitionOptions partition_options);
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
@@ -165,7 +165,7 @@ class ConnectionImpl : public Connection,
   template <typename ResultType>
   StatusOr<ResultType> ExecuteSqlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, Sqlparams params,
+      std::int64_t seqno, SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
       std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
           google::spanner::v1 ::ExecuteSqlRequest& request)> const&
@@ -174,13 +174,13 @@ class ConnectionImpl : public Connection,
   template <typename ResultType>
   ResultType CommonQueryImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, Sqlparams params,
+      std::int64_t seqno, SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 
   template <typename ResultType>
   StatusOr<ResultType> CommonDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      std::int64_t seqno, Sqlparams params,
+      std::int64_t seqno, SqlParams params,
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 
   Database db_;

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -43,12 +43,11 @@ class MockConnection : public spanner::Connection {
   MOCK_METHOD1(Read, spanner::RowStream(ReadParams));
   MOCK_METHOD1(PartitionRead, StatusOr<std::vector<spanner::ReadPartition>>(
                                   PartitionReadParams));
-  MOCK_METHOD1(ExecuteQuery, spanner::RowStream(ExecuteSqlParams));
-  MOCK_METHOD1(ExecuteDml, StatusOr<spanner::DmlResult>(ExecuteSqlParams));
-  MOCK_METHOD1(ProfileQuery, spanner::ProfileQueryResult(ExecuteSqlParams));
-  MOCK_METHOD1(ProfileDml,
-               StatusOr<spanner::ProfileDmlResult>(ExecuteSqlParams));
-  MOCK_METHOD1(AnalyzeSql, StatusOr<spanner::ExecutionPlan>(ExecuteSqlParams));
+  MOCK_METHOD1(ExecuteQuery, spanner::RowStream(Sqlparams));
+  MOCK_METHOD1(ExecuteDml, StatusOr<spanner::DmlResult>(Sqlparams));
+  MOCK_METHOD1(ProfileQuery, spanner::ProfileQueryResult(Sqlparams));
+  MOCK_METHOD1(ProfileDml, StatusOr<spanner::ProfileDmlResult>(Sqlparams));
+  MOCK_METHOD1(AnalyzeSql, StatusOr<spanner::ExecutionPlan>(Sqlparams));
   MOCK_METHOD1(ExecutePartitionedDml, StatusOr<spanner::PartitionedDmlResult>(
                                           ExecutePartitionedDmlParams));
   MOCK_METHOD1(PartitionQuery, StatusOr<std::vector<spanner::QueryPartition>>(

--- a/google/cloud/spanner/mocks/mock_spanner_connection.h
+++ b/google/cloud/spanner/mocks/mock_spanner_connection.h
@@ -43,11 +43,11 @@ class MockConnection : public spanner::Connection {
   MOCK_METHOD1(Read, spanner::RowStream(ReadParams));
   MOCK_METHOD1(PartitionRead, StatusOr<std::vector<spanner::ReadPartition>>(
                                   PartitionReadParams));
-  MOCK_METHOD1(ExecuteQuery, spanner::RowStream(Sqlparams));
-  MOCK_METHOD1(ExecuteDml, StatusOr<spanner::DmlResult>(Sqlparams));
-  MOCK_METHOD1(ProfileQuery, spanner::ProfileQueryResult(Sqlparams));
-  MOCK_METHOD1(ProfileDml, StatusOr<spanner::ProfileDmlResult>(Sqlparams));
-  MOCK_METHOD1(AnalyzeSql, StatusOr<spanner::ExecutionPlan>(Sqlparams));
+  MOCK_METHOD1(ExecuteQuery, spanner::RowStream(SqlParams));
+  MOCK_METHOD1(ExecuteDml, StatusOr<spanner::DmlResult>(SqlParams));
+  MOCK_METHOD1(ProfileQuery, spanner::ProfileQueryResult(SqlParams));
+  MOCK_METHOD1(ProfileDml, StatusOr<spanner::ProfileDmlResult>(SqlParams));
+  MOCK_METHOD1(AnalyzeSql, StatusOr<spanner::ExecutionPlan>(SqlParams));
   MOCK_METHOD1(ExecutePartitionedDml, StatusOr<spanner::PartitionedDmlResult>(
                                           ExecutePartitionedDmlParams));
   MOCK_METHOD1(PartitionQuery, StatusOr<std::vector<spanner::QueryPartition>>(

--- a/google/cloud/spanner/query_partition.cc
+++ b/google/cloud/spanner/query_partition.cc
@@ -96,7 +96,7 @@ QueryPartition MakeQueryPartition(std::string const& transaction_id,
                         sql_statement);
 }
 
-Connection::Sqlparams MakeSqlparams(QueryPartition const& query_partition) {
+Connection::SqlParams MakeSqlParams(QueryPartition const& query_partition) {
   return {internal::MakeTransactionFromIds(query_partition.session_id(),
                                            query_partition.transaction_id()),
           query_partition.sql_statement(), query_partition.partition_token()};

--- a/google/cloud/spanner/query_partition.cc
+++ b/google/cloud/spanner/query_partition.cc
@@ -96,8 +96,7 @@ QueryPartition MakeQueryPartition(std::string const& transaction_id,
                         sql_statement);
 }
 
-Connection::ExecuteSqlParams MakeExecuteSqlParams(
-    QueryPartition const& query_partition) {
+Connection::Sqlparams MakeSqlparams(QueryPartition const& query_partition) {
   return {internal::MakeTransactionFromIds(query_partition.session_id(),
                                            query_partition.transaction_id()),
           query_partition.sql_statement(), query_partition.partition_token()};

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -60,8 +60,7 @@ QueryPartition MakeQueryPartition(std::string const& transaction_id,
                                   std::string const& session_id,
                                   std::string const& partition_token,
                                   SqlStatement const& sql_statement);
-Connection::ExecuteSqlParams MakeExecuteSqlParams(
-    QueryPartition const& query_partition);
+Connection::Sqlparams MakeSqlparams(QueryPartition const& query_partition);
 }  // namespace internal
 
 /**
@@ -106,7 +105,7 @@ class QueryPartition {
   friend QueryPartition internal::MakeQueryPartition(
       std::string const& transaction_id, std::string const& session_id,
       std::string const& partition_token, SqlStatement const& sql_statement);
-  friend Connection::ExecuteSqlParams internal::MakeExecuteSqlParams(
+  friend Connection::Sqlparams internal::MakeSqlparams(
       QueryPartition const& query_partition);
   friend StatusOr<std::string> SerializeQueryPartition(
       QueryPartition const& query_partition);

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -60,7 +60,7 @@ QueryPartition MakeQueryPartition(std::string const& transaction_id,
                                   std::string const& session_id,
                                   std::string const& partition_token,
                                   SqlStatement const& sql_statement);
-Connection::Sqlparams MakeSqlparams(QueryPartition const& query_partition);
+Connection::SqlParams MakeSqlParams(QueryPartition const& query_partition);
 }  // namespace internal
 
 /**
@@ -105,7 +105,7 @@ class QueryPartition {
   friend QueryPartition internal::MakeQueryPartition(
       std::string const& transaction_id, std::string const& session_id,
       std::string const& partition_token, SqlStatement const& sql_statement);
-  friend Connection::Sqlparams internal::MakeSqlparams(
+  friend Connection::SqlParams internal::MakeSqlParams(
       QueryPartition const& query_partition);
   friend StatusOr<std::string> SerializeQueryPartition(
       QueryPartition const& query_partition);

--- a/google/cloud/spanner/query_partition_test.cc
+++ b/google/cloud/spanner/query_partition_test.cc
@@ -128,14 +128,14 @@ TEST(QueryPartitionTest, FailedDeserialize) {
   EXPECT_FALSE(partition.ok());
 }
 
-TEST(QueryPartitionTest, MakeExecuteSqlParams) {
+TEST(QueryPartitionTest, MakeSqlparams) {
   QueryPartitionTester expected_partition(internal::MakeQueryPartition(
       "foo", "session", "token",
       SqlStatement("select * from foo where name = @name",
                    {{"name", Value("Bob")}})));
 
-  Connection::ExecuteSqlParams params =
-      internal::MakeExecuteSqlParams(expected_partition.Partition());
+  Connection::Sqlparams params =
+      internal::MakeSqlparams(expected_partition.Partition());
 
   EXPECT_EQ(params.statement,
             SqlStatement("select * from foo where name = @name",

--- a/google/cloud/spanner/query_partition_test.cc
+++ b/google/cloud/spanner/query_partition_test.cc
@@ -128,14 +128,14 @@ TEST(QueryPartitionTest, FailedDeserialize) {
   EXPECT_FALSE(partition.ok());
 }
 
-TEST(QueryPartitionTest, MakeSqlparams) {
+TEST(QueryPartitionTest, MakeSqlParams) {
   QueryPartitionTester expected_partition(internal::MakeQueryPartition(
       "foo", "session", "token",
       SqlStatement("select * from foo where name = @name",
                    {{"name", Value("Bob")}})));
 
-  Connection::Sqlparams params =
-      internal::MakeSqlparams(expected_partition.Partition());
+  Connection::SqlParams params =
+      internal::MakeSqlParams(expected_partition.Partition());
 
   EXPECT_EQ(params.statement,
             SqlStatement("select * from foo where name = @name",

--- a/google/cloud/spanner/samples/mock_execute_query.cc
+++ b/google/cloud/spanner/samples/mock_execute_query.cc
@@ -79,7 +79,7 @@ TEST(MockSpannerClient, SuccessfulExecuteQuery) {
   // Setup the connection mock to return the results previously setup:
   //! [mock-execute-query]
   EXPECT_CALL(*conn, ExecuteQuery(_))
-      .WillOnce([&source](spanner::Connection::ExecuteSqlParams const&)
+      .WillOnce([&source](spanner::Connection::Sqlparams const&)
                     -> spanner::RowStream {
         return spanner::RowStream(std::move(source));
       });

--- a/google/cloud/spanner/samples/mock_execute_query.cc
+++ b/google/cloud/spanner/samples/mock_execute_query.cc
@@ -79,7 +79,7 @@ TEST(MockSpannerClient, SuccessfulExecuteQuery) {
   // Setup the connection mock to return the results previously setup:
   //! [mock-execute-query]
   EXPECT_CALL(*conn, ExecuteQuery(_))
-      .WillOnce([&source](spanner::Connection::Sqlparams const&)
+      .WillOnce([&source](spanner::Connection::SqlParams const&)
                     -> spanner::RowStream {
         return spanner::RowStream(std::move(source));
       });


### PR DESCRIPTION
BREAKING CHANGE: This rename makes sense since we no longer have an
"ExecuteSql" function, and shorter name is clearer.

Fixes: #962

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/986)
<!-- Reviewable:end -->
