### PR TITLE
ci: fix Docker image caching

### DIFF
--- a/ci/kokoro/install/build.sh
+++ b/ci/kokoro/install/build.sh
@@ -49,6 +49,13 @@ else
   exit 1
 fi
 
+echo "================================================================"
+echo "Load Google Container Registry configuration parameters $(date)."
+
+if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
+  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
+fi
+
 if [[ -z "${PROJECT_ROOT+x}" ]]; then
   readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
 fi
@@ -60,13 +67,6 @@ cd "${PROJECT_ROOT}"
 
 echo "================================================================"
 echo "Building with ${NCPU} cores $(date) on ${PWD}."
-
-echo "================================================================"
-echo "Load Google Container Registry configuration parameters $(date)."
-
-if [[ -f "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh" ]]; then
-  source "${KOKORO_GFILE_DIR:-}/gcr-configuration.sh"
-fi
 
 echo "================================================================"
 echo "Setup Google Container Registry access $(date)."


### PR DESCRIPTION
Regenerate ci/kokoro/{install,readme} from the latest version in
g-c-cpp-common.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1045)
<!-- Reviewable:end -->
