### PR TITLE
feat: split `ConnectionImpl` and `SessionPool` cleanly

### DIFF
--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -14,10 +14,12 @@
 
 #include "google/cloud/spanner/internal/session_pool.h"
 #include "google/cloud/spanner/internal/session.h"
+#include "google/cloud/spanner/testing/mock_spanner_stub.h"
 #include "google/cloud/internal/make_unique.h"
 #include "google/cloud/status.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
@@ -30,150 +32,150 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
+using ::testing::_;
 using ::testing::ByMove;
+using ::testing::HasSubstr;
+using ::testing::Invoke;
 using ::testing::Return;
 
-class MockSessionManager : public SessionManager {
- public:
-  MOCK_METHOD1(CreateSessions,
-               StatusOr<std::vector<std::unique_ptr<Session>>>(int));
-};
+namespace spanner_proto = ::google::spanner::v1;
 
-// Helper to build a vector of Sessions.
-std::vector<std::unique_ptr<Session>> MakeSessions(
-    std::vector<std::string> session_names) {
-  std::vector<std::unique_ptr<Session>> ret;
-  ret.reserve(session_names.size());
-  for (auto& name : session_names) {
-    ret.push_back(
-        google::cloud::internal::make_unique<Session>(std::move(name)));
+// Matches a BatchCreateSessionsRequest with the specified `session_count`.
+MATCHER_P(SessionCountIs, session_count,
+          "BatchCreateSessionsRequest has expected session_count") {
+  return arg.session_count() == session_count;
+}
+
+// Create a response with the given `sessions`
+spanner_proto::BatchCreateSessionsResponse MakeSessionsResponse(
+    std::vector<std::string> sessions) {
+  spanner_proto::BatchCreateSessionsResponse response;
+  for (auto& session : sessions) {
+    response.add_session()->set_name(std::move(session));
   }
-  return ret;
+  return response;
+}
+
+std::shared_ptr<SessionPool> MakeSessionPool(
+    Database db, std::shared_ptr<SpannerStub> stub,
+    SessionPoolOptions options = SessionPoolOptions()) {
+  return std::make_shared<SessionPool>(
+      std::move(db), std::move(stub),
+      google::cloud::internal::make_unique<LimitedTimeRetryPolicy>(
+          std::chrono::minutes(10)),
+      google::cloud::internal::make_unique<ExponentialBackoffPolicy>(
+          std::chrono::milliseconds(100), std::chrono::minutes(1), 2.0),
+      options);
 }
 
 TEST(SessionPool, Allocate) {
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
-  EXPECT_CALL(*mock, CreateSessions(1))
-      .WillOnce(Return(ByMove(MakeSessions({"session1"}))));
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+      .WillOnce(Invoke(
+          [&db](grpc::ClientContext&,
+                spanner_proto::BatchCreateSessionsRequest const& request) {
+            EXPECT_EQ(db.FullName(), request.database());
+            EXPECT_EQ(1, request.session_count());
+            return MakeSessionsResponse({"session1"});
+          }));
 
-  SessionPool pool(mock.get());
-  auto session = pool.Allocate();
+  auto pool = MakeSessionPool(db, mock);
+  auto session = pool->Allocate();
   ASSERT_STATUS_OK(session);
   EXPECT_EQ((*session)->session_name(), "session1");
-}
-
-TEST(SessionPool, CreateResourceExhaustedRetry) {
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
-  EXPECT_CALL(*mock, CreateSessions(1))
-      .WillOnce(
-          Return(ByMove(Status(StatusCode::kResourceExhausted, "no sessions"))))
-      .WillOnce(Return(ByMove(MakeSessions({"session1"}))));
-
-  SessionPool pool(mock.get());
-  auto session = pool.Allocate();
-  ASSERT_STATUS_OK(session);
-  EXPECT_EQ((*session)->session_name(), "session1");
-}
-
-TEST(SessionPool, CreateResourceExhaustedFail) {
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
-  EXPECT_CALL(*mock, CreateSessions(1))
-      .WillOnce(Return(
-          ByMove(Status(StatusCode::kResourceExhausted, "no sessions"))));
-
-  SessionPoolOptions options;
-  options.action_on_exhaustion = ActionOnExhaustion::FAIL;
-  SessionPool pool(mock.get(), options);
-  auto session = pool.Allocate();
-  EXPECT_EQ(session.status().code(), StatusCode::kResourceExhausted);
-  EXPECT_EQ(session.status().message(), "session pool exhausted");
 }
 
 TEST(SessionPool, CreateError) {
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
-  EXPECT_CALL(*mock, CreateSessions(1))
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(ByMove(Status(StatusCode::kInternal, "some failure"))));
 
-  SessionPool pool(mock.get());
-  auto session = pool.Allocate();
+  auto pool = MakeSessionPool(db, mock);
+  auto session = pool->Allocate();
   EXPECT_EQ(session.status().code(), StatusCode::kInternal);
-  EXPECT_EQ(session.status().message(), "some failure");
+  EXPECT_THAT(session.status().message(), HasSubstr("some failure"));
 }
 
 TEST(SessionPool, ReuseSession) {
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
-  EXPECT_CALL(*mock, CreateSessions(1))
-      .WillOnce(Return(ByMove(MakeSessions({"session1"}))));
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"session1"}))));
 
