### PR TITLE
drop executable requirement for INTEGRATION_TEST_CONFIG

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -76,7 +76,7 @@ readonly INTEGRATION_TESTS_CONFIG="/c/spanner-integration-tests-config.sh"
 # auto: only try to run integration tests if the config file is executable.
 if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
       ( "${RUN_INTEGRATION_TESTS}" == "auto" && \
-        -x "${INTEGRATION_TESTS_CONFIG}" ) ]]; then
+        -r "${INTEGRATION_TESTS_CONFIG}" ) ]]; then
   echo "================================================================"
   echo "Running the integration tests $(date)"
   echo "================================================================"

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -97,7 +97,7 @@ fi
 readonly INTEGRATION_TESTS_CONFIG="/c/spanner-integration-tests-config.sh"
 if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
       ( "${RUN_INTEGRATION_TESTS}" == "auto" && \
-        -x "${INTEGRATION_TESTS_CONFIG}" ) ]]; then
+        -r "${INTEGRATION_TESTS_CONFIG}" ) ]]; then
   echo "================================================================"
   echo "Running the integration tests $(date)"
   echo "================================================================"


### PR DESCRIPTION
we only `source` that script so it doesn't need to be executable, only
readable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1099)
<!-- Reviewable:end -->
