### PR TITLE
docs: document additional flags needed for macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# gRPC requires this flag on macOS builds, and there is (AFAIK) no way
-# to "inherit" their definitions.
+# To workaround a bug in Bazel [1], gRPC requires this flag on macOS builds,
+# and there is (AFAIK) no way to "inherit" their definitions.
+#   [1]: https://github.com/bazelbuild/bazel/issues/4341
 build --copt=-DGRPC_BAZEL_BUILD
 
 # Clang Sanitizers, use with (for example):

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# gRPC requires this flag on macOS builds, and there is (AFAIK) no way
+# to "inherit" their definitions.
+build --copt=-DGRPC_BAZEL_BUILD
+
 # Clang Sanitizers, use with (for example):
 #
 # --client_env=CXX=clang++ --client_env=CC=clang --config asan

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,7 +110,10 @@ cc_binary(
 
 ### Building with Bazel on macOS
 
-gRPC requires a command-line flag when compiled using Bazel on macOS:
+To workaround a bug in Bazel ([bazelbuild/bazel#4341][bazel-bug-4341-link]) gRPC needs a
+command-line flag when compiled using Bazel on macOS:
+
+[bazel-bug-4341]: https://github.com/bazelbuild/bazel/issues/4341
 
 ```bash
 bazel build --copt=-DGRPC_BAZEL_BUILD ...

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,6 +108,16 @@ cc_binary(
 )
 ```
 
+### Building with Bazel on macOS
+
+gRPC requires a command-line flag when compiled using Bazel on macOS:
+
+```bash
+bazel build --copt=-DGRPC_BAZEL_BUILD ...
+```
+
+Consider adding this option to your project's `.bazelrc` file.
+
 ## Required Libraries
 
 `google-cloud-cpp` directly depends on the following libraries:

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -128,6 +128,16 @@ cc_binary(
 )
 ```
 
+### Building with Bazel on macOS
+
+gRPC requires a command-line flag when compiled using Bazel on macOS:
+
+```bash
+bazel build --copt=-DGRPC_BAZEL_BUILD ...
+```
+
+Consider adding this option to your project's `.bazelrc` file.
+
 ## Required Libraries
 
 `google-cloud-cpp` directly depends on the following libraries:

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -130,7 +130,10 @@ cc_binary(
 
 ### Building with Bazel on macOS
 
-gRPC requires a command-line flag when compiled using Bazel on macOS:
+To workaround a bug in Bazel ([bazelbuild/bazel#4341][bazel-bug-4341-link]) gRPC needs a
+command-line flag when compiled using Bazel on macOS:
+
+[bazel-bug-4341]: https://github.com/bazelbuild/bazel/issues/4341
 
 ```bash
 bazel build --copt=-DGRPC_BAZEL_BUILD ...


### PR DESCRIPTION
gRPC requires an additional flag to compile with Bazel. I chose to
both document this *and* set it on our .bazelrc. Note that users will
need to set this flag on their own .bazelrc.

Fixes #1003

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1005)
<!-- Reviewable:end -->
