### PR TITLE
feat: add efficient move support to mutation builder temporaries

### DIFF
--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -339,9 +339,9 @@ TEST(MutationsTest, FluentInsertBuilder) {
   std::string const data(128, 'x');
   std::string blob = data;
   Mutation m = InsertMutationBuilder("table-name", {"col_a"})
-                        .EmplaceRow(std::move(blob))
-                        .AddRow({Value(data)})
-                        .Build();
+                   .EmplaceRow(std::move(blob))
+                   .AddRow({Value(data)})
+                   .Build();
   auto actual = std::move(m).as_proto();
   EXPECT_EQ(2, actual.insert().values().size());
   EXPECT_EQ(data, actual.insert().values(0).values(0).string_value());
@@ -359,9 +359,9 @@ TEST(MutationsTest, FluentUpdateBuilder) {
   std::string const data(128, 'x');
   std::string blob = data;
   Mutation m = UpdateMutationBuilder("table-name", {"col_a"})
-                        .EmplaceRow(std::move(blob))
-                        .AddRow({Value(data)})
-                        .Build();
+                   .EmplaceRow(std::move(blob))
+                   .AddRow({Value(data)})
+                   .Build();
   auto actual = std::move(m).as_proto();
   EXPECT_EQ(2, actual.update().values().size());
   EXPECT_EQ(data, actual.update().values(0).values(0).string_value());

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -22,6 +22,8 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 namespace google {
@@ -314,6 +316,108 @@ TEST(MutationsTest, DeleteSimple) {
   EXPECT_NE(dele, empty);
 
   auto actual = std::move(dele).as_proto();
+  spanner_proto::Mutation expected;
+  ASSERT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        delete: {
+          table: "table-name"
+          key_set: { keys: { values { string_value: "key-to-delete" } } }
+        }
+      )pb",
+      &expected));
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
+TEST(MutationsTest, FluentInsertBuilder) {
+  static_assert(
+      std::is_rvalue_reference<decltype(std::declval<InsertMutationBuilder>()
+                                            .EmplaceRow()
+                                            .AddRow({})
+                                            .Build())>::value,
+      "Build() should return an rvalue if called fluently on a temporary");
+
+  std::string const data(128, 'x');
+  std::string blob = data;
+  Mutation m = InsertMutationBuilder("table-name", {"col_a"})
+                        .EmplaceRow(std::move(blob))
+                        .AddRow({Value(data)})
+                        .Build();
+  auto actual = std::move(m).as_proto();
+  EXPECT_EQ(2, actual.insert().values().size());
+  EXPECT_EQ(data, actual.insert().values(0).values(0).string_value());
+  EXPECT_EQ(data, actual.insert().values(1).values(0).string_value());
+}
+
+TEST(MutationsTest, FluentUpdateBuilder) {
+  static_assert(
+      std::is_rvalue_reference<decltype(std::declval<UpdateMutationBuilder>()
+                                            .EmplaceRow()
+                                            .AddRow({})
+                                            .Build())>::value,
+      "Build() should return an rvalue if called fluently on a temporary");
+
+  std::string const data(128, 'x');
+  std::string blob = data;
+  Mutation m = UpdateMutationBuilder("table-name", {"col_a"})
+                        .EmplaceRow(std::move(blob))
+                        .AddRow({Value(data)})
+                        .Build();
+  auto actual = std::move(m).as_proto();
+  EXPECT_EQ(2, actual.update().values().size());
+  EXPECT_EQ(data, actual.update().values(0).values(0).string_value());
+  EXPECT_EQ(data, actual.update().values(1).values(0).string_value());
+}
+
+TEST(MutationsTest, FluentInsertOrUpdateBuilder) {
+  static_assert(
+      std::is_rvalue_reference<decltype(
+          std::declval<InsertOrUpdateMutationBuilder>()
+              .EmplaceRow()
+              .AddRow({})
+              .Build())>::value,
+      "Build() should return an rvalue if called fluently on a temporary");
+
+  std::string const data(128, 'x');
+  std::string blob = data;
+  Mutation m = InsertOrUpdateMutationBuilder("table-name", {"col_a"})
+                   .EmplaceRow(std::move(blob))
+                   .AddRow({Value(data)})
+                   .Build();
+  auto actual = std::move(m).as_proto();
+  EXPECT_EQ(2, actual.insert_or_update().values().size());
+  EXPECT_EQ(data, actual.insert_or_update().values(0).values(0).string_value());
+  EXPECT_EQ(data, actual.insert_or_update().values(1).values(0).string_value());
+}
+
+TEST(MutationsTest, FluentReplaceBuilder) {
+  static_assert(
+      std::is_rvalue_reference<decltype(std::declval<ReplaceMutationBuilder>()
+                                            .EmplaceRow()
+                                            .AddRow({})
+                                            .Build())>::value,
+      "Build() should return an rvalue if called fluently on a temporary");
+
+  std::string const data(128, 'x');
+  std::string blob = data;
+  Mutation m = ReplaceMutationBuilder("table-name", {"col_a"})
+                   .EmplaceRow(std::move(blob))
+                   .AddRow({Value(data)})
+                   .Build();
+  auto actual = std::move(m).as_proto();
+  EXPECT_EQ(2, actual.replace().values().size());
+  EXPECT_EQ(data, actual.replace().values(0).values(0).string_value());
+  EXPECT_EQ(data, actual.replace().values(1).values(0).string_value());
+}
+
+TEST(MutationsTest, FluentDeleteBuilder) {
+  static_assert(
+      std::is_rvalue_reference<decltype(
+          std::declval<DeleteMutationBuilder>().Build())>::value,
+      "Build() should return an rvalue if called fluently on a temporary");
+
+  auto ks = KeySet().AddKey(MakeKey("key-to-delete"));
+  Mutation m = DeleteMutationBuilder("table-name", ks).Build();
+  auto actual = std::move(m).as_proto();
   spanner_proto::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(


### PR DESCRIPTION
Fixes: #379 

Most of the testing for this is done via `static_assert`s that ensure that a chain of method calls results in a call to `.Build()` that returns an rvalue. That ensures that the right functions are being called. Then I actually call the code and test that it works, but this part of the test doesn't really verify that moving happened, just that the code path works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/989)
<!-- Reviewable:end -->
