### PR TITLE
ci: actually enable caching for install builds

### DIFF
--- a/ci/kokoro/install/common.cfg
+++ b/ci/kokoro/install/common.cfg
@@ -16,5 +16,7 @@
 build_file: "google-cloud-cpp-spanner/ci/kokoro/install/build.sh"
 timeout_mins: 120
 
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-service-account.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-integration-tests-config.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-credentials.json"


### PR DESCRIPTION
The necessary credentials were missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1061)
<!-- Reviewable:end -->
