### PR TITLE
bug: disable benchmark smoke tests

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -1031,7 +1031,7 @@ class RunAllExperiment : public Experiment {
   Status SetUp(Config const&, cs::Database const&) override { return {}; }
   Status TearDown(Config const&, cs::Database const&) override { return {}; }
 
-  Status Run(Config const& cfg, cs::Database const& database) override {
+  Status Run(Config const& cfg, cs::Database const& /*database*/) override {
     // Smoke test all the experiments by running a very small version of each.
 
     std::vector<std::future<google::cloud::Status>> tasks;
@@ -1051,10 +1051,12 @@ class RunAllExperiment : public Experiment {
 
       auto experiment = kv.second(generator_);
 
+      // TODO(#1119) - tests disabled until we can stay within admin op quota
+#if 0
       tasks.push_back(std::async(
           std::launch::async,
-          [](Config config, cs::Database const& database, std::mutex& mu,
-             std::unique_ptr<Experiment> experiment) {
+          [](Config config, cs::Database const& database,
+             std::mutex& mu, std::unique_ptr<Experiment> experiment) {
             {
               std::lock_guard<std::mutex> lk(mu);
               std::cout << "# Smoke test for experiment\n";
@@ -1074,6 +1076,7 @@ class RunAllExperiment : public Experiment {
             return google::cloud::Status();
           },
           config, database, std::ref(mu_), std::move(experiment)));
+#endif
     }
 
     Status status;

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -703,8 +703,8 @@ class RunAllExperiment : public Experiment {
  public:
   void SetUp(Config const&, cloud_spanner::Database const&) override {}
 
-  void Run(Config const& cfg, cloud_spanner::Database const& database,
-           SampleSink const& sink) override {
+  void Run(Config const& cfg, cloud_spanner::Database const& /*database*/,
+           SampleSink const&) override {
     // Smoke test all the experiments by running a very small version of each.
     for (auto& kv : AvailableExperiments()) {
       // Do not recurse, skip this experiment.
@@ -714,8 +714,11 @@ class RunAllExperiment : public Experiment {
       config.samples = 1;
       config.iteration_duration = std::chrono::seconds(1);
       std::cout << "# Smoke test for experiment: " << kv.first << "\n";
+      // TODO(#1119) - tests disabled until we can stay within admin op quota
+#if 0
       kv.second->SetUp(config, database);
       kv.second->Run(config, database, sink);
+#endif
     }
   }
 };


### PR DESCRIPTION
The smoke tests are performing too many admin operations (basically
CREATE TABLE), to the point where they exceed the project quota and the
integration tests flake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1120)
<!-- Reviewable:end -->
