### PR TITLE
feat: add function to get a single row from a range

### DIFF
--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -431,6 +431,21 @@ class StreamOf {
   iterator end_;
 };
 
+/**
+ * Returns the current row from the given range, if any.
+ *
+ * If there are no rows left, an error `Status` is returned. This is a
+ * convenience function that can be useful if the caller knows there will be
+ * only a single row returned.
+ */
+template <typename RowRange>
+auto GetCurrentRow(RowRange&& range) -> typename std::decay<
+    decltype(*std::forward<RowRange>(range).begin())>::type {
+  auto it = std::forward<RowRange>(range).begin();
+  if (it != std::forward<RowRange>(range).end()) return *it;
+  return Status(StatusCode::kResourceExhausted, "No more rows");
+}
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -486,6 +486,36 @@ TEST(StreamOf, IterationError) {
   EXPECT_EQ(it, end);
 }
 
+TEST(GetCurrentRow, BasicEmpty) {
+  std::vector<Row> rows;
+  RowRange range(MakeRowStreamIteratorSource(rows));
+  auto row = GetCurrentRow(range);
+  EXPECT_FALSE(row.ok());
+  EXPECT_EQ(row.status().code(), StatusCode::kResourceExhausted);
+}
+
+TEST(GetCurrentRow, BasicNotEmpty) {
+  std::vector<Row> rows;
+  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
+
+  RowRange range(MakeRowStreamIteratorSource(rows));
+  auto row = GetCurrentRow(range);
+  EXPECT_STATUS_OK(row);
+  EXPECT_EQ(1, *row->get<std::int64_t>(0));
+}
+
+TEST(GetCurrentRow, TupleStreamNotEmpty) {
+  std::vector<Row> rows;
+  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
+
+  auto row_range = RowRange(MakeRowStreamIteratorSource(rows));
+  auto tup_range = StreamOf<std::tuple<std::int64_t>>(row_range);
+
+  auto row = GetCurrentRow(tup_range);
+  EXPECT_STATUS_OK(row);
+  EXPECT_EQ(1, std::get<0>(*row));
+}
+
 }  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner


### PR DESCRIPTION
Fixes: #386

This is just a convenience, but it seems nice in some cases. I found on
example that could use this in our current code. I also have another one
in an upcoming PR where I would like this.

Do we like this? Or do we have a better API to consider?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1074)
<!-- Reviewable:end -->
