### PR TITLE
feat: measure CPU for multiple rows per query

### DIFF
--- a/google/cloud/spanner/benchmarks/CMakeLists.txt
+++ b/google/cloud/spanner/benchmarks/CMakeLists.txt
@@ -37,7 +37,7 @@ function (spanner_client_define_benchmarks)
 
     set(spanner_client_benchmarks
         # cmake-format: sortable
-        single_row_throughput_benchmark.cc single_row_cpu_benchmark.cc
+        single_row_throughput_benchmark.cc multiple_rows_cpu_benchmark.cc
         throughput_benchmark.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -698,7 +698,7 @@ google::cloud::StatusOr<Config> ParseArgs(std::vector<std::string> args) {
 
   if (config.query_size <= 0) {
     std::ostringstream os;
-    os << "The query size (" << config.query_size << ") should be > 1";
+    os << "The query size (" << config.query_size << ") should be > 0";
     return invalid_argument(os.str());
   }
 

--- a/google/cloud/spanner/benchmarks/spanner_client_benchmarks.bzl
+++ b/google/cloud/spanner/benchmarks/spanner_client_benchmarks.bzl
@@ -18,6 +18,6 @@
 
 spanner_client_benchmarks = [
     "single_row_throughput_benchmark.cc",
-    "single_row_cpu_benchmark.cc",
+    "multiple_rows_cpu_benchmark.cc",
     "throughput_benchmark.cc",
 ]


### PR DESCRIPTION
Change the CPU overhead benchmark to fetch multiple rows per
query, which amortizes the RPC overhead.

I made several "cleanups" because the code had a lot of duplication
between the "using stubs" vs. "using client" cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1051)
<!-- Reviewable:end -->
