### PR TITLE
bug: fix list of benchmarks in build

### DIFF
--- a/google/cloud/spanner/benchmarks/CMakeLists.txt
+++ b/google/cloud/spanner/benchmarks/CMakeLists.txt
@@ -46,7 +46,7 @@ function (spanner_client_define_benchmarks)
                          "spanner_client_benchmarks")
 
     # Generate a target for each benchmark.
-    foreach (fname ${spanner_client_integration_tests})
+    foreach (fname ${spanner_client_benchmarks})
         google_cloud_cpp_test_name_to_target(target "${fname}")
         add_executable(${target} ${fname})
         target_link_libraries(


### PR DESCRIPTION
My previous refactoring was wrong, I use the wrong variable, which went
undetected because things that are not built do not generate errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1044)
<!-- Reviewable:end -->
