### PR TITLE
docs: clarifies that serialized partitions are strings of binary data

### DIFF
--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -43,7 +43,8 @@ class QueryPartition;
  * @par Example
  * @snippet samples.cc serialize-query-partition
  *
- * [formatted-io]: https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
+ * [formatted-io]:
+ * https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
  */
 StatusOr<std::string> SerializeQueryPartition(
     QueryPartition const& query_partition);
@@ -63,7 +64,8 @@ StatusOr<std::string> SerializeQueryPartition(
  * @par Example
  * @snippet samples.cc deserialize-query-partition
  *
- * [formatted-io]: https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
+ * [formatted-io]:
+ * https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
  */
 StatusOr<QueryPartition> DeserializeQueryPartition(
     std::string const& serialized_query_partition);

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -29,8 +29,13 @@ inline namespace SPANNER_CLIENT_NS {
 class QueryPartition;
 
 /**
- * Serializes an instance of `QueryPartition` for transmission to another
- * process.
+ * Serializes an instance of `QueryPartition` to a string of bytes.
+ *
+ * The serialized string of bytes is suitable for writing to disk or
+ * transmission to another process.
+ *
+ * @note The serialized string may contain NUL and other non-printable
+ *     characters.
  *
  * @param query_partition - instance to be serialized.
  *
@@ -41,10 +46,13 @@ StatusOr<std::string> SerializeQueryPartition(
     QueryPartition const& query_partition);
 
 /**
- * Deserializes the provided string into a `QueryPartition`, if able.
+ * Deserializes the provided string into a `QueryPartition`.
  *
- * Returned `Status` should be checked to determine if deserialization was
- * successful.
+ * The @p serialized_query_partition argument must be a string that was
+ * previously returned by a call to `SerializeQueryPartition()`.
+ *
+ * @note The serialized string may contain NUL and other non-printable
+ *     characters.
  *
  * @param serialized_query_partition
  *

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -35,12 +35,15 @@ class QueryPartition;
  * transmission to another process.
  *
  * @note The serialized string may contain NUL and other non-printable
- *     characters.
+ *     characters. Therefore, callers should avoid [formatted IO][formatted-io]
+ *     functions that may incorrectly reformat the string data.
  *
  * @param query_partition - instance to be serialized.
  *
  * @par Example
  * @snippet samples.cc serialize-query-partition
+ *
+ * [formatted-io]: https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
  */
 StatusOr<std::string> SerializeQueryPartition(
     QueryPartition const& query_partition);
@@ -52,12 +55,15 @@ StatusOr<std::string> SerializeQueryPartition(
  * previously returned by a call to `SerializeQueryPartition()`.
  *
  * @note The serialized string may contain NUL and other non-printable
- *     characters.
+ *     characters. Therefore, callers should avoid [formatted IO][formatted-io]
+ *     functions that may incorrectly reformat the string data.
  *
  * @param serialized_query_partition
  *
  * @par Example
  * @snippet samples.cc deserialize-query-partition
+ *
+ * [formatted-io]: https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
  */
 StatusOr<QueryPartition> DeserializeQueryPartition(
     std::string const& serialized_query_partition);

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -37,12 +37,15 @@ class ReadPartition;
  * transmission to another process.
  *
  * @note The serialized string may contain NUL and other non-printable
- *     characters.
+ *     characters. Therefore, callers should avoid [formatted IO][formatted-io]
+ *     functions that may incorrectly reformat the string data.
  *
  * @param read_partition - instance to be serialized.
  *
  * @par Example
  * @snippet samples.cc serialize-read-partition
+ *
+ * [formatted-io]: https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
  */
 StatusOr<std::string> SerializeReadPartition(
     ReadPartition const& read_partition);
@@ -54,12 +57,15 @@ StatusOr<std::string> SerializeReadPartition(
  * previously returned by a call to `SerializeReadPartition()`.
  *
  * @note The serialized string may contain NUL and other non-printable
- *     characters.
+ *     characters. Therefore, callers should avoid [formatted IO][formatted-io]
+ *     functions that may incorrectly reformat the string data.
  *
  * @param serialized_read_partition - string representation to be deserialized.
  *
  * @par Example
  * @snippet samples.cc deserialize-read-partition
+ *
+ * [formatted-io]: https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
  */
 StatusOr<ReadPartition> DeserializeReadPartition(
     std::string const& serialized_read_partition);

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -45,7 +45,8 @@ class ReadPartition;
  * @par Example
  * @snippet samples.cc serialize-read-partition
  *
- * [formatted-io]: https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
+ * [formatted-io]:
+ * https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
  */
 StatusOr<std::string> SerializeReadPartition(
     ReadPartition const& read_partition);
@@ -65,7 +66,8 @@ StatusOr<std::string> SerializeReadPartition(
  * @par Example
  * @snippet samples.cc deserialize-read-partition
  *
- * [formatted-io]: https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
+ * [formatted-io]:
+ * https://en.cppreference.com/w/cpp/string/basic_string/operator_ltltgtgt
  */
 StatusOr<ReadPartition> DeserializeReadPartition(
     std::string const& serialized_read_partition);

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -31,8 +31,13 @@ inline namespace SPANNER_CLIENT_NS {
 class ReadPartition;
 
 /**
- * Serializes an instance of `ReadPartition` for transmission to another
- * process.
+ * Serializes an instance of `ReadPartition` to a string of bytes.
+ *
+ * The serialized string of bytes is suitable for writing to disk or
+ * transmission to another process.
+ *
+ * @note The serialized string may contain NUL and other non-printable
+ *     characters.
  *
  * @param read_partition - instance to be serialized.
  *
@@ -43,10 +48,13 @@ StatusOr<std::string> SerializeReadPartition(
     ReadPartition const& read_partition);
 
 /**
- * Deserializes the provided string into a `ReadPartition`, if able.
+ * Deserializes the provided string into a `ReadPartition`.
  *
- * Returned `Status` should be checked to determine if deserialization was
- * successful.
+ * The @p serialized_read_partition argument must be a string that was
+ * previously returned by a call to `SerializeReadPartition()`.
+ *
+ * @note The serialized string may contain NUL and other non-printable
+ *     characters.
  *
  * @param serialized_read_partition - string representation to be deserialized.
  *

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -1471,7 +1471,7 @@ void ExampleStatusOr(google::cloud::spanner::Client client) {
 
 class RemoteConnectionFake {
  public:
-  void Send(std::string const& serialized_partition) {
+  void SendBinaryStringData(std::string const& serialized_partition) {
     serialized_partition_in_transit_ = serialized_partition;
   }
   std::string Receive() { return serialized_partition_in_transit_; }
@@ -1484,7 +1484,10 @@ class RemoteConnectionFake {
     if (!serialized_partition) {
       throw std::runtime_error(serialized_partition.status().message());
     }
-    Send(*serialized_partition);
+    std::string const& bytes = *serialized_partition;
+    // `bytes` contains the serialized data, which may contain NULs and other
+    // non-printable characters.
+    SendBinaryStringData(bytes);
     //! [serialize-read-partition]
   }
 
@@ -1497,7 +1500,10 @@ class RemoteConnectionFake {
     if (!serialized_partition) {
       throw std::runtime_error(serialized_partition.status().message());
     }
-    Send(*serialized_partition);
+    std::string const& bytes = *serialized_partition;
+    // `bytes` contains the serialized data, which may contain NULs and other
+    // non-printable characters.
+    SendBinaryStringData(bytes);
     //! [serialize-query-partition]
   }
   //! [deserialize-read-partition]


### PR DESCRIPTION
Fixes: #541 

I *think* this fixes #541. I added a `@note` to all the relevant places in the docs. I also added a comment to the example code, and renamed the `Send()` function to make it clear that it's a string of binary data. I suspect this should make it clear enough.

Do you think we need more than this, or should this make it clear enough?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1067)
<!-- Reviewable:end -->
