### PR TITLE
feat: add more DataType tests

### DIFF
--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -34,7 +34,8 @@ using ::testing::UnorderedElementsAreArray;
 // given data to the DataTypes table, then it reads all the data back and
 // returns it to the caller.
 template <typename T>
-StatusOr<T> WriteReadData(Client& client, T const& data, std::string const& column) {
+StatusOr<T> WriteReadData(Client& client, T const& data,
+                          std::string const& column) {
   auto commit_result = client.Commit(
       [&data, &column](Transaction const& txn) -> StatusOr<Mutations> {
         Mutations mutations;

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -173,11 +173,12 @@ TEST_F(DataTypeIntegrationTest, WriteReadBytes) {
 }
 
 TEST_F(DataTypeIntegrationTest, WriteReadTimestamp) {
-  auto min = internal::TimestampFromString("0001-01-01T00:00:00Z");
-  auto max = internal::TimestampFromString("9999-12-31T23:59:59.999999999Z");
+  // TODO(#1098): `Timestamp` cannot represent these extreme values.
+  // auto min = internal::TimestampFromString("0001-01-01T00:00:00Z");
+  // auto max = internal::TimestampFromString("9999-12-31T23:59:59.999999999Z");
 
-  ASSERT_STATUS_OK(min);
-  ASSERT_STATUS_OK(max);
+  // ASSERT_STATUS_OK(min);
+  // ASSERT_STATUS_OK(max);
 
   std::vector<Timestamp> const data = {
       // *min,  // TODO(#1098)

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -180,14 +180,14 @@ TEST_F(DataTypeIntegrationTest, WriteReadTimestamp) {
   ASSERT_STATUS_OK(max);
 
   std::vector<Timestamp> const data = {
-      *min,
+      // *min,  // TODO(#1098)
       Timestamp(std::chrono::seconds(-1)),
       Timestamp(std::chrono::nanoseconds(-1)),
       Timestamp(std::chrono::seconds(0)),
       Timestamp(std::chrono::nanoseconds(1)),
       Timestamp(std::chrono::seconds(1)),
       Timestamp(std::chrono::system_clock::now()),
-      *max,
+      // *max,  // TODO(#1098)
   };
   auto result = WriteReadData(*client_, data, "TimestampValue");
   ASSERT_STATUS_OK(result);

--- a/google/cloud/spanner/testing/database_environment.cc
+++ b/google/cloud/spanner/testing/database_environment.cc
@@ -52,8 +52,12 @@ void DatabaseEnvironment::SetUp() {
                                          R"sql(CREATE TABLE DataTypes (
     Id STRING(256) NOT NULL,
     BoolValue BOOL,
-    DateValue DATE,
+    Int64Value INT64,
+    Float64Value FLOAT64,
     StringValue STRING(1024),
+    BytesValue BYTES(1024),
+    TimestampValue TIMESTAMP,
+    DateValue DATE
   ) PRIMARY KEY (Id))sql"});
   int i = 0;
   int const timeout = 120;


### PR DESCRIPTION
Part of #1096

This PR adds DataType integration tests for all the non-aggregate
spanner value types that. I'll add the array and struct types in a
follow up PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1097)
<!-- Reviewable:end -->
