### PR TITLE
feat: change GetCurrentRow to GetSingularRow

### DIFF
--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -74,7 +74,7 @@ TEST_F(DataTypeIntegrationTest, ReadWriteDate) {
                               " WHERE Id = @id",
                               {{"id", Value("ReadWriteDate-1")}}));
 
-        auto row = GetCurrentRow(StreamOf<RowType>(reader));
+        auto row = GetSingularRow(StreamOf<RowType>(reader));
         if (!row) return std::move(row).status();
         read_back = *std::move(row);
         return Mutations{};

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -452,13 +452,10 @@ auto GetSingularRow(RowRange&& range) -> typename std::decay<
     decltype(*std::forward<RowRange>(range).begin())>::type {
   auto const e = std::forward<RowRange>(range).end();
   auto it = std::forward<RowRange>(range).begin();
-  if (it != e) {
-    auto row = std::move(*it);
-    if (++it == e) return row;
-  }
-  return Status(StatusCode::kInvalidArgument,
-                std::string(it != e ? "too many" : "no") +
-                    " rows (expected exactly one)");
+  if (it == e) return Status(StatusCode::kInvalidArgument, "no rows");
+  auto row = std::move(*it);
+  if (++it != e) return Status(StatusCode::kInvalidArgument, "too many rows");
+  return row;
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -489,7 +489,7 @@ TEST(StreamOf, IterationError) {
 TEST(GetCurrentRow, BasicEmpty) {
   std::vector<Row> rows;
   RowRange range(MakeRowStreamIteratorSource(rows));
-  auto row = GetCurrentRow(range);
+  auto row = GetCurrentRow(std::move(range));
   EXPECT_FALSE(row.ok());
   EXPECT_EQ(row.status().code(), StatusCode::kResourceExhausted);
 }
@@ -499,7 +499,7 @@ TEST(GetCurrentRow, BasicNotEmpty) {
   rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
-  auto row = GetCurrentRow(range);
+  auto row = GetCurrentRow(std::move(range));
   EXPECT_STATUS_OK(row);
   EXPECT_EQ(1, *row->get<std::int64_t>(0));
 }
@@ -511,7 +511,7 @@ TEST(GetCurrentRow, TupleStreamNotEmpty) {
   auto row_range = RowRange(MakeRowStreamIteratorSource(rows));
   auto tup_range = StreamOf<std::tuple<std::int64_t>>(row_range);
 
-  auto row = GetCurrentRow(tup_range);
+  auto row = GetCurrentRow(std::move(tup_range));
   EXPECT_STATUS_OK(row);
   EXPECT_EQ(1, std::get<0>(*row));
 }

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -24,7 +24,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-namespace {
+using ::testing::HasSubstr;
 
 // Given a `vector<StatusOr<Row>>` creates a 'Row::Source' object. This is
 // helpeful for unit testing and letting the test inject a non-OK Status.
@@ -46,18 +46,15 @@ RowStreamIterator::Source MakeRowStreamIteratorSource(
 
 class RowRange {
  public:
-  explicit RowRange(RowStreamIterator::Source s) : begin_(std::move(s)) {}
+  explicit RowRange(RowStreamIterator::Source s) : s_(std::move(s)) {}
   // NOLINTNEXTLINE(readability-identifier-naming)
-  RowStreamIterator begin() const { return begin_; }
+  RowStreamIterator begin() { return RowStreamIterator(s_); }
   // NOLINTNEXTLINE(readability-identifier-naming)
-  RowStreamIterator end() const { return end_; }
+  RowStreamIterator end() { return RowStreamIterator(); }
 
  private:
-  RowStreamIterator begin_;
-  RowStreamIterator end_;
+  RowStreamIterator::Source s_;
 };
-
-}  // namespace
 
 TEST(Row, DefaultConstruct) {
   Row row;
@@ -486,34 +483,68 @@ TEST(StreamOf, IterationError) {
   EXPECT_EQ(it, end);
 }
 
-TEST(GetCurrentRow, BasicEmpty) {
+TEST(GetSingularRow, BasicEmpty) {
   std::vector<Row> rows;
   RowRange range(MakeRowStreamIteratorSource(rows));
-  auto row = GetCurrentRow(std::move(range));
+  auto row = GetSingularRow(range);
   EXPECT_FALSE(row.ok());
-  EXPECT_EQ(row.status().code(), StatusCode::kResourceExhausted);
+  EXPECT_EQ(row.status().code(), StatusCode::kInvalidArgument);
+  EXPECT_THAT(row.status().message(), HasSubstr("no rows"));
 }
 
-TEST(GetCurrentRow, BasicNotEmpty) {
+TEST(GetSingularRow, TupleStreamEmpty) {
+  std::vector<Row> rows;
+  RowRange range(MakeRowStreamIteratorSource(rows));
+  auto row = GetSingularRow(StreamOf<std::tuple<std::int64_t>>(range));
+  EXPECT_FALSE(row.ok());
+  EXPECT_EQ(row.status().code(), StatusCode::kInvalidArgument);
+  EXPECT_THAT(row.status().message(), HasSubstr("no rows"));
+}
+
+TEST(GetSingularRow, BasicSingleRow) {
   std::vector<Row> rows;
   rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
-  auto row = GetCurrentRow(std::move(range));
+  auto row = GetSingularRow(range);
   EXPECT_STATUS_OK(row);
   EXPECT_EQ(1, *row->get<std::int64_t>(0));
 }
 
-TEST(GetCurrentRow, TupleStreamNotEmpty) {
+TEST(GetSingularRow, TupleStreamSingleRow) {
   std::vector<Row> rows;
   rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
 
   auto row_range = RowRange(MakeRowStreamIteratorSource(rows));
   auto tup_range = StreamOf<std::tuple<std::int64_t>>(row_range);
 
-  auto row = GetCurrentRow(std::move(tup_range));
+  auto row = GetSingularRow(tup_range);
   EXPECT_STATUS_OK(row);
   EXPECT_EQ(1, std::get<0>(*row));
+}
+
+TEST(GetSingularRow, BasicTooManyRows) {
+  std::vector<Row> rows;
+  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
+  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
+
+  RowRange range(MakeRowStreamIteratorSource(rows));
+  auto row = GetSingularRow(range);
+  EXPECT_FALSE(row.ok());
+  EXPECT_EQ(row.status().code(), StatusCode::kInvalidArgument);
+  EXPECT_THAT(row.status().message(), HasSubstr("too many rows"));
+}
+
+TEST(GetSingularRow, TupleStreamTooManyRows) {
+  std::vector<Row> rows;
+  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
+  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
+
+  RowRange range(MakeRowStreamIteratorSource(rows));
+  auto row = GetSingularRow(StreamOf<std::tuple<std::int64_t>>(range));
+  EXPECT_FALSE(row.ok());
+  EXPECT_EQ(row.status().code(), StatusCode::kInvalidArgument);
+  EXPECT_THAT(row.status().message(), HasSubstr("too many rows"));
 }
 
 }  // namespace

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -1028,9 +1028,8 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
     auto rows = client.Read(std::move(txn), "Albums", std::move(key),
                             {"MarketingBudget"});
     using RowType = std::tuple<std::int64_t>;
-    // We expect at most one result from the `Read()` request. Return
-    // the first one.
-    auto row = spanner::GetCurrentRow(spanner::StreamOf<RowType>(rows));
+    // We expect at most one result from the `Read()` request.
+    auto row = spanner::GetSingularRow(spanner::StreamOf<RowType>(rows));
     // Return the error (as opposed to throwing an exception) because
     // Commit() only retries on StatusCode::kAborted.
     if (!row) return std::move(row).status();
@@ -1302,7 +1301,7 @@ void DmlGettingStartedUpdate(google::cloud::spanner::Client client) {
     auto key = spanner::KeySet().AddKey(spanner::MakeKey(album_id, singer_id));
     auto rows = client.Read(std::move(txn), "Albums", key, {"MarketingBudget"});
     using RowType = std::tuple<google::cloud::optional<std::int64_t>>;
-    auto row = spanner::GetCurrentRow(spanner::StreamOf<RowType>(rows));
+    auto row = spanner::GetSingularRow(spanner::StreamOf<RowType>(rows));
     if (!row) return row.status();
     auto const budget = std::get<0>(*row);
     return budget ? *budget : 0;

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -1028,7 +1028,6 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
     auto rows = client.Read(std::move(txn), "Albums", std::move(key),
                             {"MarketingBudget"});
     using RowType = std::tuple<std::int64_t>;
-    // We expect at most one result from the `Read()` request.
     auto row = spanner::GetSingularRow(spanner::StreamOf<RowType>(rows));
     // Return the error (as opposed to throwing an exception) because
     // Commit() only retries on StatusCode::kAborted.


### PR DESCRIPTION
After some discussion with the local folks, we decided to change the semantics and name of `GetCurrentRow` that was added in #1074. Previously `GetCurrentRow` would return the first row in a range that might potentially contain multiple rows. The observation is that those may not be the best or safest semantics for callers.

The use case we're trying to address is when a callers does a query/read and they know that only one row should be returned. Maybe they used `LIMIT 1`, or maybe they specified a primary key to guarantee this. In any case, if they know that only one result can be returned, it would be nice to let them conveniently access that one row without having to create a loop, break out, etc.

The problem with `GetCurrentRow` was that _if_ the row range happened to have _more_ than one row, there would be no error and the user may never notice this. So it seems safer to clearly name this function and change its semantics so that it will produce an error if the given range does not contain *exactly* a single row.

We also considered requiring the caller to pass an rvalue (i.e., std::move the range into the argument). The reason I don't enforce this is because that would then prevent callers for subsequently calling the `RowStream::ReadTimestamp` function.

Adding @devbww as the reviewer since he initially raised some of these questions. And cc: @coryan  and @mr-salty as potentially interested observers who are welcome to comment if they want.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1092)
<!-- Reviewable:end -->
