### PR TITLE
cleanup: ensure policies are not modified before use

### DIFF
--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -341,9 +341,9 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
   }
 
   std::shared_ptr<internal::DatabaseAdminStub> stub_;
-  std::unique_ptr<RetryPolicy> retry_policy_;
-  std::unique_ptr<BackoffPolicy> backoff_policy_;
-  std::unique_ptr<PollingPolicy> polling_policy_;
+  std::unique_ptr<RetryPolicy const> retry_policy_;
+  std::unique_ptr<BackoffPolicy const> backoff_policy_;
+  std::unique_ptr<PollingPolicy const> polling_policy_;
 };
 }  // namespace
 

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -321,9 +321,9 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
     return f;
   }
   std::shared_ptr<internal::InstanceAdminStub> stub_;
-  std::unique_ptr<RetryPolicy> retry_policy_;
-  std::unique_ptr<BackoffPolicy> backoff_policy_;
-  std::unique_ptr<PollingPolicy> polling_policy_;
+  std::unique_ptr<RetryPolicy const> retry_policy_;
+  std::unique_ptr<BackoffPolicy const> backoff_policy_;
+  std::unique_ptr<PollingPolicy const> polling_policy_;
 };
 }  // namespace
 

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -157,8 +157,8 @@ class ConnectionImpl : public Connection {
 
   Database db_;
   std::shared_ptr<SpannerStub> stub_;
-  std::shared_ptr<RetryPolicy> retry_policy_;
-  std::shared_ptr<BackoffPolicy> backoff_policy_;
+  std::shared_ptr<RetryPolicy const> retry_policy_;
+  std::shared_ptr<BackoffPolicy const> backoff_policy_;
   std::shared_ptr<SessionPool> session_pool_;
 };
 


### PR DESCRIPTION
Making the policy member variables `const` ensures that we call `clone` prior to using them, so we can't perturb the initial state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1019)
<!-- Reviewable:end -->
