### PR TITLE
ci: make install/build.sh more like other repos

### DIFF
--- a/ci/etc/kokoro/install/run-installed-programs.sh
+++ b/ci/etc/kokoro/install/run-installed-programs.sh
@@ -30,7 +30,7 @@ if [[ -f "${CONFIG_DIRECTORY}/spanner-integration-tests-config.sh" ]]; then
     "--env" "GOOGLE_CLOUD_CPP_SPANNER_INSTANCE=${GOOGLE_CLOUD_CPP_SPANNER_INSTANCE}"
     "--env" "GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA=${GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA}"
 
-    # Mount the config directory as a volumne in `/c`
+    # Mount the config directory as a volume in `/c`
     "--volume" "${CONFIG_DIRECTORY}:/c"
   )
   echo "================================================================"

--- a/ci/etc/kokoro/install/run-installed-programs.sh
+++ b/ci/etc/kokoro/install/run-installed-programs.sh
@@ -35,6 +35,6 @@ if [[ -f "${CONFIG_DIRECTORY}/spanner-integration-tests-config.sh" ]]; then
   )
   echo "================================================================"
   echo "Run test program against installed libraries ${DISTRO}."
-  docker run "${run_args[@]}" "${INSTALL_RUN_IMAGE}" "/i/spanner_install_test"
+  docker run "${run_args[@]}" "${INSTALL_RUN_IMAGE}" "/o/spanner_install_test"
   echo "================================================================"
 fi

--- a/ci/kokoro/define-docker-variables.sh
+++ b/ci/kokoro/define-docker-variables.sh
@@ -15,10 +15,53 @@
 
 set -eu
 
+if [[ -z "${NCPU+x}" ]]; then
+  # Mac doesn't have nproc. Run the equivalent.
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    NCPU=$(sysctl -n hw.physicalcpu)
+  else
+    NCPU=$(nproc)
+  fi
+  export NCPU
+fi
+
 if [[ -n "${IMAGE+x}" ]]; then
   echo "IMAGE is already defined."
 else
-  readonly IMAGE="spanci-${DISTRO}-${DISTRO_VERSION}"
-  readonly BUILD_OUTPUT="cmake-out/${IMAGE}-${BUILD_NAME}"
-  readonly BUILD_HOME="cmake-out/home/${IMAGE}-${BUILD_NAME}"
+  DOCKER_IMAGE_BASENAME="ci-${DISTRO}"
+  DOCKER_README_IMAGE_BASENAME="ci-readme-${DISTRO}"
+  DOCKER_INSTALL_IMAGE_BASENAME="ci-install-${DISTRO}"
+  if [[ -n "${DISTRO_VERSION:-}" ]]; then
+    DOCKER_IMAGE_BASENAME="${DOCKER_IMAGE_BASENAME}-${DISTRO_VERSION}"
+    DOCKER_README_IMAGE_BASENAME="${DOCKER_README_IMAGE_BASENAME}-${DISTRO_VERSION}"
+    DOCKER_INSTALL_IMAGE_BASENAME="${DOCKER_INSTALL_IMAGE_BASENAME}-${DISTRO_VERSION}"
+  fi
+  readonly DOCKER_README_IMAGE_BASENAME
+  readonly DOCKER_INSTALL_IMAGE_BASENAME
+  readonly DOCKER_IMAGE_BASENAME
+
+  if [[ -n "${PROJECT_ID:-}" ]]; then
+    DOCKER_IMAGE_PREFIX="gcr.io/${PROJECT_ID}/google-cloud-cpp-spanner"
+  else
+    # We want a prefix that works when running interactively, so it must be a
+    # (syntactically) valid project id, this works.
+    DOCKER_IMAGE_PREFIX="gcr.io/cloud-cpp-reserved/google-cloud-cpp-spanner"
+  fi
+  readonly DOCKER_IMAGE_PREFIX
+
+  IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_IMAGE_BASENAME}"
+  README_IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_README_IMAGE_BASENAME}"
+  INSTALL_IMAGE="${DOCKER_IMAGE_PREFIX}/${DOCKER_INSTALL_IMAGE_BASENAME}"
+  readonly IMAGE
+  readonly README_IMAGE
+  readonly README_INSTALL_IMAGE
+
+  BUILD_OUTPUT="cmake-out/${DOCKER_IMAGE_BASENAME}"
+  BUILD_HOME="cmake-out/home/${DOCKER_IMAGE_BASENAME}"
+  if [[ -n "${BUILD_NAME:-}" ]]; then
+    BUILD_OUTPUT="${BUILD_OUTPUT}-${BUILD_NAME}"
+    BUILD_HOME="${BUILD_HOME}-${BUILD_NAME}"
+  fi
+  readonly BUILD_OUTPUT
+  readonly BUILD_NAME
 fi

--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -43,63 +43,86 @@ else
  exit 1
 fi
 
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
+fi
+source "${PROJECT_ROOT}/ci/kokoro/define-docker-variables.sh"
+
 echo "================================================================"
 echo "Change working directory to project root $(date)."
-cd "$(dirname "$0")/../../.."
+cd "${PROJECT_ROOT}"
 
