### PR TITLE
refactor: factor Session preparation to a helper

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -88,6 +88,9 @@ class ConnectionImpl : public Connection {
                  std::unique_ptr<RetryPolicy> retry_policy,
                  std::unique_ptr<BackoffPolicy> backoff_policy);
 
+  Status PrepareSession(SessionHolder& session,
+                        bool dissociate_from_pool = false);
+
   RowStream ReadImpl(SessionHolder& session,
                      google::spanner::v1::TransactionSelector& s,
                      ReadParams params);


### PR DESCRIPTION
This will facilitate some upcoming Session/Stub-related changes.

I also added another helper to help build a result with a `StatusOnlyResultSetSource`.

One subtler change is instead of doing `Session` preparation inside `ExecuteSqlImpl` we now do it in its two callers (`CommonQueryImpl` and `CommonDmlImpl`), that will also facilitate additional changes involving stubs (which are used in the body of the latter two methods).

Part of #307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1037)
<!-- Reviewable:end -->
