### PR TITLE
bug: set "sticky" I/O format flags before forking threads

### DIFF
--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -40,7 +40,7 @@ bool SupportPerThreadUsage() {
 }  // namespace
 
 std::ostream& operator<<(std::ostream& os, Config const& config) {
-  return os << std::boolalpha << "# Experiment: " << config.experiment
+  return os << "# Experiment: " << config.experiment
             << "\n# Project: " << config.project_id
             << "\n# Instance: " << config.instance_id
             << "\n# Database: " << config.database_id

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -59,9 +59,9 @@ struct RowCpuSample {
 };
 
 std::ostream& operator<<(std::ostream& os, RowCpuSample const& s) {
-  return os << std::boolalpha << s.client_count << ',' << s.thread_count << ','
-            << s.using_stub << ',' << s.row_count << ',' << s.elapsed.count()
-            << ',' << s.cpu_time.count() << ',' << s.status.code();
+  return os << s.client_count << ',' << s.thread_count << ',' << s.using_stub
+            << ',' << s.row_count << ',' << s.elapsed.count() << ','
+            << s.cpu_time.count() << ',' << s.status.code();
 }
 
 class Experiment {
@@ -83,6 +83,9 @@ std::map<std::string, ExperimentFactory> AvailableExperiments();
 }  // namespace
 
 int main(int argc, char* argv[]) {
+  // Set any "sticky" I/O format flags before we fork threads.
+  std::cout.setf(std::ios::boolalpha);
+
   Config config;
   {
     std::vector<std::string> args{argv, argv + argc};

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -56,6 +56,9 @@ std::map<std::string, std::shared_ptr<Experiment>> AvailableExperiments();
 }  // namespace
 
 int main(int argc, char* argv[]) {
+  // Set any "sticky" I/O format flags before we fork threads.
+  std::cout.setf(std::ios::boolalpha);
+
   Config config;
   {
     std::vector<std::string> args{argv, argv + argc};
@@ -119,8 +122,8 @@ int main(int argc, char* argv[]) {
           std::vector<SingleRowThroughputSample> const& samples) mutable {
         std::unique_lock<std::mutex> lk(cout_mu);
         for (auto const& s : samples) {
-          std::cout << std::boolalpha << s.client_count << ',' << s.thread_count
-                    << ',' << s.event_count << ',' << s.elapsed.count() << '\n'
+          std::cout << s.client_count << ',' << s.thread_count << ','
+                    << s.event_count << ',' << s.elapsed.count() << '\n'
                     << std::flush;
         }
       };


### PR DESCRIPTION
Any I/O manipulator that sets a per-stream I/O format flag
is not thread safe, as recent ThreadSanitizer warnings attest.
So, set `std::ios::boolalpha` in the benchmarks before we fork
any threads, rather than during concurrent output operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1128)
<!-- Reviewable:end -->
