### PR TITLE
chore: add issue template for spanner

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Answering these questions before submitting your bug report will help us give you a quicker answer. Thank you!
+
+If one or more of these questions are not applicable, feel free to remove them.
+
+### Does this issue affect the `google-cloud-cpp-spanner` project?
+
+If the problem is with the service exposed by the `google-cloud-cpp-spanner` APIs instead of the client libraries you may consider opening a support request instead. The `google-cloud-cpp-spanner` developers cannot help you troubleshoot problems with the service itself.
+
+### What version of `google-cloud-cpp-spanner` are you using?
+
+Please include the output from `git rev-parse HEAD` if you are compiling from source, or the version number from the applicable `*/version.h` file.
+
+### What compiler and version are you using?
+
+Please include the output of `g++ -v` or the equivalent command-line flag.
+
+### What operating system and version are you using?
+
+If you are using a Linux distribution include the name and version of the distribution too.
+
+### What were you trying to do?
+
+If possible, produce a recipe for reproducing the problem.
+
+### What did you expect to see?
+
+What was the behavior you expected from the library?
+
+### What did you see instead?
+
+What was the behavior you actually observed?
+
+### Anything else you would like us to know?
+
+Include here information about your environment that is not captured above, or any other information you think might be relevant.


### PR DESCRIPTION
This is using the "new workflow" from the github UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/998)
<!-- Reviewable:end -->
