### PR TITLE
feat: add some plumbing to enable multiple channels

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -314,7 +314,8 @@ class ReadExperiment : public Experiment {
       auto options = cs::ConnectionOptions().set_channel_pool_domain(
           "task:" + std::to_string(i));
       clients.emplace_back(cs::Client(cs::MakeConnection(database, options)));
-      stubs.emplace_back(cs::internal::CreateDefaultSpannerStub(options, i));
+      stubs.emplace_back(
+          cs::internal::CreateDefaultSpannerStub(options, /*channel_id=*/0));
       std::cout << '.' << std::flush;
     }
     std::cout << " DONE\n";

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -314,7 +314,7 @@ class ReadExperiment : public Experiment {
       auto options = cs::ConnectionOptions().set_channel_pool_domain(
           "task:" + std::to_string(i));
       clients.emplace_back(cs::Client(cs::MakeConnection(database, options)));
-      stubs.emplace_back(cs::internal::CreateDefaultSpannerStub(options));
+      stubs.emplace_back(cs::internal::CreateDefaultSpannerStub(options, i));
       std::cout << '.' << std::flush;
     }
     std::cout << " DONE\n";

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -219,8 +219,13 @@ StatusOr<PartitionedDmlResult> Client::ExecutePartitionedDml(
 
 std::shared_ptr<Connection> MakeConnection(Database const& db,
                                            ConnectionOptions const& options) {
-  auto stub = internal::CreateDefaultSpannerStub(options);
-  return internal::MakeConnection(db, std::move(stub));
+  std::vector<std::shared_ptr<internal::SpannerStub>> stubs;
+  int num_channels = std::min(options.num_channels(), 1);
+  stubs.reserve(num_channels);
+  for (int i = 0; i < num_channels; ++i) {
+    stubs.push_back(internal::CreateDefaultSpannerStub(options));
+  }
+  return internal::MakeConnection(db, std::move(stubs));
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -222,8 +222,8 @@ std::shared_ptr<Connection> MakeConnection(Database const& db,
   std::vector<std::shared_ptr<internal::SpannerStub>> stubs;
   int num_channels = std::min(options.num_channels(), 1);
   stubs.reserve(num_channels);
-  for (int i = 0; i < num_channels; ++i) {
-    stubs.push_back(internal::CreateDefaultSpannerStub(options));
+  for (int channel_id = 0; channel_id < num_channels; ++channel_id) {
+    stubs.push_back(internal::CreateDefaultSpannerStub(options, channel_id));
   }
   return internal::MakeConnection(db, std::move(stubs));
 }

--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -35,6 +35,7 @@ ConnectionOptions::ConnectionOptions(
     std::shared_ptr<grpc::ChannelCredentials> credentials)
     : credentials_(std::move(credentials)),
       endpoint_("spanner.googleapis.com"),
+      num_channels_(1),
       user_agent_prefix_(internal::BaseUserAgentPrefix()),
       background_threads_factory_([] {
         return google::cloud::internal::make_unique<

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -76,6 +76,24 @@ class ConnectionOptions {
   std::string const& endpoint() const { return endpoint_; }
 
   /**
+   * The number of transport channels to create.
+   *
+   * Some transports limit the number of simultaneous calls in progress on a
+   * channel (for gRPC the limit is 100). Increasing the number of channels
+   * thus increases the number of operations that can be in progress in
+   * parallel.
+   *
+   * The default value is 1.
+   */
+  int num_channels() const { return num_channels_; }
+
+  /// Set the value for `num_channels()`.
+  ConnectionOptions& set_num_channels(int num_channels) {
+    num_channels_ = num_channels;
+    return *this;
+  }
+
+  /**
    * Return whether tracing is enabled for the given @p component.
    *
    * The Cloud Spanner C++ client can log interesting events to help library and
@@ -177,6 +195,7 @@ class ConnectionOptions {
  private:
   std::shared_ptr<grpc::ChannelCredentials> credentials_;
   std::string endpoint_;
+  int num_channels_;
   std::set<std::string> tracing_components_;
   std::string channel_pool_domain_;
 

--- a/google/cloud/spanner/connection_options.h
+++ b/google/cloud/spanner/connection_options.h
@@ -83,7 +83,7 @@ class ConnectionOptions {
    * thus increases the number of operations that can be in progress in
    * parallel.
    *
-   * The default value is 1.
+   * The default value is 1.  TODO(#307) increase this.
    */
   int num_channels() const { return num_channels_; }
 

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -50,9 +50,11 @@ TEST(ConnectionOptionsTest, AdminEndpoint) {
 
 TEST(ConnectionOptionsTest, NumChannels) {
   ConnectionOptions options(grpc::InsecureChannelCredentials());
-  EXPECT_EQ(1, options.num_channels());
-  options.set_num_channels(4);
-  EXPECT_EQ(4, options.num_channels());
+  int num_channels = options.num_channels();
+  EXPECT_LT(0, num_channels);
+  num_channels *= 2;  // ensure we change it from the default value.
+  options.set_num_channels(num_channels);
+  EXPECT_EQ(num_channels, options.num_channels());
 }
 
 TEST(ConnectionOptionsTest, Tracing) {

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -48,6 +48,13 @@ TEST(ConnectionOptionsTest, AdminEndpoint) {
   EXPECT_EQ("invalid-endpoint", options.endpoint());
 }
 
+TEST(ConnectionOptionsTest, NumChannels) {
+  ConnectionOptions options(grpc::InsecureChannelCredentials());
+  EXPECT_EQ(1, options.num_channels());
+  options.set_num_channels(4);
+  EXPECT_EQ(4, options.num_channels());
+}
+
 TEST(ConnectionOptionsTest, Tracing) {
   ConnectionOptions options(grpc::InsecureChannelCredentials());
   options.enable_tracing("fake-component");

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -94,22 +94,23 @@ std::unique_ptr<BackoffPolicy> DefaultConnectionBackoffPolicy() {
 }
 
 std::shared_ptr<ConnectionImpl> MakeConnection(
-    Database db, std::shared_ptr<SpannerStub> stub,
+    Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
     std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy) {
   return std::shared_ptr<ConnectionImpl>(
-      new ConnectionImpl(std::move(db), std::move(stub),
+      new ConnectionImpl(std::move(db), std::move(stubs),
                          std::move(retry_policy), std::move(backoff_policy)));
 }
 
-ConnectionImpl::ConnectionImpl(Database db, std::shared_ptr<SpannerStub> stub,
+ConnectionImpl::ConnectionImpl(Database db,
+                               std::vector<std::shared_ptr<SpannerStub>> stubs,
                                std::unique_ptr<RetryPolicy> retry_policy,
                                std::unique_ptr<BackoffPolicy> backoff_policy)
     : db_(std::move(db)),
       retry_policy_prototype_(std::move(retry_policy)),
       backoff_policy_prototype_(std::move(backoff_policy)),
       session_pool_(std::make_shared<SessionPool>(
-          db_, std::move(stub), retry_policy_prototype_->clone(),
+          db_, std::move(stubs), retry_policy_prototype_->clone(),
           backoff_policy_prototype_->clone())) {}
 
 RowStream ConnectionImpl::Read(ReadParams params) {

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -47,11 +47,11 @@ std::unique_ptr<BackoffPolicy> DefaultConnectionBackoffPolicy();
 /**
  * Factory method to construct a `ConnectionImpl`.
  *
- * @note In tests we can use a mock stub and custom (or mock) policies.
+ * @note In tests we can use mock stubs and custom (or mock) policies.
  */
 class ConnectionImpl;
 std::shared_ptr<ConnectionImpl> MakeConnection(
-    Database db, std::shared_ptr<SpannerStub> stub,
+    Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
     std::unique_ptr<RetryPolicy> retry_policy = DefaultConnectionRetryPolicy(),
     std::unique_ptr<BackoffPolicy> backoff_policy =
         DefaultConnectionBackoffPolicy());
@@ -82,9 +82,9 @@ class ConnectionImpl : public Connection {
  private:
   // Only the factory method can construct instances of this class.
   friend std::shared_ptr<ConnectionImpl> MakeConnection(
-      Database, std::shared_ptr<SpannerStub>, std::unique_ptr<RetryPolicy>,
-      std::unique_ptr<BackoffPolicy>);
-  ConnectionImpl(Database db, std::shared_ptr<SpannerStub> stub,
+      Database, std::vector<std::shared_ptr<SpannerStub>>,
+      std::unique_ptr<RetryPolicy>, std::unique_ptr<BackoffPolicy>);
+  ConnectionImpl(Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
                  std::unique_ptr<RetryPolicy> retry_policy,
                  std::unique_ptr<BackoffPolicy> backoff_policy);
 

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -93,7 +93,7 @@ std::shared_ptr<Connection> MakeLimitedRetryConnection(
     Database const& db,
     std::shared_ptr<spanner_testing::MockSpannerStub> mock) {
   return MakeConnection(
-      db, std::move(mock),
+      db, {std::move(mock)},
       LimitedErrorCountRetryPolicy(/*maximum_failures=*/2).clone(),
       ExponentialBackoffPolicy(/*initial_delay=*/std::chrono::microseconds(1),
                                /*maximum_delay=*/std::chrono::microseconds(1),
@@ -114,7 +114,7 @@ TEST(ConnectionImplTest, ReadGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -139,7 +139,7 @@ TEST(ConnectionImplTest, ReadStreamingReadFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
@@ -174,7 +174,7 @@ TEST(ConnectionImplTest, ReadSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -314,7 +314,7 @@ TEST(ConnectionImplTest, ReadImplicitBeginTransaction) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -346,7 +346,7 @@ TEST(ConnectionImplTest, ReadImplicitBeginTransaction) {
 TEST(ConnectionImplTest, ExecuteQueryGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -368,7 +368,7 @@ TEST(ConnectionImplTest, ExecuteQueryStreamingReadFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -399,7 +399,7 @@ TEST(ConnectionImplTest, ExecuteQueryReadSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -459,7 +459,7 @@ TEST(ConnectionImplTest, ExecuteQueryImplicitBeginTransaction) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -490,7 +490,7 @@ TEST(ConnectionImplTest, ExecuteQueryImplicitBeginTransaction) {
 TEST(ConnectionImplTest, ExecuteDmlGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -509,7 +509,7 @@ TEST(ConnectionImplTest, ExecuteDmlGetSessionFailure) {
 TEST(ConnectionImplTest, ExecuteDmlDeleteSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
@@ -535,7 +535,7 @@ TEST(ConnectionImplTest, ExecuteDmlDeleteSuccess) {
 TEST(ConnectionImplTest, ExecuteDmlDelete_PermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
@@ -574,7 +574,7 @@ TEST(ConnectionImplTest, ExecuteDmlDelete_TooManyTransientFailures) {
 TEST(ConnectionImplTest, ProfileQuerySuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -658,7 +658,7 @@ TEST(ConnectionImplTest, ProfileQuerySuccess) {
 TEST(ConnectionImplTest, ProfileQueryGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -680,7 +680,7 @@ TEST(ConnectionImplTest, ProfileQueryStreamingReadFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -710,7 +710,7 @@ TEST(ConnectionImplTest, ProfileQueryStreamingReadFailure) {
 TEST(ConnectionImplTest, ProfileDmlGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -729,7 +729,7 @@ TEST(ConnectionImplTest, ProfileDmlGetSessionFailure) {
 TEST(ConnectionImplTest, ProfileDmlDeleteSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
@@ -781,7 +781,7 @@ TEST(ConnectionImplTest, ProfileDmlDeleteSuccess) {
 TEST(ConnectionImplTest, ProfileDmlDelete_PermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
@@ -837,7 +837,7 @@ TEST(ConnectionImplTest, AnalyzeSqlSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -876,7 +876,7 @@ TEST(ConnectionImplTest, AnalyzeSqlSuccess) {
 TEST(ConnectionImplTest, AnalyzeSqlGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -895,7 +895,7 @@ TEST(ConnectionImplTest, AnalyzeSqlGetSessionFailure) {
 TEST(ConnectionImplTest, AnalyzeSqlDelete_PermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
@@ -975,7 +975,7 @@ TEST(ConnectionImplTest, ExecuteBatchDmlSuccess) {
       SqlStatement("update ..."),
   };
 
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   auto txn = MakeReadWriteTransaction();
   auto result = conn->ExecuteBatchDml({txn, request});
   EXPECT_STATUS_OK(result);
@@ -1014,7 +1014,7 @@ TEST(ConnectionImplTest, ExecuteBatchDml_PartialFailure) {
       SqlStatement("update ..."),
   };
 
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   auto txn = MakeReadWriteTransaction();
   auto result = conn->ExecuteBatchDml({txn, request});
   EXPECT_STATUS_OK(result);
@@ -1080,7 +1080,7 @@ TEST(ConnectionImplTest, ExecuteBatchDml_TooManyTransientFailures) {
 TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
@@ -1116,7 +1116,7 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteSuccess) {
 TEST(ConnectionImplTest, ExecutePartitionedDmlGetSessionFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -1135,7 +1135,7 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlGetSessionFailure) {
 TEST(ConnectionImplTest, ExecutePartitionedDmlDelete_PermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
@@ -1197,7 +1197,7 @@ TEST(ConnectionImplTest,
      ExecutePartitionedDmlDelete_BeginTransactionPermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(MakeSessionsResponse({"session-name"})));
@@ -1355,7 +1355,7 @@ TEST(ConnectionImplTest, CommitCommit_IdempotentTransientSuccess) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Invoke(
           [&db](grpc::ClientContext&,
@@ -1397,7 +1397,7 @@ TEST(ConnectionImplTest, CommitCommit_NonIdempotentTransientFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Invoke(
           [&db](grpc::ClientContext&,
@@ -1425,7 +1425,7 @@ TEST(ConnectionImplTest, CommitSuccessWithTransactionId) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Invoke(
           [&db](grpc::ClientContext&,
@@ -1469,7 +1469,7 @@ TEST(ConnectionImplTest, RollbackGetSessionFailure) {
           }));
   EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
 
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   auto txn = MakeReadWriteTransaction();
   auto rollback = conn->Rollback({txn});
   EXPECT_EQ(StatusCode::kPermissionDenied, rollback.code());
@@ -1491,7 +1491,7 @@ TEST(ConnectionImplTest, RollbackBeginTransaction) {
           }));
   EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
 
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   auto txn = MakeReadWriteTransaction();
   auto rollback = conn->Rollback({txn});
   EXPECT_STATUS_OK(rollback);
@@ -1512,7 +1512,7 @@ TEST(ConnectionImplTest, RollbackSingleUseTransaction) {
           }));
   EXPECT_CALL(*mock, Rollback(_, _)).Times(0);
 
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   auto txn = internal::MakeSingleUseTransaction(
       Transaction::SingleUseOptions{Transaction::ReadOnlyOptions{}});
   auto rollback = conn->Rollback({txn});
@@ -1620,7 +1620,7 @@ TEST(ConnectionImplTest, Rollback_Success) {
         return Status();
       }));
 
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   auto txn = MakeReadWriteTransaction();
   auto begin_transaction =
       [&transaction_id](SessionHolder&, spanner_proto::TransactionSelector& s,
@@ -1636,7 +1636,7 @@ TEST(ConnectionImplTest, Rollback_Success) {
 TEST(ConnectionImplTest, PartitionReadSuccess) {
   auto mock_spanner_stub = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock_spanner_stub);
+  auto conn = MakeConnection(db, {mock_spanner_stub});
   EXPECT_CALL(*mock_spanner_stub, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -1750,7 +1750,7 @@ TEST(ConnectionImplTest, PartitionRead_TooManyTransientFailures) {
 TEST(ConnectionImplTest, PartitionQuerySuccess) {
   auto mock_spanner_stub = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock_spanner_stub);
+  auto conn = MakeConnection(db, {mock_spanner_stub});
   EXPECT_CALL(*mock_spanner_stub, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,
@@ -1880,7 +1880,7 @@ TEST(ConnectionImplTest, MultipleThreads) {
             return Status();
           }));
 
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
 
   int const per_thread_iterations = 1000;
   auto const thread_count = []() -> unsigned {
@@ -1927,7 +1927,7 @@ TEST(ConnectionImplTest, TransactionSessionBinding) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock,
               BatchCreateSessions(_, BatchCreateSessionsRequestHasDatabase(db)))
       .WillOnce(Return(MakeSessionsResponse({"session-1"})))
@@ -2033,7 +2033,7 @@ TEST(ConnectionImplTest, TransactionOutlivesConnection) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
 
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
-  auto conn = MakeConnection(db, mock);
+  auto conn = MakeConnection(db, {mock});
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(::testing::Invoke(
           [&db](grpc::ClientContext&,

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -28,12 +28,13 @@ namespace internal {
 
 namespace spanner_proto = ::google::spanner::v1;
 
-SessionPool::SessionPool(Database db, std::shared_ptr<SpannerStub> stub,
+SessionPool::SessionPool(Database db,
+                         std::vector<std::shared_ptr<SpannerStub>> stubs,
                          std::unique_ptr<RetryPolicy> retry_policy,
                          std::unique_ptr<BackoffPolicy> backoff_policy,
                          SessionPoolOptions options)
     : db_(std::move(db)),
-      stub_(std::move(stub)),
+      stub_(std::move(stubs[0])),  // TODO(#307): use all the stubs
       retry_policy_prototype_(std::move(retry_policy)),
       backoff_policy_prototype_(std::move(backoff_policy)),
       options_(options) {

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -94,7 +94,7 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
    * manage the pool, and to associate `Session`s with the stubs used to
    * create them.
    */
-  SessionPool(Database db, std::shared_ptr<SpannerStub> stub,
+  SessionPool(Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
               std::unique_ptr<RetryPolicy> retry_policy,
               std::unique_ptr<BackoffPolicy> backoff_policy,
               SessionPoolOptions options = SessionPoolOptions());

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -257,8 +257,11 @@ StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionRead(
 }  // namespace
 
 std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(
-    ConnectionOptions const& options) {
+    ConnectionOptions const& options, int channel_id) {
   grpc::ChannelArguments channel_arguments = options.CreateChannelArguments();
+  // Newer versions of gRPC include a macro (`GRPC_ARG_CHANNEL_ID`) but use
+  // its value here to allow compiling against older versions.
+  channel_arguments.SetInt("grpc.channel_id", channel_id);
 
   auto spanner_grpc_stub =
       spanner_proto::Spanner::NewStub(grpc::CreateCustomChannel(

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -104,9 +104,11 @@ class SpannerStub {
 
 /**
  * Creates a SpannerStub configured with @p options.
+ * @p channel_id should be unique among all stubs in the same Connection pool,
+ * to ensure they use different underlying connections.
  */
 std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(
-    ConnectionOptions const& options);
+    ConnectionOptions const& options, int channel_id);
 
 }  // namespace internal
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/spanner_stub.h
+++ b/google/cloud/spanner/internal/spanner_stub.h
@@ -103,7 +103,8 @@ class SpannerStub {
 };
 
 /**
- * Creates a SpannerStub configured with @p options.
+ * Creates a SpannerStub configured with @p options and @p channel_id.
+ *
  * @p channel_id should be unique among all stubs in the same Connection pool,
  * to ensure they use different underlying connections.
  */

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -27,7 +27,7 @@ namespace {
 using ::testing::AnyOf;
 
 TEST(SpannerStub, CreateDefaultStub) {
-  auto stub = CreateDefaultSpannerStub(ConnectionOptions());
+  auto stub = CreateDefaultSpannerStub(ConnectionOptions(), /*channel_id=*/0);
   EXPECT_NE(stub, nullptr);
 }
 
@@ -39,7 +39,8 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
   auto stub = CreateDefaultSpannerStub(
       ConnectionOptions(grpc::InsecureChannelCredentials())
           .set_endpoint("localhost:1")
-          .enable_tracing("rpc"));
+          .enable_tracing("rpc"),
+      /*channel_id=*/0);
   EXPECT_NE(stub, nullptr);
 
   grpc::ClientContext context;


### PR DESCRIPTION
Note that `Client` might create multiple channels but the `SessionPool`
only uses the first one right now. I'll add proper support for multiple
channels in a subsequent change but wanted to get some of the more
mechanical parts out of the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1050)
<!-- Reviewable:end -->