-  SessionPool pool(mock.get());
-  auto session = pool.Allocate();
+  auto pool = MakeSessionPool(db, mock);
+  auto session = pool->Allocate();
   ASSERT_STATUS_OK(session);
   EXPECT_EQ((*session)->session_name(), "session1");
-  pool.Release(*std::move(session));
+  session->reset();
 
-  auto session2 = pool.Allocate();
+  auto session2 = pool->Allocate();
   ASSERT_STATUS_OK(session2);
   EXPECT_EQ((*session2)->session_name(), "session1");
-  pool.Release(*std::move(session2));
 }
 
 TEST(SessionPool, Lifo) {
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
-  EXPECT_CALL(*mock, CreateSessions(1))
-      .WillOnce(Return(ByMove(MakeSessions({"session1"}))))
-      .WillOnce(Return(ByMove(MakeSessions({"session2"}))));
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"session1"}))))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"session2"}))));
 
-  SessionPool pool(mock.get());
-  auto session = pool.Allocate();
+  auto pool = MakeSessionPool(db, mock);
+  auto session = pool->Allocate();
   ASSERT_STATUS_OK(session);
   EXPECT_EQ((*session)->session_name(), "session1");
 
-  auto session2 = pool.Allocate();
+  auto session2 = pool->Allocate();
   ASSERT_STATUS_OK(session2);
   EXPECT_EQ((*session2)->session_name(), "session2");
 
-  pool.Release(*std::move(session));
-  pool.Release(*std::move(session2));
+  session->reset();
+  session2->reset();
 
   // The pool is Last-In-First-Out (LIFO), so we expect to get the sessions
   // back in the reverse order they were released.
-  auto session3 = pool.Allocate();
+  auto session3 = pool->Allocate();
   ASSERT_STATUS_OK(session3);
   EXPECT_EQ((*session3)->session_name(), "session2");
 
-  auto session4 = pool.Allocate();
+  auto session4 = pool->Allocate();
   ASSERT_STATUS_OK(session4);
   EXPECT_EQ((*session4)->session_name(), "session1");
 }
 
 TEST(SessionPool, MinSessionsEagerAllocation) {
   const int min_sessions = 3;
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
-  EXPECT_CALL(*mock, CreateSessions(min_sessions))
-      .WillOnce(Return(ByMove(MakeSessions({"s3", "s2", "s1"}))));
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"s3", "s2", "s1"}))));
 
   SessionPoolOptions options;
   options.min_sessions = min_sessions;
-  SessionPool pool(mock.get(), options);
+  auto pool = MakeSessionPool(db, mock, options);
+  auto session = pool->Allocate();
 }
 
 TEST(SessionPool, MinSessionsMultipleAllocations) {
   const int min_sessions = 3;
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto db = Database("project", "instance", "database");
   // The constructor will make this call.
-  EXPECT_CALL(*mock, CreateSessions(min_sessions))
-      .WillOnce(Return(ByMove(MakeSessions({"s3", "s2", "s1"}))));
+  EXPECT_CALL(*mock, BatchCreateSessions(_, SessionCountIs(min_sessions)))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"s3", "s2", "s1"}))));
 
   SessionPoolOptions options;
   options.min_sessions = min_sessions;
