### PR TITLE
cleanup: delete unused `SessionManager` interface

### DIFF
--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -39,16 +39,6 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-// Interface used by the `SessionPool` to manage sessions.
-class SessionManager {
- public:
-  virtual ~SessionManager() = default;
-  // Create up to `num_sessions` sessions (note that fewer may be returned).
-  // `num_sessions` must be > 0 or an error is returned.
-  virtual StatusOr<std::vector<std::unique_ptr<Session>>> CreateSessions(
-      int num_sessions) = 0;
-};
-
 // What action to take if the session pool is exhausted.
 enum class ActionOnExhaustion { BLOCK, FAIL };
 


### PR DESCRIPTION
This should have been deleted in a previous PR but I must have missed
it. There are no more references to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1047)
<!-- Reviewable:end -->
