### PR TITLE
fix: tell clang-format to leave doxygen @copydoc directives alone

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -31,3 +31,5 @@ RawStringFormats:
   - 'pb'
   - 'proto'
   BasedOnStyle: Google
+
+CommentPragmas: '(@copydoc)'


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1122)
<!-- Reviewable:end -->