-  SessionPool pool(mock.get(), options);
+  auto pool = MakeSessionPool(db, mock, options);
 
   // When we run out of sessions it will make this call.
-  EXPECT_CALL(*mock, CreateSessions(min_sessions + 1))
-      .WillOnce(Return(ByMove(MakeSessions({"s7", "s6", "s5", "s4"}))));
-  std::vector<std::unique_ptr<Session>> sessions;
+  EXPECT_CALL(*mock, BatchCreateSessions(_, SessionCountIs(min_sessions + 1)))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"s7", "s6", "s5", "s4"}))));
+  std::vector<SessionHolder> sessions;
   for (int i = 1; i <= 7; ++i) {
-    auto session = pool.Allocate();
+    auto session = pool->Allocate();
     ASSERT_STATUS_OK(session);
     EXPECT_EQ((*session)->session_name(), "s" + std::to_string(i));
     sessions.push_back(*std::move(session));
@@ -182,50 +184,52 @@ TEST(SessionPool, MinSessionsMultipleAllocations) {
 
 TEST(SessionPool, MaxSessionsFailOnExhaustion) {
   const int max_sessions = 3;
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
-  EXPECT_CALL(*mock, CreateSessions(1))
-      .WillOnce(Return(ByMove(MakeSessions({"s1"}))))
-      .WillOnce(Return(ByMove(MakeSessions({"s2"}))))
-      .WillOnce(Return(ByMove(MakeSessions({"s3"}))));
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"s1"}))))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"s2"}))))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"s3"}))));
 
   SessionPoolOptions options;
   options.max_sessions = max_sessions;
   options.action_on_exhaustion = ActionOnExhaustion::FAIL;
-  SessionPool pool(mock.get(), options);
-  std::vector<std::unique_ptr<Session>> sessions;
+  auto pool = MakeSessionPool(db, mock, options);
+  std::vector<SessionHolder> sessions;
   for (int i = 1; i <= 3; ++i) {
-    auto session = pool.Allocate();
+    auto session = pool->Allocate();
     ASSERT_STATUS_OK(session);
     EXPECT_EQ((*session)->session_name(), "s" + std::to_string(i));
     sessions.push_back(*std::move(session));
   }
-  auto session = pool.Allocate();
+  auto session = pool->Allocate();
   EXPECT_EQ(session.status().code(), StatusCode::kResourceExhausted);
   EXPECT_EQ(session.status().message(), "session pool exhausted");
 }
 
 TEST(SessionPool, MaxSessionsBlockUntilRelease) {
   const int max_sessions = 1;
-  auto mock = google::cloud::internal::make_unique<MockSessionManager>();
-  EXPECT_CALL(*mock, CreateSessions(1))
-      .WillOnce(Return(ByMove(MakeSessions({"s1"}))));
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto db = Database("project", "instance", "database");
+  EXPECT_CALL(*mock, BatchCreateSessions(_, _))
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"s1"}))));
 
   SessionPoolOptions options;
   options.max_sessions = max_sessions;
   options.action_on_exhaustion = ActionOnExhaustion::BLOCK;
-  SessionPool pool(mock.get(), options);
-  auto session = pool.Allocate();
+  auto pool = MakeSessionPool(db, mock, options);
+  auto session = pool->Allocate();
   ASSERT_STATUS_OK(session);
   EXPECT_EQ((*session)->session_name(), "s1");
 
   // This thread will block in Allocate() until the main thread releases s1.
   std::thread t([&pool]() {
-    auto session = pool.Allocate();
+    auto session = pool->Allocate();
     ASSERT_STATUS_OK(session);
     EXPECT_EQ((*session)->session_name(), "s1");
   });
 
-  pool.Release(*std::move(session));
+  session->reset();
   t.join();
 }
 


### PR DESCRIPTION
Remove the circular dependency between `ConnectionImpl` and
`SessionPool`. The latter can now make RPCs directly instead of
having to call back through the `SessionManager` interface.

The `SessionHolder` deleter also now calls directly into `SessionPool`
so we don't need to forward those calls from `ConnectionImpl`.

I also removed the tests where `BatchCreateSessions` returned
`RESOURCE_EXHAUSTED` since we learned from spanner team that will never
happen (since there are no longer server-side session limits), and the tests
conflicted with our retry policy.

Part of #307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1022)
<!-- Reviewable:end -->
