### PR TITLE
bug: reduce number of admin operations for smoke test

### DIFF
--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -703,8 +703,8 @@ class RunAllExperiment : public Experiment {
  public:
   void SetUp(Config const&, cloud_spanner::Database const&) override {}
 
-  void Run(Config const& cfg, cloud_spanner::Database const& /*database*/,
-           SampleSink const&) override {
+  void Run(Config const& cfg, cloud_spanner::Database const& database,
+           SampleSink const& sink) override {
     // Smoke test all the experiments by running a very small version of each.
     for (auto& kv : AvailableExperiments()) {
       // Do not recurse, skip this experiment.
@@ -715,10 +715,8 @@ class RunAllExperiment : public Experiment {
       config.iteration_duration = std::chrono::seconds(1);
       std::cout << "# Smoke test for experiment: " << kv.first << "\n";
       // TODO(#1119) - tests disabled until we can stay within admin op quota
-#if 0
       kv.second->SetUp(config, database);
       kv.second->Run(config, database, sink);
-#endif
     }
   }
 };


### PR DESCRIPTION
Change the multiple_rows_cpu_benchmark to perform a single admin operation
that creates all the required tables. This should keep us under the quota
for admin operations.

This fixes #1119

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1124)
<!-- Reviewable:end -->
