### PR TITLE
feat: update the pool options to match the design

### DIFF
--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -32,15 +32,14 @@ namespace spanner_proto = ::google::spanner::v1;
 namespace {
 
 // Ensure the options have sensible values.
-SessionPoolOptions SanitizeOptions(SessionPoolOptions options) {
+SessionPoolOptions SanitizeOptions(SessionPoolOptions options,
+                                   int num_channels) {
   options.min_sessions = (std::max)(options.min_sessions, 0);
-  options.max_sessions = (std::max)(options.max_sessions, options.min_sessions);
-  options.max_sessions = (std::max)(options.max_sessions, 1);
+  options.max_sessions_per_channel =
+      (std::max)(options.max_sessions_per_channel, 1);
+  options.min_sessions = (std::min)(
+      options.min_sessions, options.max_sessions_per_channel * num_channels);
   options.max_idle_sessions = (std::max)(options.max_idle_sessions, 0);
-  options.write_sessions_fraction =
-      (std::max)(options.write_sessions_fraction, 0.0);
-  options.write_sessions_fraction =
-      (std::min)(options.write_sessions_fraction, 1.0);
   return options;
 }
 
@@ -54,7 +53,9 @@ SessionPool::SessionPool(Database db,
     : db_(std::move(db)),
       retry_policy_prototype_(std::move(retry_policy)),
       backoff_policy_prototype_(std::move(backoff_policy)),
-      options_(SanitizeOptions(options)) {
+      options_(SanitizeOptions(options, stubs.size())),
+      max_pool_size_(options.max_sessions_per_channel *
+                     static_cast<int>(stubs.size())) {
   if (stubs.empty()) {
     google::cloud::internal::ThrowInvalidArgument(
         "SessionPool requires a non-empty set of stubs");
@@ -106,12 +107,12 @@ StatusOr<SessionHolder> SessionPool::Allocate(bool dissociate_from_pool) {
 
     // If the pool is at its max size, fail or wait until someone returns a
     // session to the pool then try again.
-    if (total_sessions_ >= options_.max_sessions) {
+    if (total_sessions_ >= max_pool_size_) {
       if (options_.action_on_exhaustion == ActionOnExhaustion::FAIL) {
         return Status(StatusCode::kResourceExhausted, "session pool exhausted");
       }
       cond_.wait(lk, [this] {
-        return !sessions_.empty() || total_sessions_ < options_.max_sessions;
+        return !sessions_.empty() || total_sessions_ < max_pool_size_;
       });
       continue;
     }
@@ -129,10 +130,11 @@ StatusOr<SessionHolder> SessionPool::Allocate(bool dissociate_from_pool) {
     }
 
     // Add `min_sessions` to the pool (plus the one we're going to return),
-    // subject to the `max_sessions` cap.
-    int sessions_to_create = (std::min)(
-        options_.min_sessions + 1, options_.max_sessions - total_sessions_);
+    // subject to the `max_sessions_per_channel` cap.
     ChannelInfo& channel = *next_channel_for_create_sessions_;
+    int sessions_to_create =
+        (std::min)(options_.min_sessions + 1,
+                   options_.max_sessions_per_channel - channel.session_count);
     auto create_status = CreateSessions(lk, channel, sessions_to_create);
     if (!create_status.ok()) {
       return create_status;

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -53,8 +53,8 @@ SessionPool::SessionPool(Database db,
     : db_(std::move(db)),
       retry_policy_prototype_(std::move(retry_policy)),
       backoff_policy_prototype_(std::move(backoff_policy)),
-      options_(SanitizeOptions(options, stubs.size())),
-      max_pool_size_(options.max_sessions_per_channel *
+      options_(SanitizeOptions(options, static_cast<int>(stubs.size()))),
+      max_pool_size_(options_.max_sessions_per_channel *
                      static_cast<int>(stubs.size())) {
   if (stubs.empty()) {
     google::cloud::internal::ThrowInvalidArgument(

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -180,7 +180,7 @@ Status SessionPool::CreateSessions(std::unique_lock<std::mutex>& lk,
   spanner_proto::BatchCreateSessionsRequest request;
   request.set_database(db_.FullName());
   request.set_session_count(std::int32_t{num_sessions});
-  const auto& stub = channel.stub;
+  auto const& stub = channel.stub;
   auto response = RetryLoop(
       retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
       true,

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -45,12 +45,12 @@ enum class ActionOnExhaustion { BLOCK, FAIL };
 struct SessionPoolOptions {
   // The minimum number of sessions to keep in the pool.
   // Values <= 0 are treated as 0.
-  // In case of a conflict, `max_sessions_per_channel` takes precedence.
+  // This value will be reduced if it exceeds the overall limit on the number
+  // of sessions (`max_sessions_per_channel` * number of channels).
   int min_sessions = 0;
 
   // The maximum number of sessions to create on each channel.
   // Values <= 1 are treated as 1.
-  // The `max_sessions_per_channel` limit takes precedence over `min_sessions`.
   int max_sessions_per_channel = 100;
 
   // The maximum number of sessions that can be in the pool in an idle state.
@@ -141,7 +141,7 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
   SessionPoolOptions const options_;
-  const int max_pool_size_;
+  int const max_pool_size_;
 
   std::mutex mu_;
   std::condition_variable cond_;

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -45,22 +45,17 @@ enum class ActionOnExhaustion { BLOCK, FAIL };
 struct SessionPoolOptions {
   // The minimum number of sessions to keep in the pool.
   // Values <= 0 are treated as 0.
+  // In case of a conflict, `max_sessions_per_channel` takes precedence.
   int min_sessions = 0;
 
-  // The maximum number of sessions to create. This should be the number
-  // of channels * 100.
+  // The maximum number of sessions to create on each channel.
   // Values <= 1 are treated as 1.
-  // If this is less than `min_sessions`, it will be set to `min_sessions`.
-  int max_sessions = 100;  // Channel Count * 100
+  // The `max_sessions_per_channel` limit takes precedence over `min_sessions`.
+  int max_sessions_per_channel = 100;
 
   // The maximum number of sessions that can be in the pool in an idle state.
   // Values <= 0 are treated as 0.
   int max_idle_sessions = 0;
-
-  // The fraction of sessions to prepare for write in advance.
-  // This fraction represents observed cloud spanner usage as of May 2019.
-  // Values <= 0.0 are treated as 0.0; values >= 1.0 are treated as 1.0.
-  double write_sessions_fraction = 0.25;
 
   // Decide whether to block or fail on pool exhaustion.
   ActionOnExhaustion action_on_exhaustion = ActionOnExhaustion::BLOCK;
@@ -146,6 +141,7 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
   SessionPoolOptions const options_;
+  const int max_pool_size_;
 
   std::mutex mu_;
   std::condition_variable cond_;

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -188,7 +188,7 @@ TEST(SessionPool, MinSessionsMultipleAllocations) {
 }
 
 TEST(SessionPool, MaxSessionsFailOnExhaustion) {
-  const int max_sessions = 3;
+  const int max_sessions_per_channel = 3;
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("project", "instance", "database");
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
@@ -197,7 +197,7 @@ TEST(SessionPool, MaxSessionsFailOnExhaustion) {
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s3"}))));
 
   SessionPoolOptions options;
-  options.max_sessions = max_sessions;
+  options.max_sessions_per_channel = max_sessions_per_channel;
   options.action_on_exhaustion = ActionOnExhaustion::FAIL;
   auto pool = MakeSessionPool(db, {mock}, options);
   std::vector<SessionHolder> sessions;
@@ -215,14 +215,14 @@ TEST(SessionPool, MaxSessionsFailOnExhaustion) {
 }
 
 TEST(SessionPool, MaxSessionsBlockUntilRelease) {
-  const int max_sessions = 1;
+  const int max_sessions_per_channel = 1;
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("project", "instance", "database");
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s1"}))));
 
   SessionPoolOptions options;
-  options.max_sessions = max_sessions;
+  options.max_sessions_per_channel = max_sessions_per_channel;
   options.action_on_exhaustion = ActionOnExhaustion::BLOCK;
   auto pool = MakeSessionPool(db, {mock}, options);
   auto session = pool->Allocate();
@@ -272,29 +272,30 @@ TEST(SessionPool, MultipleChannelsPreAllocation) {
   auto mock3 = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("project", "instance", "database");
   EXPECT_CALL(*mock1, BatchCreateSessions(_, _))
-      .WillOnce(Return(
-          ByMove(MakeSessionsResponse({"c1s1", "c1s2", "c1s3", "c1s4"}))));
+      .WillOnce(Return(ByMove(MakeSessionsResponse({"c1s1", "c1s2", "c1s3"}))));
   EXPECT_CALL(*mock2, BatchCreateSessions(_, _))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c2s1", "c2s2", "c2s3"}))));
   EXPECT_CALL(*mock3, BatchCreateSessions(_, _))
       .WillOnce(Return(ByMove(MakeSessionsResponse({"c3s1", "c3s2", "c3s3"}))));
 
   SessionPoolOptions options;
-  options.min_sessions = 10;
-  options.max_sessions = 10;
+  // note that min_sessions will effectively be reduced to 9
+  // (max_sessions_per_channel * num_channels).
+  options.min_sessions = 20;
+  options.max_sessions_per_channel = 3;
   options.action_on_exhaustion = ActionOnExhaustion::FAIL;
   auto pool = MakeSessionPool(db, {mock1, mock2, mock3}, options);
   std::vector<SessionHolder> sessions;
   std::vector<std::string> session_names;
-  for (int i = 1; i <= 10; ++i) {
+  for (int i = 1; i <= 9; ++i) {
     auto session = pool->Allocate();
     ASSERT_STATUS_OK(session);
     session_names.push_back((*session)->session_name());
     sessions.push_back(*std::move(session));
   }
   EXPECT_THAT(session_names,
-              UnorderedElementsAre("c1s1", "c1s2", "c1s3", "c1s4", "c2s1",
-                                   "c2s2", "c2s3", "c3s1", "c3s2", "c3s3"));
+              UnorderedElementsAre("c1s1", "c1s2", "c1s3", "c2s1", "c2s2",
+                                   "c2s3", "c3s1", "c3s2", "c3s3"));
   auto session = pool->Allocate();
   EXPECT_EQ(session.status().code(), StatusCode::kResourceExhausted);
   EXPECT_EQ(session.status().message(), "session pool exhausted");

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -148,7 +148,7 @@ TEST(SessionPool, Lifo) {
 }
 
 TEST(SessionPool, MinSessionsEagerAllocation) {
-  const int min_sessions = 3;
+  int const min_sessions = 3;
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("project", "instance", "database");
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
@@ -161,7 +161,7 @@ TEST(SessionPool, MinSessionsEagerAllocation) {
 }
 
 TEST(SessionPool, MinSessionsMultipleAllocations) {
-  const int min_sessions = 3;
+  int const min_sessions = 3;
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("project", "instance", "database");
   // The constructor will make this call.
@@ -188,7 +188,7 @@ TEST(SessionPool, MinSessionsMultipleAllocations) {
 }
 
 TEST(SessionPool, MaxSessionsFailOnExhaustion) {
-  const int max_sessions_per_channel = 3;
+  int const max_sessions_per_channel = 3;
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("project", "instance", "database");
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
@@ -215,7 +215,7 @@ TEST(SessionPool, MaxSessionsFailOnExhaustion) {
 }
 
 TEST(SessionPool, MaxSessionsBlockUntilRelease) {
-  const int max_sessions_per_channel = 1;
+  int const max_sessions_per_channel = 1;
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("project", "instance", "database");
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))


### PR DESCRIPTION
* `max_sessions` is now `max_sessions_per_channel`
* we're not going to be using `write_sessions_fraction`, so remove it.

Note I also flipped the precedence of `min_sessions` and (`max_sessions_per_channel` * the number of channels) - the latter now takes precedence, just for simplicity; I don't think it matters that much because it's a misconfiguration.

Part of #307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1089)
<!-- Reviewable:end -->
