### PR TITLE
bug: only install the required headers

### DIFF
--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -123,6 +123,23 @@ if [[ "${TEST_INSTALL:-}" = "yes" ]]; then
     echo "Running the test install $(date)"
     echo "================================================================"
     cmake --build "${BINARY_DIR}" --target install || echo "FAILED"
+
+    # Verify only the expected directories are created in the install directory.
+    echo
+    echo "${COLOR_YELLOW}Verify installed headers created only" \
+        " expected directories.${COLOR_RESET}"
+    if comm -23 \
+        <(find "$HOME/staging/include/google/cloud" -type d | sort) \
+        <(echo "$HOME/staging/include/google/cloud" ; \
+          echo "$HOME/staging/include/google/cloud/spanner" ; \
+          echo "$HOME/staging/include/google/cloud/spanner/internal" ; \
+          /bin/true) | grep -q "$HOME"; then
+        echo "${COLOR_YELLOW}Installed directories do not match expectation.${COLOR_RESET}"
+        echo "${COLOR_RED}Found:"
+        find "$HOME/staging/include/google/cloud" -type d | sort
+        echo "${COLOR_RESET}"
+        /bin/false
+    fi
 fi
 
 echo "================================================================"

--- a/cmake/GoogleCloudCppSpannerFunctions.cmake
+++ b/cmake/GoogleCloudCppSpannerFunctions.cmake
@@ -21,3 +21,27 @@ function (google_cloud_cpp_test_name_to_target var fname)
         "${target}"
         PARENT_SCOPE)
 endfunction ()
+
+#
+# google_cloud_cpp_install_headers : install all the headers in a target
+#
+# Find all the headers in @p target and install them at @p destination,
+# preserving the directory structure.
+#
+# * target the name of the target.
+# * destination the destination directory, relative to <PREFIX>. Typically this
+#   starts with `include/google/cloud`, the function requires the full
+#   destination in case some headers get installed elsewhere in the future.
+#
+function (google_cloud_cpp_install_headers target destination)
+    get_target_property(target_sources ${target} SOURCES)
+    foreach (header ${target_sources})
+        if (NOT "${header}" MATCHES "\\.h$" AND NOT "${header}" MATCHES
+                                                "\\.inc$")
+            continue()
+        endif ()
+        string(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/" "" relative "${header}")
+        get_filename_component(dir "${relative}" DIRECTORY)
+        install(FILES "${header}" DESTINATION "${destination}/${dir}")
+    endforeach ()
+endfunction ()

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -417,18 +417,8 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT google_cloud_cpp_spanner_development)
 
-install(
-    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
-    DESTINATION include/google/cloud/spanner
-    COMPONENT google_cloud_cpp_spanner_development
-    FILES_MATCHING
-    PATTERN "*.h")
-install(
-    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
-    DESTINATION include/google/cloud/spanner
-    COMPONENT google_cloud_cpp_spanner_development
-    FILES_MATCHING
-    PATTERN "*.inc")
+google_cloud_cpp_install_headers("spanner_client"
+                                 "include/google/cloud/spanner")
 
 # Setup global variables used in the following *.in files.
 set(GOOGLE_CLOUD_SPANNER_CONFIG_VERSION_MAJOR ${SPANNER_CLIENT_VERSION_MAJOR})


### PR DESCRIPTION
The install rule was creating unexpected directories in the
`$PREFIX/include` path, such as
`google/cloud/spanner/integration_tests`. Fixed the install rules to
only install the headers associated with specific targets.

Fixes #926

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/993)
<!-- Reviewable:end -->
