### PR TITLE
cleanup: clarify the purpose of MakeTestConnection

### DIFF
--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -37,8 +37,10 @@ namespace gcsa = ::google::spanner::admin::instance::v1;
 namespace giam = ::google::iam::v1;
 
 // Create a `Connection` suitable for use in tests that continue retrying
-// until the retry policy is exhausted. Attempting that with the default
+// until the retry policy is exhausted - attempting that with the default
 // policies would take too long (30 minutes).
+// Other tests can use this method or just call `MakeInstanceAdminConnection()`
+// directly.
 std::shared_ptr<InstanceAdminConnection> MakeLimitedRetryConnection(
     std::shared_ptr<spanner_testing::MockInstanceAdminStub> mock) {
   LimitedErrorCountRetryPolicy retry(/*maximum_failures=*/2);

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -86,8 +86,9 @@ spanner_proto::BatchCreateSessionsResponse MakeSessionsResponse(
 }
 
 // Create a `Connection` suitable for use in tests that continue retrying
-// until the retry policy is exhausted. Attempting that with the default
+// until the retry policy is exhausted - attempting that with the default
 // policies would take too long (10 minutes).
+// Other tests can use this method or just call `MakeConnection()` directly.
 std::shared_ptr<Connection> MakeLimitedRetryConnection(
     Database const& db,
     std::shared_ptr<spanner_testing::MockSpannerStub> mock) {


### PR DESCRIPTION
I added a comment and also renamed it to MakeLimitedRetryConnection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1048)
<!-- Reviewable:end -->
