### PR TITLE
feat: benchmark CPU overhead for UPDATE

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -411,8 +411,9 @@ class ExperimentImpl {
     std::lock_guard<std::mutex> lk(mu_);
     std::copy(samples.begin(), samples.end(),
               std::ostream_iterator<RowCpuSample>(std::cout, "\n"));
-    auto it = std::find_if(samples.begin(), samples.end(),
-        [](RowCpuSample const& x) { return !x.status.ok(); });
+    auto it =
+        std::find_if(samples.begin(), samples.end(),
+                     [](RowCpuSample const& x) { return !x.status.ok(); });
     if (it == samples.end()) {
       return;
     }
@@ -903,7 +904,8 @@ class UpdateExperiment : public Experiment {
         grpc::ClientContext context;
         auto response = stub->ExecuteSql(context, request);
         if (response) {
-          row_count = static_cast<int>(response->stats().row_count_lower_bound());
+          row_count =
+              static_cast<int>(response->stats().row_count_lower_bound());
           transaction_id = response->metadata().transaction().id();
         } else {
           status = std::move(response).status();
@@ -918,8 +920,6 @@ class UpdateExperiment : public Experiment {
         auto response = stub->Commit(context, commit_request);
         if (!response) status = std::move(response).status();
       }
-
-
 
       timer.Stop();
       samples.push_back(RowCpuSample{thread_count, client_count, true,

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -402,7 +402,7 @@ class ExperimentImpl {
   }
 
   /// Get a snapshot of the random bit generator
-  google::cloud::internal::DefaultPRNG generator() const {
+  google::cloud::internal::DefaultPRNG Generator() const {
     std::lock_guard<std::mutex> lk(mu_);
     return generator_;
   };
@@ -530,7 +530,7 @@ class ReadExperiment : public Experiment {
                                                         config.maximum_threads);
 
     // Get a snapshot of the generator, to be used in this thread only.
-    auto generator = impl_.generator();
+    auto generator = impl_.Generator();
 
     // Capture some overall getrusage() statistics as comments.
     SimpleTimer overall;
@@ -770,7 +770,7 @@ class UpdateExperiment : public Experiment {
     std::uniform_int_distribution<int> thread_count_gen(config.minimum_threads,
                                                         config.maximum_threads);
 
-    auto generator = impl_.generator();
+    auto generator = impl_.Generator();
     // Capture some overall getrusage() statistics as comments.
     SimpleTimer overall;
     overall.Start();

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -1012,7 +1012,7 @@ class RunAllExperiment : public Experiment {
       config.table_size = 10;
       config.query_size = 1;
       std::cout << "# Smoke test for experiment: " << kv.first << "\n";
-      std::cout << cfg << "\n" << std::flush;
+      std::cout << config << "\n" << std::flush;
       auto experiment = kv.second(generator_);
       auto status = experiment->SetUp(config, database);
       if (!status.ok()) {

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -902,7 +902,7 @@ class UpdateExperiment : public Experiment {
       auto response = stub->ExecuteSql(context, request);
       int row_count = 0;
       if (response) {
-        row_count = response->stats().row_count_lower_bound();
+        row_count = static_cast<int>(response->stats().row_count_lower_bound());
       }
       timer.Stop();
       samples.push_back(RowCpuSample{thread_count, client_count, true,

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -480,7 +480,7 @@ class ExperimentImpl {
       }
       mutation.EmplaceRow(key, value0, value1, value2, value3, value4, value5,
                           value6, value7, value8, value9);
-      current_mutations++;
+      ++current_mutations;
       auto status = flush_as_needed();
       if (!status.ok()) return status;
     }


### PR DESCRIPTION
Add new benchmarks to measure the CPU overhead (if any) of making
`UPDATE` queries via the client library vs. the raw gRPC code. The
benchmarks can measure the overhead for different data types.

Fixes #1016

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1095)
<!-- Reviewable:end -->