-# TODO: this is a watered down version of
-# google-cloud-cpp/ci/kokoro/install/build.sh with the functionality related to
-# caching the image and uploading to gcr removed. We want to add that
-# eventually.
+echo "================================================================"
+echo "Building with ${NCPU} cores $(date) on ${PWD}."
+
+echo "================================================================"
+echo "Load Google Container Registry configuration parameters $(date)."
+
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
+  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
+fi
+
+echo "================================================================"
+echo "Setup Google Container Registry access $(date)."
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-service-account.json" ]]; then
+  gcloud auth activate-service-account --key-file \
+    "${KOKORO_GFILE_DIR}/gcr-service-account.json"
+fi
+gcloud auth configure-docker
+
+echo "================================================================"
+echo "Download existing image (if available) for ${DISTRO} $(date)."
+has_cache="false"
+if docker pull "${INSTALL_IMAGE}:latest"; then
+  echo "Existing image successfully downloaded."
+  has_cache="true"
+fi
+
 echo "================================================================"
 echo "Build base image with minimal development tools for ${DISTRO} $(date)."
-
-
-readonly DEV_IMAGE="test-install-${DISTRO}"
+update_cache="false"
 
 devtools_flags=(
   # Only build up to the stage that installs the minimal development tools, but
   # does not compile any of our code.
   "--target" "devtools"
-  # Create the image with the same tag as the cache we are using.
-  "-t" "${DEV_IMAGE}:latest"
+  # Create the image with the same tag as the cache we are using, so we can
+  # upload it.
+  "-t" "${INSTALL_IMAGE}:latest"
+  "--build-arg" "NCPU=${NCPU}"
   "-f" "ci/kokoro/install/Dockerfile.${DISTRO}"
 )
 
+if "${has_cache}"; then
+  devtools_flags+=("--cache-from=${INSTALL_IMAGE}:latest")
+fi
+
+if [[ "${RUNNING_CI:-}" == "yes" ]] && \
+   [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
+  devtools_flags+=("--no-cache")
+fi
+
 echo "Running docker build with " "${devtools_flags[@]}"
-docker build "${devtools_flags[@]}" ci
+if docker build "${devtools_flags[@]}" ci; then
+   update_cache="true"
+fi
+
+if "${update_cache}" && [[ "${RUNNING_CI:-}" == "yes" ]] &&
+   [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]]; then
+  echo "================================================================"
+  echo "Uploading updated base image for ${DISTRO} $(date)."
+  # Do not stop the build on a failure to update the cache.
+  docker push "${INSTALL_IMAGE}:latest" || true
+fi
 
 echo "================================================================"
 echo "Run validation script for INSTALL instructions on ${DISTRO}."
-RUN_IMAGE="spanci-test-install-full-${DISTRO}:latest"
-readonly RUN_IMAGE
-docker build -t "${RUN_IMAGE}" \
-  "--cache-from=${DEV_IMAGE}:latest" \
+readonly INSTALL_RUN_IMAGE="${DOCKER_IMAGE_PREFIX}/ci-install-runtime-${DISTRO}"
+docker build -t "${INSTALL_RUN_IMAGE}" \
+  "--cache-from=${INSTALL_IMAGE}:latest" \
   "--target=install" \
+  "--build-arg" "NCPU=${NCPU}" \
   -f "ci/kokoro/install/Dockerfile.${DISTRO}" .
 echo "================================================================"
 
-CONFIG_DIRECTORY="${KOKORO_GFILE_DIR:-/dev/shm}"
-readonly CONFIG_DIRECTORY
-if [[ -f "${CONFIG_DIRECTORY}/spanner-integration-tests-config.sh" ]]; then
-  source "${CONFIG_DIRECTORY}/spanner-integration-tests-config.sh"
-
-  run_args=(
-    # Remove the container after running
-    "--rm"
-
-    # Set the environment variables for the test program.
-    "--env" "GOOGLE_APPLICATION_CREDENTIALS=/c/spanner-credentials.json"
-    "--env" "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}"
-    "--env" "RUN_SLOW_INTEGRATION_TESTS=${RUN_SLOW_INTEGRATION_TESTS}"
-    "--env" "GOOGLE_CLOUD_CPP_SPANNER_INSTANCE=${GOOGLE_CLOUD_CPP_SPANNER_INSTANCE}"
-    "--env" "GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA=${GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA}"
-
-    # Mount the config directory as a volumne in `/c`
-    "--volume" "${CONFIG_DIRECTORY}:/c"
-  )
-  echo "================================================================"
-  echo "Run test program against installed libraries ${DISTRO}."
-  docker run "${run_args[@]}" "${RUN_IMAGE}" "/o/spanner_install_test"
-  echo "================================================================"
-fi
+source "${PROJECT_ROOT}/ci/etc/kokoro/install/run-installed-programs.sh"


### PR DESCRIPTION
We are trying to make the build scripts automatically generated, this PR
makes the `ci/kokoro/install/build.sh` script look more like the script
in g-c-cpp-common, so we can automatically generate it soon-ish.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/987)
<!-- Reviewable:end -->
