### PR TITLE
cleanup: remove unnecessary calls to testing::Invoke()

### DIFF
--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -27,7 +27,6 @@ namespace internal {
 namespace {
 
 using ::testing::_;
-using ::testing::Invoke;
 namespace gcsa = google::spanner::admin::database::v1;
 
 class DatabaseAdminMetadataTest : public ::testing::Test {
@@ -50,15 +49,15 @@ class DatabaseAdminMetadataTest : public ::testing::Test {
 
 TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
   EXPECT_CALL(*mock_, CreateDatabase(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::CreateDatabaseRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::CreateDatabaseRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.database.v1.DatabaseAdmin."
             "CreateDatabase",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -72,15 +71,15 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
 
 TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
   EXPECT_CALL(*mock_, UpdateDatabase(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::UpdateDatabaseDdlRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::UpdateDatabaseDdlRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.database.v1.DatabaseAdmin."
             "UpdateDatabaseDdl",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -95,15 +94,15 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
 
 TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
   EXPECT_CALL(*mock_, DropDatabase(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::DropDatabaseRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::DropDatabaseRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.database.v1.DatabaseAdmin."
             "DropDatabase",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -118,15 +117,15 @@ TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
 
 TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
   EXPECT_CALL(*mock_, ListDatabases(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::ListDatabasesRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::ListDatabasesRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.database.v1.DatabaseAdmin."
             "ListDatabases",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -140,15 +139,15 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
 
 TEST_F(DatabaseAdminMetadataTest, GetIamPolicy) {
   EXPECT_CALL(*mock_, GetIamPolicy(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              google::iam::v1::GetIamPolicyRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::iam::v1::GetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.database.v1.DatabaseAdmin."
             "GetIamPolicy",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -163,15 +162,15 @@ TEST_F(DatabaseAdminMetadataTest, GetIamPolicy) {
 
 TEST_F(DatabaseAdminMetadataTest, SetIamPolicy) {
   EXPECT_CALL(*mock_, SetIamPolicy(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              google::iam::v1::SetIamPolicyRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::iam::v1::SetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.database.v1.DatabaseAdmin."
             "SetIamPolicy",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -192,16 +191,15 @@ TEST_F(DatabaseAdminMetadataTest, SetIamPolicy) {
 
 TEST_F(DatabaseAdminMetadataTest, TestIamPermissions) {
   EXPECT_CALL(*mock_, TestIamPermissions(_, _))
-      .WillOnce(
-          Invoke([this](grpc::ClientContext& context,
-                        google::iam::v1::TestIamPermissionsRequest const&) {
-            EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
-                context,
-                "google.spanner.admin.database.v1.DatabaseAdmin."
-                "TestIamPermissions",
-                expected_api_client_header_));
-            return TransientError();
-          }));
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::iam::v1::TestIamPermissionsRequest const&) {
+        EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
+            context,
+            "google.spanner.admin.database.v1.DatabaseAdmin."
+            "TestIamPermissions",
+            expected_api_client_header_));
+        return TransientError();
+      });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -216,13 +214,13 @@ TEST_F(DatabaseAdminMetadataTest, TestIamPermissions) {
 
 TEST_F(DatabaseAdminMetadataTest, GetOperation) {
   EXPECT_CALL(*mock_, GetOperation(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              google::longrunning::GetOperationRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::longrunning::GetOperationRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.longrunning.Operations.GetOperation",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -27,7 +27,6 @@ namespace internal {
 namespace {
 
 using ::testing::_;
-using ::testing::Invoke;
 namespace gcsa = google::spanner::admin::instance::v1;
 
 class InstanceAdminMetadataTest : public ::testing::Test {
@@ -50,15 +49,15 @@ class InstanceAdminMetadataTest : public ::testing::Test {
 
 TEST_F(InstanceAdminMetadataTest, GetInstance) {
   EXPECT_CALL(*mock_, GetInstance(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::GetInstanceRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::GetInstanceRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.instance.v1.InstanceAdmin."
             "GetInstance",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -72,15 +71,15 @@ TEST_F(InstanceAdminMetadataTest, GetInstance) {
 
 TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
   EXPECT_CALL(*mock_, GetInstanceConfig(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::GetInstanceConfigRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::GetInstanceConfigRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.instance.v1.InstanceAdmin."
             "GetInstanceConfig",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -94,15 +93,15 @@ TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
 
 TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
   EXPECT_CALL(*mock_, ListInstanceConfigs(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::ListInstanceConfigsRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::ListInstanceConfigsRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.instance.v1.InstanceAdmin."
             "ListInstanceConfigs",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -114,15 +113,15 @@ TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
 
 TEST_F(InstanceAdminMetadataTest, CreateInstance) {
   EXPECT_CALL(*mock_, CreateInstance(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::CreateInstanceRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::CreateInstanceRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.instance.v1.InstanceAdmin."
             "CreateInstance",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -135,15 +134,15 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
 
 TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
   EXPECT_CALL(*mock_, UpdateInstance(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::UpdateInstanceRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::UpdateInstanceRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.instance.v1.InstanceAdmin."
             "UpdateInstance",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -156,15 +155,15 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
 
 TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
   EXPECT_CALL(*mock_, DeleteInstance(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::DeleteInstanceRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::DeleteInstanceRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.instance.v1.InstanceAdmin."
             "DeleteInstance",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -176,15 +175,15 @@ TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
 
 TEST_F(InstanceAdminMetadataTest, ListInstances) {
   EXPECT_CALL(*mock_, ListInstances(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              gcsa::ListInstancesRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::ListInstancesRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.instance.v1.InstanceAdmin."
             "ListInstances",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -196,15 +195,15 @@ TEST_F(InstanceAdminMetadataTest, ListInstances) {
 
 TEST_F(InstanceAdminMetadataTest, GetIamPolicy) {
   EXPECT_CALL(*mock_, GetIamPolicy(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              google::iam::v1::GetIamPolicyRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::iam::v1::GetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.instance.v1.InstanceAdmin."
             "GetIamPolicy",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -217,15 +216,15 @@ TEST_F(InstanceAdminMetadataTest, GetIamPolicy) {
 
 TEST_F(InstanceAdminMetadataTest, SetIamPolicy) {
   EXPECT_CALL(*mock_, SetIamPolicy(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              google::iam::v1::SetIamPolicyRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::iam::v1::SetIamPolicyRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context,
             "google.spanner.admin.instance.v1.InstanceAdmin."
             "SetIamPolicy",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -237,16 +236,15 @@ TEST_F(InstanceAdminMetadataTest, SetIamPolicy) {
 
 TEST_F(InstanceAdminMetadataTest, TestIamPermissions) {
   EXPECT_CALL(*mock_, TestIamPermissions(_, _))
-      .WillOnce(
-          Invoke([this](grpc::ClientContext& context,
-                        google::iam::v1::TestIamPermissionsRequest const&) {
-            EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
-                context,
-                "google.spanner.admin.instance.v1.InstanceAdmin."
-                "TestIamPermissions",
-                expected_api_client_header_));
-            return TransientError();
-          }));
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::iam::v1::TestIamPermissionsRequest const&) {
+        EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
+            context,
+            "google.spanner.admin.instance.v1.InstanceAdmin."
+            "TestIamPermissions",
+            expected_api_client_header_));
+        return TransientError();
+      });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -27,7 +27,6 @@ namespace internal {
 namespace {
 
 using ::testing::_;
-using ::testing::Invoke;
 namespace spanner_proto = google::spanner::v1;
 
 // This ugly macro and the supporting template member function refactor most
@@ -63,12 +62,12 @@ class MetadataSpannerStubTest : public ::testing::Test {
                      std::string const& rpc_name,
                      MemberFunction member_function) {
     call.WillOnce(
-        Invoke([this, rpc_name](grpc::ClientContext& context, Request const&) {
+        [this, rpc_name](grpc::ClientContext& context, Request const&) {
           EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
               context, "google.spanner.v1.Spanner." + rpc_name,
               expected_api_client_header_));
           return TransientError();
-        }));
+        });
 
     MetadataSpannerStub stub(mock_);
     grpc::ClientContext context;
@@ -88,13 +87,13 @@ class MetadataSpannerStubTest : public ::testing::Test {
 
 TEST_F(MetadataSpannerStubTest, CreateSession) {
   EXPECT_CALL(*mock_, CreateSession(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              spanner_proto::CreateSessionRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       spanner_proto::CreateSessionRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.CreateSession",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   MetadataSpannerStub stub(mock_);
   grpc::ClientContext context;
@@ -109,14 +108,13 @@ TEST_F(MetadataSpannerStubTest, CreateSession) {
 
 TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
   EXPECT_CALL(*mock_, BatchCreateSessions(_, _))
-      .WillOnce(
-          Invoke([this](grpc::ClientContext& context,
-                        spanner_proto::BatchCreateSessionsRequest const&) {
-            EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
-                context, "google.spanner.v1.Spanner.BatchCreateSessions",
-                expected_api_client_header_));
-            return TransientError();
-          }));
+      .WillOnce([this](grpc::ClientContext& context,
+                       spanner_proto::BatchCreateSessionsRequest const&) {
+        EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
+            context, "google.spanner.v1.Spanner.BatchCreateSessions",
+            expected_api_client_header_));
+        return TransientError();
+      });
 
   MetadataSpannerStub stub(mock_);
   grpc::ClientContext context;
@@ -132,13 +130,13 @@ TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
 
 TEST_F(MetadataSpannerStubTest, GetSession) {
   EXPECT_CALL(*mock_, GetSession(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              spanner_proto::GetSessionRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       spanner_proto::GetSessionRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.GetSession",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   MetadataSpannerStub stub(mock_);
   grpc::ClientContext context;
@@ -154,13 +152,13 @@ TEST_F(MetadataSpannerStubTest, GetSession) {
 
 TEST_F(MetadataSpannerStubTest, ListSessions) {
   EXPECT_CALL(*mock_, ListSessions(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              spanner_proto::ListSessionsRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       spanner_proto::ListSessionsRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.ListSessions",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   MetadataSpannerStub stub(mock_);
   grpc::ClientContext context;
@@ -175,13 +173,13 @@ TEST_F(MetadataSpannerStubTest, ListSessions) {
 
 TEST_F(MetadataSpannerStubTest, DeleteSession) {
   EXPECT_CALL(*mock_, DeleteSession(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              spanner_proto::DeleteSessionRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       spanner_proto::DeleteSessionRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.DeleteSession",
             expected_api_client_header_));
         return TransientError();
-      }));
+      });
 
   MetadataSpannerStub stub(mock_);
   grpc::ClientContext context;
@@ -201,14 +199,14 @@ TEST_F(MetadataSpannerStubTest, ExecuteSql) {
 
 TEST_F(MetadataSpannerStubTest, ExecuteStreamingSql) {
   EXPECT_CALL(*mock_, ExecuteStreamingSql(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              spanner_proto::ExecuteSqlRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       spanner_proto::ExecuteSqlRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.ExecuteStreamingSql",
             expected_api_client_header_));
         return std::unique_ptr<
             grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
-      }));
+      });
 
   MetadataSpannerStub stub(mock_);
   grpc::ClientContext context;
@@ -232,14 +230,14 @@ TEST_F(MetadataSpannerStubTest, Read) {
 
 TEST_F(MetadataSpannerStubTest, StreamingRead) {
   EXPECT_CALL(*mock_, StreamingRead(_, _))
-      .WillOnce(Invoke([this](grpc::ClientContext& context,
-                              spanner_proto::ReadRequest const&) {
+      .WillOnce([this](grpc::ClientContext& context,
+                       spanner_proto::ReadRequest const&) {
         EXPECT_STATUS_OK(spanner_testing::IsContextMDValid(
             context, "google.spanner.v1.Spanner.StreamingRead",
             expected_api_client_header_));
         return std::unique_ptr<
             grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
-      }));
+      });
 
   MetadataSpannerStub stub(mock_);
   grpc::ClientContext context;

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -35,7 +35,6 @@ namespace {
 using ::testing::_;
 using ::testing::ByMove;
 using ::testing::HasSubstr;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::UnorderedElementsAre;
 
@@ -73,13 +72,13 @@ TEST(SessionPool, Allocate) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("project", "instance", "database");
   EXPECT_CALL(*mock, BatchCreateSessions(_, _))
-      .WillOnce(Invoke(
+      .WillOnce(
           [&db](grpc::ClientContext&,
                 spanner_proto::BatchCreateSessionsRequest const& request) {
             EXPECT_EQ(db.FullName(), request.database());
             EXPECT_EQ(1, request.session_count());
             return MakeSessionsResponse({"session1"});
-          }));
+          });
 
   auto pool = MakeSessionPool(db, {mock});
   auto session = pool->Allocate();


### PR DESCRIPTION
It is not necessary to `Invoke()` a lambda in the context of `WillOnce()`
or `WillRepeatedly()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1091)
<!-- Reviewable:end -->
