### PR TITLE
bug: optimize Timestamp conversions to/from string

### DIFF
--- a/google/cloud/spanner/internal/time.cc
+++ b/google/cloud/spanner/internal/time.cc
@@ -14,7 +14,9 @@
 
 #include "google/cloud/spanner/internal/time.h"
 #include "google/cloud/spanner/internal/time_format.h"
+#include <array>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <iomanip>
@@ -52,8 +54,7 @@ std::chrono::nanoseconds FromProto(google::protobuf::Duration const& proto) {
 
 namespace {
 
-// RFC3339 "date-time" prefix (no "time-secfrac" or "time-offset").
-constexpr auto kTimeFormat = "%Y-%m-%dT%H:%M:%S";
+constexpr auto kDigits = "0123456789";
 
 // Split a Timestamp into a seconds-since-epoch and a (>=0) subsecond.
 std::pair<std::chrono::seconds, Timestamp::duration> SplitTime(Timestamp ts) {
@@ -157,10 +158,10 @@ Timestamp FromProto(google::protobuf::Timestamp const& proto) {
 
 // TODO(#145): Reconcile this implementation with FormatRfc3339() in
 // google/cloud/internal/format_time_point.h in google-cloud-cpp.
-std::string TimestampToString(Timestamp ts) {
+std::string TimestampToString(Timestamp ts, std::chrono::minutes utc_offset) {
   std::ostringstream output;
   auto p = SplitTime(ts);
-  output << FormatTime(kTimeFormat, ZTime(p.first));
+  output << FormatTime(ZTime(p.first + utc_offset));
 
   if (auto ss = p.second.count()) {
     int width = 0;
@@ -176,7 +177,13 @@ std::string TimestampToString(Timestamp ts) {
     output << '.' << std::setfill('0') << std::setw(width) << ss;
   }
 
-  output << 'Z';
+  if (auto const minutes = utc_offset.count()) {
+    output << std::setfill('0') << std::internal << std::showpos
+           << std::setw(1 + 2) << (minutes / 60) << ':' << std::noshowpos
+           << std::setw(2) << std::abs(minutes % 60);
+  } else {
+    output << 'Z';
+  }
   return output.str();
 }
 
@@ -185,19 +192,21 @@ std::string TimestampToString(Timestamp ts) {
 StatusOr<Timestamp> TimestampFromString(std::string const& s) {
   std::tm tm;
   auto const len = s.size();
-  auto pos = ParseTime(kTimeFormat, s, &tm);
-  if (pos == std::string::npos || pos == len) {
+
+  // Parse full-date "T" time-hour ":" time-minute ":" time-second.
+  auto pos = ParseTime(s, &tm);
+  if (pos == std::string::npos) {
     return Status(StatusCode::kInvalidArgument,
                   s + ": Failed to match RFC3339 date-time");
   }
 
+  // Parse time-secfrac.
   Timestamp::duration ss(0);
-  if (s[pos] == '.') {
+  if (pos != len && s[pos] == '.') {
     Timestamp::duration::rep v = 0;
     auto scale = Timestamp::duration::period::den;
-    auto fpos = pos + 1;  // start of fractional part
+    auto fpos = pos + 1;  // start of fractional digits
     while (++pos != len) {
-      static constexpr auto kDigits = "0123456789";
       char const* dp = std::strchr(kDigits, s[pos]);
       if (dp == nullptr || *dp == '\0') break;  // non-digit
       if (scale == 1) continue;                 // drop insignificant digits
@@ -209,19 +218,66 @@ StatusOr<Timestamp> TimestampFromString(std::string const& s) {
       return Status(StatusCode::kInvalidArgument,
                     s + ": RFC3339 time-secfrac must include a digit");
     }
-    ss = Timestamp::duration(v * scale);
+    ss = scale * Timestamp::duration(v);
   }
 
-  if (pos == len || s[pos] != 'Z') {
-    return Status(StatusCode::kInvalidArgument,
-                  s + ": Missing RFC3339 time-offset 'Z'");
+  // Parse time-offset.
+  std::chrono::minutes utc_offset = std::chrono::minutes::zero();
+  bool offset_error = (pos == len);
+  if (!offset_error) {
+    switch (s[pos]) {
+      case 'Z':  // Zulu time
+      case 'z': {
+        ++pos;
+        break;
+      }
+      case '+':  // [-+]HH:MM
+      case '-': {
+        // Parse colon-separated hours, minutes, but not (yet) seconds.
+        std::array<std::chrono::minutes::rep, 2> fields = {{0, 0}};
+        auto it = fields.begin();
+        auto min_it = it + 1;  // how far we must reach for success (minutes)
+        int const sign = (s[pos] == '-') ? -1 : 1;
+        auto ipos = pos + 1;  // start of integer digits
+        while (++pos != len) {
+          if (s[pos] == ':') {
+            if (++it == fields.end()) break;  // too many fields
+            if (pos == ipos) break;           // missing digit
+            ipos = pos + 1;
+          } else {
+            char const* dp = std::strchr(kDigits, s[pos]);
+            if (dp == nullptr || *dp == '\0') break;  // non-digit
+            *it *= 10;
+            *it += dp - kDigits;
+            if (*it >= 100) break;  // avoid overflow using overall bound
+          }
+        }
+        if (pos == ipos || it < min_it || fields[0] >= 24 || fields[1] >= 60) {
+          // Missing digit, not enough fields, or a field out of range.
+          offset_error = true;
+        } else {
+          utc_offset += std::chrono::hours(fields[0]);
+          utc_offset += std::chrono::minutes(fields[1]);
+          utc_offset *= sign;
+        }
+        break;
+      }
+      default: {
+        offset_error = true;
+        break;
+      }
+    }
   }
-  if (++pos != len) {
+  if (offset_error) {
+    return Status(StatusCode::kInvalidArgument,
+                  s + ": Failed to match RFC3339 time-offset");
+  }
+
+  if (pos != len) {
     return Status(StatusCode::kInvalidArgument,
                   s + ": Extra data after RFC3339 date-time");
   }
-
-  return CombineTime(TimeZ(tm), ss);
+  return CombineTime(TimeZ(tm) + utc_offset, ss);
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/time.cc
+++ b/google/cloud/spanner/internal/time.cc
@@ -212,7 +212,7 @@ StatusOr<Timestamp> TimestampFromString(std::string const& s) {
       if (scale == 1) continue;                 // drop insignificant digits
       scale /= 10;
       v *= 10;
-      v += dp - kDigits;
+      v += static_cast<Timestamp::duration::rep>(dp - kDigits);
     }
     if (pos == fpos) {
       return Status(StatusCode::kInvalidArgument,
@@ -248,7 +248,7 @@ StatusOr<Timestamp> TimestampFromString(std::string const& s) {
             char const* dp = std::strchr(kDigits, s[pos]);
             if (dp == nullptr || *dp == '\0') break;  // non-digit
             *it *= 10;
-            *it += dp - kDigits;
+            *it += static_cast<std::chrono::minutes::rep>(dp - kDigits);
             if (*it >= 100) break;  // avoid overflow using overall bound
           }
         }

--- a/google/cloud/spanner/internal/time.h
+++ b/google/cloud/spanner/internal/time.h
@@ -51,13 +51,17 @@ Timestamp FromProto(google::protobuf::Timestamp const& proto);
 
 /**
  * Convert a google::cloud::spanner::Timestamp to an RFC3339 "date-time".
+ *
+ * If @p utc_offset is non-zero, render the timestamp with a "[-+]HH:MM" UTC
+ * offset. Otherwise use a "Z" to specify Zulu time (+00:00).
  */
-std::string TimestampToString(Timestamp ts);
+std::string TimestampToString(Timestamp ts, std::chrono::minutes utc_offset =
+                                                std::chrono::minutes::zero());
 
 /**
  * Convert an RFC3339 "date-time" to a google::cloud::spanner::Timestamp.
  *
- * Returns a a non-OK Status if the input cannot be parsed.
+ * Returns a non-OK Status if the input cannot be parsed.
  */
 StatusOr<Timestamp> TimestampFromString(std::string const& s);
 

--- a/google/cloud/spanner/internal/time_format.cc
+++ b/google/cloud/spanner/internal/time_format.cc
@@ -48,6 +48,8 @@ inline char* Format02d(char* ep, int v) {
   return ep;
 }
 
+// We eschew std::strtol() for reasons of over-generality (whitespace skip,
+// plus-sign parsing, locale-specific formats).
 char const* ParseInt(char const* dp, int min, int max, int* vp) {
   int value = 0;
   bool neg = false;

--- a/google/cloud/spanner/internal/time_format.cc
+++ b/google/cloud/spanner/internal/time_format.cc
@@ -21,6 +21,9 @@
 #endif
 
 #include "google/cloud/spanner/internal/time_format.h"
+#include <array>
+#include <cstring>
+#include <limits>
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 5
 #include <time.h>  // <ctime> doesn't have to declare strptime()
 #else
@@ -33,6 +36,62 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
+
+namespace {
+
+constexpr auto kDigits = "0123456789";
+
+// Formats [0 .. 99] as %02d.
+inline char* Format02d(char* ep, int v) {
+  *--ep = kDigits[v % 10];
+  *--ep = kDigits[(v / 10) % 10];
+  return ep;
+}
+
+char const* ParseInt(char const* dp, int min, int max, int* vp) {
+  int value = 0;
+  bool neg = false;
+  if (*dp == '-') {
+    neg = true;
+    ++dp;
+  }
+  char const* const bp = dp;
+  constexpr int kMin = std::numeric_limits<int>::min();
+  while (char const* cp = std::strchr(kDigits, *dp)) {
+    int d = static_cast<int>(cp - kDigits);
+    if (d >= 10) break;  // non-digit
+    if (value < kMin / 10) return nullptr;
+    value *= 10;
+    if (value < kMin + d) return nullptr;
+    value -= d;
+    ++dp;
+  }
+  if (dp == bp) return nullptr;
+  if (!neg) {
+    if (value == kMin) return nullptr;
+    value = -value;  // make positive
+  }
+  if (value < min || max < value) return nullptr;
+  *vp = value;
+  return dp;
+}
+
+inline bool LeapYear(int y) {
+  return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+}
+
+// Note: tm.tm_year and tm.tm_mon are unadjusted (i.e., have true values).
+bool ValidDay(std::tm const& tm) {
+  static constexpr std::array<int, 1 + 12> kMonthDays = {
+      {-1, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}  // non leap year
+  };
+  if (tm.tm_mon == 2 && LeapYear(tm.tm_year)) {
+    return tm.tm_mday <= 29;
+  }
+  return tm.tm_mday <= kMonthDays[tm.tm_mon];
+}
+
+}  // namespace
 
 std::string FormatTime(char const* fmt, std::tm const& tm) {
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 5
@@ -53,6 +112,46 @@ std::string FormatTime(char const* fmt, std::tm const& tm) {
 #endif
 }
 
+std::string FormatTime(std::tm const& tm) {
+  std::array<char, sizeof "-9223372036854775808-01-01T23:59:59"> buf;
+  char* ep = buf.data() + buf.size();
+  *--ep = '\0';
+  ep = Format02d(ep, tm.tm_sec);
+  *--ep = ':';
+  ep = Format02d(ep, tm.tm_min);
+  *--ep = ':';
+  ep = Format02d(ep, tm.tm_hour);
+  *--ep = 'T';
+  ep = Format02d(ep, tm.tm_mday);
+  *--ep = '-';
+  ep = Format02d(ep, tm.tm_mon + 1);
+  *--ep = '-';
+  // Produce a 4-char tm_year rendering when possible.
+  auto year = tm.tm_year + 1900LL;
+  char sign = '\0';
+  if (year < 0) {
+    sign = '-';
+    year = -year;
+  }
+  ep = Format02d(ep, static_cast<int>(year % 100));
+  year /= 100;
+  if (sign != '\0') {
+    *--ep = kDigits[year % 10];
+    year /= 10;
+  } else {
+    ep = Format02d(ep, static_cast<int>(year % 100));
+    year /= 100;
+  }
+  while (year != 0) {
+    *--ep = kDigits[year % 10];
+    year /= 10;
+  }
+  if (sign != '\0') {
+    *--ep = sign;
+  }
+  return ep;
+}
+
 std::size_t ParseTime(char const* fmt, std::string const& s, std::tm* tm) {
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 5
   char const* const bp = s.c_str();
@@ -68,6 +167,38 @@ std::size_t ParseTime(char const* fmt, std::string const& s, std::tm* tm) {
   if (pos >= 0) return pos;
   return s.size();
 #endif
+}
+
+std::size_t ParseTime(std::string const& s, std::tm* tm) {
+  constexpr auto kYearMin = std::numeric_limits<int>::min() + 1900;
+  constexpr auto kYearMax = std::numeric_limits<int>::max();
+  std::tm tmp{};
+  char const* dp = ParseInt(s.c_str(), kYearMin, kYearMax, &tmp.tm_year);
+  if (dp != nullptr && *dp == '-') {
+    dp = ParseInt(dp + 1, 1, 12, &tmp.tm_mon);
+    if (dp != nullptr && *dp == '-') {
+      dp = ParseInt(dp + 1, 1, 31, &tmp.tm_mday);  // refine range next
+      if (dp != nullptr && ValidDay(tmp) && (*dp == 'T' || *dp == 't')) {
+        dp = ParseInt(dp + 1, 0, 23, &tmp.tm_hour);
+        if (dp != nullptr && *dp == ':') {
+          dp = ParseInt(dp + 1, 0, 59, &tmp.tm_min);
+          if (dp != nullptr && *dp == ':') {
+            // The tm_sec range allows for a positive leap second.  The true
+            // maximum for a particular minute depends on leap-second rules,
+            // which we don't have, and can't predict.
+            dp = ParseInt(dp + 1, 0, 60, &tmp.tm_sec);
+            if (dp != nullptr) {
+              tmp.tm_year -= 1900;
+              tmp.tm_mon -= 1;
+              *tm = tmp;
+              return dp - s.c_str();
+            }
+          }
+        }
+      }
+    }
+  }
+  return std::string::npos;
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/time_format.h
+++ b/google/cloud/spanner/internal/time_format.h
@@ -28,17 +28,31 @@ namespace internal {
 
 /**
  * Format the date/time information from `tm` into a string according to
- * format string `fmt`.
+ * format string `fmt` (as defined by `std::put_time()`).
  */
 std::string FormatTime(char const* fmt, std::tm const& tm);
 
 /**
- * Parse the date/time string `s` according to format string `fmt`, storing
- * the result in the std::tm addressed by `tm`. Returns std::string::npos if
- * the format string could not be matched. Otherwise returns the position of
- * the first character not consumed (s.size() if the entire string matched).
+ * Like `FormatTime("%Y-%m-%dT%H:%M:%S", tm)` but optimized for the fixed
+ * format, and produces a 4-char `tm.tm_year` rendering when possible (unlike
+ * the "%Y" format specifier).
+ */
+std::string FormatTime(std::tm const& tm);
+
+/**
+ * Parse the date/time string `s` according to format string `fmt` (as defined
+ * by `std::get_time()`), storing the result in the std::tm addressed by
+ * `tm`. Returns std::string::npos if the format string could not be matched.
+ * Otherwise returns the position of the first character not consumed (s.size()
+ * if the entire string matched).
  */
 std::size_t ParseTime(char const* fmt, std::string const& s, std::tm* tm);
+
+/**
+ * Like `ParseTime("%Y-%m-%dT%H:%M:%S", s, tm)` but optimized for the fixed
+ * format.
+ */
+std::size_t ParseTime(std::string const& s, std::tm* tm);
 
 }  // namespace internal
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/internal/time_format_test.cc
+++ b/google/cloud/spanner/internal/time_format_test.cc
@@ -48,6 +48,7 @@ TEST(TimeFormat, Format) {
   EXPECT_EQ("123-06-21T16:52:22", FormatTime(kTimeFormat, tm));
 #endif
 
+#if !defined(_WIN32)
   tm.tm_year = -12 - 1900;
   tm.tm_mon = 6 - 1;
   tm.tm_mday = 21;
@@ -58,6 +59,7 @@ TEST(TimeFormat, Format) {
   EXPECT_EQ("-012-06-21T16:52:22", FormatTime(kTimeFormat, tm));
 #else
   EXPECT_EQ("-12-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+#endif
 #endif
 }
 

--- a/google/cloud/spanner/internal/time_format_test.cc
+++ b/google/cloud/spanner/internal/time_format_test.cc
@@ -27,6 +27,7 @@ constexpr auto kTimeFormat = "%Y-%m-%dT%H:%M:%S";
 
 TEST(TimeFormat, Format) {
   std::tm tm;
+
   tm.tm_year = 2019 - 1900;
   tm.tm_mon = 6 - 1;
   tm.tm_mday = 21;
@@ -34,6 +35,50 @@ TEST(TimeFormat, Format) {
   tm.tm_min = 52;
   tm.tm_sec = 22;
   EXPECT_EQ("2019-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+
+  tm.tm_year = 123 - 1900;
+  tm.tm_mon = 6 - 1;
+  tm.tm_mday = 21;
+  tm.tm_hour = 16;
+  tm.tm_min = 52;
+  tm.tm_sec = 22;
+  EXPECT_EQ("123-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+
+  tm.tm_year = -12 - 1900;
+  tm.tm_mon = 6 - 1;
+  tm.tm_mday = 21;
+  tm.tm_hour = 16;
+  tm.tm_min = 52;
+  tm.tm_sec = 22;
+  EXPECT_EQ("-12-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+}
+
+TEST(TimeFormat, FormatFixed) {
+  std::tm tm;
+
+  tm.tm_year = 2019 - 1900;
+  tm.tm_mon = 6 - 1;
+  tm.tm_mday = 21;
+  tm.tm_hour = 16;
+  tm.tm_min = 52;
+  tm.tm_sec = 22;
+  EXPECT_EQ("2019-06-21T16:52:22", FormatTime(tm));
+
+  tm.tm_year = 123 - 1900;
+  tm.tm_mon = 6 - 1;
+  tm.tm_mday = 21;
+  tm.tm_hour = 16;
+  tm.tm_min = 52;
+  tm.tm_sec = 22;
+  EXPECT_EQ("0123-06-21T16:52:22", FormatTime(tm));  // note 4-char year
+
+  tm.tm_year = -12 - 1900;
+  tm.tm_mon = 6 - 1;
+  tm.tm_mday = 21;
+  tm.tm_hour = 16;
+  tm.tm_min = 52;
+  tm.tm_sec = 22;
+  EXPECT_EQ("-012-06-21T16:52:22", FormatTime(tm));  // note 4-char year
 }
 
 TEST(TimeFormat, Parse) {
@@ -56,6 +101,28 @@ TEST(TimeFormat, Parse) {
   EXPECT_EQ(tm.tm_sec, 23);
 
   EXPECT_EQ(std::string::npos, ParseTime(kTimeFormat, "garbage in", &tm));
+}
+
+TEST(TimeFormat, ParseFixed) {
+  std::tm tm{};
+
+  EXPECT_EQ(19, ParseTime("2019-06-21T16:52:22", &tm));
+  EXPECT_EQ(tm.tm_year, 2019 - 1900);
+  EXPECT_EQ(tm.tm_mon, 6 - 1);
+  EXPECT_EQ(tm.tm_mday, 21);
+  EXPECT_EQ(tm.tm_hour, 16);
+  EXPECT_EQ(tm.tm_min, 52);
+  EXPECT_EQ(tm.tm_sec, 22);
+
+  EXPECT_EQ(19, ParseTime("2020-07-22T17:53:23xxx", &tm));
+  EXPECT_EQ(tm.tm_year, 2020 - 1900);
+  EXPECT_EQ(tm.tm_mon, 7 - 1);
+  EXPECT_EQ(tm.tm_mday, 22);
+  EXPECT_EQ(tm.tm_hour, 17);
+  EXPECT_EQ(tm.tm_min, 53);
+  EXPECT_EQ(tm.tm_sec, 23);
+
+  EXPECT_EQ(std::string::npos, ParseTime("garbage in", &tm));
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/time_format_test.cc
+++ b/google/cloud/spanner/internal/time_format_test.cc
@@ -36,6 +36,7 @@ TEST(TimeFormat, Format) {
   tm.tm_sec = 22;
   EXPECT_EQ("2019-06-21T16:52:22", FormatTime(kTimeFormat, tm));
 
+#if !defined(_WIN32)
   tm.tm_year = 10000 - 1900;
   tm.tm_mon = 6 - 1;
   tm.tm_mday = 21;
@@ -43,6 +44,7 @@ TEST(TimeFormat, Format) {
   tm.tm_min = 52;
   tm.tm_sec = 22;
   EXPECT_EQ("10000-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+#endif
 
   tm.tm_year = 123 - 1900;
   tm.tm_mon = 6 - 1;

--- a/google/cloud/spanner/internal/time_format_test.cc
+++ b/google/cloud/spanner/internal/time_format_test.cc
@@ -42,7 +42,7 @@ TEST(TimeFormat, Format) {
   tm.tm_hour = 16;
   tm.tm_min = 52;
   tm.tm_sec = 22;
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(_WIN32)
   EXPECT_EQ("0123-06-21T16:52:22", FormatTime(kTimeFormat, tm));
 #else
   EXPECT_EQ("123-06-21T16:52:22", FormatTime(kTimeFormat, tm));
@@ -100,10 +100,10 @@ TEST(TimeFormat, Parse) {
   EXPECT_EQ(tm.tm_min, 52);
   EXPECT_EQ(tm.tm_sec, 22);
 
-  EXPECT_EQ(19, ParseTime(kTimeFormat, "2020-07-22T17:53:23xxx", &tm));
+  EXPECT_EQ(19, ParseTime(kTimeFormat, "2020-02-29T17:53:23xxx", &tm));
   EXPECT_EQ(tm.tm_year, 2020 - 1900);
-  EXPECT_EQ(tm.tm_mon, 7 - 1);
-  EXPECT_EQ(tm.tm_mday, 22);
+  EXPECT_EQ(tm.tm_mon, 2 - 1);
+  EXPECT_EQ(tm.tm_mday, 29);
   EXPECT_EQ(tm.tm_hour, 17);
   EXPECT_EQ(tm.tm_min, 53);
   EXPECT_EQ(tm.tm_sec, 23);
@@ -122,10 +122,10 @@ TEST(TimeFormat, ParseFixed) {
   EXPECT_EQ(tm.tm_min, 52);
   EXPECT_EQ(tm.tm_sec, 22);
 
-  EXPECT_EQ(19, ParseTime("2020-07-22T17:53:23xxx", &tm));
+  EXPECT_EQ(19, ParseTime("2020-02-29T17:53:23xxx", &tm));
   EXPECT_EQ(tm.tm_year, 2020 - 1900);
-  EXPECT_EQ(tm.tm_mon, 7 - 1);
-  EXPECT_EQ(tm.tm_mday, 22);
+  EXPECT_EQ(tm.tm_mon, 2 - 1);
+  EXPECT_EQ(tm.tm_mday, 29);
   EXPECT_EQ(tm.tm_hour, 17);
   EXPECT_EQ(tm.tm_min, 53);
   EXPECT_EQ(tm.tm_sec, 23);

--- a/google/cloud/spanner/internal/time_format_test.cc
+++ b/google/cloud/spanner/internal/time_format_test.cc
@@ -42,7 +42,11 @@ TEST(TimeFormat, Format) {
   tm.tm_hour = 16;
   tm.tm_min = 52;
   tm.tm_sec = 22;
+#if defined(__APPLE__)
+  EXPECT_EQ("0123-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+#else
   EXPECT_EQ("123-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+#endif
 
   tm.tm_year = -12 - 1900;
   tm.tm_mon = 6 - 1;
@@ -50,7 +54,11 @@ TEST(TimeFormat, Format) {
   tm.tm_hour = 16;
   tm.tm_min = 52;
   tm.tm_sec = 22;
+#if defined(__APPLE__)
+  EXPECT_EQ("-012-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+#else
   EXPECT_EQ("-12-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+#endif
 }
 
 TEST(TimeFormat, FormatFixed) {

--- a/google/cloud/spanner/internal/time_format_test.cc
+++ b/google/cloud/spanner/internal/time_format_test.cc
@@ -36,6 +36,14 @@ TEST(TimeFormat, Format) {
   tm.tm_sec = 22;
   EXPECT_EQ("2019-06-21T16:52:22", FormatTime(kTimeFormat, tm));
 
+  tm.tm_year = 10000 - 1900;
+  tm.tm_mon = 6 - 1;
+  tm.tm_mday = 21;
+  tm.tm_hour = 16;
+  tm.tm_min = 52;
+  tm.tm_sec = 22;
+  EXPECT_EQ("10000-06-21T16:52:22", FormatTime(kTimeFormat, tm));
+
   tm.tm_year = 123 - 1900;
   tm.tm_mon = 6 - 1;
   tm.tm_mday = 21;
@@ -73,6 +81,14 @@ TEST(TimeFormat, FormatFixed) {
   tm.tm_min = 52;
   tm.tm_sec = 22;
   EXPECT_EQ("2019-06-21T16:52:22", FormatTime(tm));
+
+  tm.tm_year = 10000 - 1900;
+  tm.tm_mon = 6 - 1;
+  tm.tm_mday = 21;
+  tm.tm_hour = 16;
+  tm.tm_min = 52;
+  tm.tm_sec = 22;
+  EXPECT_EQ("10000-06-21T16:52:22", FormatTime(tm));
 
   tm.tm_year = 123 - 1900;
   tm.tm_mon = 6 - 1;

--- a/google/cloud/spanner/internal/time_test.cc
+++ b/google/cloud/spanner/internal/time_test.cc
@@ -349,6 +349,7 @@ TEST(Time, TimestampFromStringFailure) {
 
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+0:"));
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+:0"));
+  EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+0:-0"));
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22x00:00"));
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+ab:cd"));
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22-24:60"));

--- a/google/cloud/spanner/internal/time_test.cc
+++ b/google/cloud/spanner/internal/time_test.cc
@@ -346,6 +346,7 @@ TEST(Time, TimestampFromStringFailure) {
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22.9"));
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22.Z"));
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22ZX"));
+  EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:-22Z"));
 
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+0:"));
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+:0"));

--- a/google/cloud/spanner/internal/time_test.cc
+++ b/google/cloud/spanner/internal/time_test.cc
@@ -262,6 +262,16 @@ TEST(Time, TimestampToString) {
   EXPECT_EQ("2019-06-21T16:52:22Z", TimestampToString(ts));
 }
 
+TEST(Time, TimestampToStringOffset) {
+  Timestamp ts = FromTimeT(1546398245);
+  auto utc_offset = std::chrono::minutes::zero();
+  EXPECT_EQ("2019-01-02T03:04:05Z", TimestampToString(ts, utc_offset));
+  utc_offset = -std::chrono::minutes(1 * 60 + 2);
+  EXPECT_EQ("2019-01-02T02:02:05-01:02", TimestampToString(ts, utc_offset));
+  utc_offset = std::chrono::minutes(1 * 60 + 2);
+  EXPECT_EQ("2019-01-02T04:06:05+01:02", TimestampToString(ts, utc_offset));
+}
+
 TEST(Time, TimestampToStringLimit) {
   Timestamp ts = FromTimeT(-9223372036L);
   EXPECT_EQ("1677-09-21T00:12:44Z", TimestampToString(ts));
@@ -311,6 +321,24 @@ TEST(Time, TimestampFromString) {
   EXPECT_EQ(ts, TimestampFromString("2019-06-21T16:52:22Z").value());
 }
 
+TEST(Time, TimestampFromStringOffset) {
+  Timestamp ts = FromTimeT(1546398245);
+  EXPECT_EQ(ts + std::chrono::minutes::zero(),
+            TimestampFromString("2019-01-02T03:04:05+00:00").value());
+  EXPECT_EQ(ts + std::chrono::hours(1) + std::chrono::minutes(2),
+            TimestampFromString("2019-01-02T03:04:05+01:02").value());
+  EXPECT_EQ(ts - std::chrono::hours(1) - std::chrono::minutes(2),
+            TimestampFromString("2019-01-02T03:04:05-01:02").value());
+}
+
+TEST(Time, TimestampFromStringLimit) {
+  Timestamp ts = FromTimeT(-9223372036L);
+  EXPECT_EQ(ts, TimestampFromString("1677-09-21T00:12:44Z").value());
+
+  ts = FromTimeT(9223372036L) + std::chrono::nanoseconds(854775807);
+  EXPECT_EQ(ts, TimestampFromString("2262-04-11T23:47:16.854775807Z").value());
+}
+
 TEST(Time, TimestampFromStringFailure) {
   EXPECT_FALSE(TimestampFromString(""));
   EXPECT_FALSE(TimestampFromString("garbage in"));
@@ -318,6 +346,13 @@ TEST(Time, TimestampFromStringFailure) {
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22.9"));
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22.Z"));
   EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22ZX"));
+
+  EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+0:"));
+  EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+:0"));
+  EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22x00:00"));
+  EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+ab:cd"));
+  EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22-24:60"));
+  EXPECT_FALSE(TimestampFromString("2019-06-21T16:52:22+00:00:00"));
 }
 
 }  // namespace


### PR DESCRIPTION
Introduce versions of `internal::FormatTime()` and `internal::ParseTime()`
that do not take a format-specifier string. Instead they only format and
parse _"%Y-%m-%dT%H:%M:%S"_, allowing them to be very specific and fast.  In
particular this allows us to avoid `std::put_time()` and `std::get_time()`
(and we avoid `std::sscanf()` too). Use these to implemented the Spanner
`TimestampToString()` and `TimestampFromString()` conversion functions.
Fixes #1088.

Note: The new, format-specifier-less `internal::FormatTime()` produces a
4-character year when possible (unlike the _"%Y"_ format specifier).

Also introduce formatting and parsing of _"[-+]HH:MM"_ UTC offset fields.
While we will always produce a _"Z"_ offset in `TimestampToString()` for
Spanner, this will enable some refactoring of the time-formatting code
between all the Cloud C++ projects. See #145.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1110)
<!-- Reviewable:end -->
