### PR TITLE
fix: execute each rerun of an aborted transaction in the same session

### DIFF
--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -17,7 +17,6 @@
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/version.h"
-#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -53,11 +52,11 @@ class Session {
 };
 
 /**
- * A `SessionHolder` is a unique_ptr with a custom deleter that normally
+ * A `SessionHolder` is a shared_ptr with a custom deleter that normally
  * returns the `Session` to the pool it came from (although in some cases it
  * just deletes the `Session` - see `MakeDissociatedSessionHolder`)
  */
-using SessionHolder = std::unique_ptr<Session, std::function<void(Session*)>>;
+using SessionHolder = std::shared_ptr<Session>;
 
 /**
  * Returns a `SessionHolder` for a new `Session` that is not associated with

--- a/google/cloud/spanner/internal/transaction_impl.h
+++ b/google/cloud/spanner/internal/transaction_impl.h
@@ -44,6 +44,10 @@ class TransactionImpl {
   TransactionImpl(google::spanner::v1::TransactionSelector selector)
       : TransactionImpl(/*session=*/{}, std::move(selector)) {}
 
+  TransactionImpl(TransactionImpl const& impl,
+                  google::spanner::v1::TransactionSelector selector)
+      : TransactionImpl(impl.session_, std::move(selector)) {}
+
   TransactionImpl(SessionHolder session,
                   google::spanner::v1::TransactionSelector selector)
       : session_(std::move(session)),

--- a/google/cloud/spanner/transaction.cc
+++ b/google/cloud/spanner/transaction.cc
@@ -87,6 +87,13 @@ Transaction::Transaction(ReadWriteOptions opts) {
   impl_ = std::make_shared<internal::TransactionImpl>(std::move(selector));
 }
 
+Transaction::Transaction(Transaction const& txn, ReadWriteOptions opts) {
+  google::spanner::v1::TransactionSelector selector;
+  *selector.mutable_begin() = MakeOpts(std::move(opts.rw_opts_));
+  impl_ = std::make_shared<internal::TransactionImpl>(*txn.impl_,
+                                                      std::move(selector));
+}
+
 Transaction::Transaction(SingleUseOptions opts) {
   google::spanner::v1::TransactionSelector selector;
   *selector.mutable_single_use() = MakeOpts(std::move(opts.ro_opts_));
@@ -111,6 +118,7 @@ Transaction MakeTransactionFromIds(std::string session_id,
 }
 
 }  // namespace internal
+
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud

--- a/google/cloud/spanner/transaction_test.cc
+++ b/google/cloud/spanner/transaction_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/transaction.h"
+#include "google/cloud/spanner/internal/session.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -91,6 +92,28 @@ TEST(Transaction, Visit) {
                                std::int64_t seqno) {
     EXPECT_EQ("test-txn-id", s.id());
     EXPECT_GT(seqno, a_seqno);
+    return 0;
+  });
+}
+
+TEST(Transaction, SessionAffinity) {
+  auto a_session = internal::MakeDissociatedSessionHolder("SessionAffinity");
+  Transaction a = MakeReadWriteTransaction();
+  internal::Visit(a, [&a_session](internal::SessionHolder& session,
+                                  google::spanner::v1::TransactionSelector& s,
+                                  std::int64_t) {
+    EXPECT_FALSE(session);
+    EXPECT_TRUE(s.has_begin());
+    session = a_session;
+    s.set_id("a-txn-id");
+    return 0;
+  });
+  Transaction b = MakeReadWriteTransaction(a);
+  internal::Visit(b, [&a_session](internal::SessionHolder& session,
+                                  google::spanner::v1::TransactionSelector& s,
+                                  std::int64_t) {
+    EXPECT_EQ(a_session, session);  // session affinity
+    EXPECT_TRUE(s.has_begin());     // but a new transaction
     return 0;
   });
 }


### PR DESCRIPTION
Fixes #472.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1079)
<!-- Reviewable:end -->
