### PR TITLE
feat: associate `SpannerStub` with a `Session`

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -159,7 +159,6 @@ class ConnectionImpl : public Connection {
       google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode);
 
   Database db_;
-  std::shared_ptr<SpannerStub> stub_;
   std::shared_ptr<RetryPolicy const> retry_policy_prototype_;
   std::shared_ptr<BackoffPolicy const> backoff_policy_prototype_;
   std::shared_ptr<SessionPool> session_pool_;

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_SESSION_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_SESSION_H_
 
+#include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/version.h"
 #include <functional>
 #include <memory>
@@ -32,8 +33,8 @@ namespace internal {
  */
 class Session {
  public:
-  Session(std::string session_name) noexcept
-      : session_name_(std::move(session_name)) {}
+  Session(std::string session_name, std::shared_ptr<SpannerStub> stub) noexcept
+      : session_name_(std::move(session_name)), stub_(std::move(stub)) {}
 
   // Not copyable or moveable.
   Session(Session const&) = delete;
@@ -42,9 +43,12 @@ class Session {
   Session& operator=(Session&&) = delete;
 
   std::string const& session_name() const { return session_name_; }
+  std::shared_ptr<SpannerStub> stub() const { return stub_; }
+  void set_stub(std::shared_ptr<SpannerStub> stub) { stub_ = stub; }
 
  private:
   std::string session_name_;
+  std::shared_ptr<SpannerStub> stub_;
 };
 
 /**

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -122,6 +122,11 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
    */
   StatusOr<SessionHolder> Allocate(bool dissociate_from_pool = false);
 
+  /**
+   * Assign a `SpannerStub` to `session` if it doesn't already have one.
+   */
+  void AssignStubIfNeeded(SessionHolder& session);
+
  private:
   /**
    * Release session back to the pool.

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -233,6 +233,18 @@ TEST(SessionPool, MaxSessionsBlockUntilRelease) {
   t.join();
 }
 
+TEST(SessionPool, AssignStubIfNeeded) {
+  auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
+  auto db = Database("project", "instance", "database");
+  auto pool = MakeSessionPool(db, mock);
+  auto session = MakeDissociatedSessionHolder("session_id", /*stub=*/nullptr);
+  EXPECT_EQ(session->stub(), nullptr);
+  pool->AssignStubIfNeeded(session);
+  EXPECT_EQ(session->stub(), mock);
+  pool->AssignStubIfNeeded(session);
+  EXPECT_EQ(session->stub(), mock);
+}
+
 }  // namespace
 }  // namespace internal
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -132,7 +132,8 @@ ResultSet Client::Read(SessionHolder& session, TransactionSelector& selector,
     }
     switch (mode_) {
       case Mode::kReadSucceeds:  // `begin` -> `id`, calls now parallelized
-        session = internal::MakeDissociatedSessionHolder(session_id_);
+        session = internal::MakeDissociatedSessionHolder(session_id_,
+                                                         /*stub=*/nullptr);
         selector.set_id(txn_id_);
         break;
       case Mode::kReadFails:  // leave as `begin`, calls stay serialized

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -97,7 +97,7 @@ Transaction::Transaction(std::string session_id, std::string transaction_id) {
   google::spanner::v1::TransactionSelector selector;
   selector.set_id(std::move(transaction_id));
   impl_ = std::make_shared<internal::TransactionImpl>(
-      internal::MakeDissociatedSessionHolder(std::move(session_id)),
+      internal::MakeDissociatedSessionHolder(std::move(session_id), nullptr),
       std::move(selector));
 }
 


### PR DESCRIPTION
`SessionPool` manages assigning a `SpannerStub` to each `Session`
`ConnectionImpl` obtains the stub to use for a call from the `Session`
and no longer retains any knowledge of the stub.

This will enable the use of multiple stubs per `Connection`; it's
important for a `Session` to remain associated with the stub/channel
that created it, otherwise there is a performance penalty.

Part of #307