### PR TITLE
refactor: make `SessionPoolOptions` a class

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -338,6 +338,7 @@ function (spanner_client_define_tests)
         retry_policy_test.cc
         row_test.cc
         query_partition_test.cc
+        session_pool_options_test.cc
         spanner_version_test.cc
         sql_statement_test.cc
         transaction_test.cc

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -159,7 +159,7 @@ TEST(SessionPool, MinSessionsEagerAllocation) {
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s3", "s2", "s1"}))));
 
   SessionPoolOptions options;
-  options.min_sessions = min_sessions;
+  options.set_min_sessions(min_sessions);
   auto pool = MakeSessionPool(db, {mock}, options);
   auto session = pool->Allocate();
 }
@@ -173,7 +173,7 @@ TEST(SessionPool, MinSessionsMultipleAllocations) {
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s3", "s2", "s1"}))));
 
   SessionPoolOptions options;
-  options.min_sessions = min_sessions;
+  options.set_min_sessions(min_sessions);
   auto pool = MakeSessionPool(db, {mock}, options);
 
   // When we run out of sessions it will make this call.
@@ -201,8 +201,8 @@ TEST(SessionPool, MaxSessionsFailOnExhaustion) {
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s3"}))));
 
   SessionPoolOptions options;
-  options.max_sessions_per_channel = max_sessions_per_channel;
-  options.action_on_exhaustion = ActionOnExhaustion::FAIL;
+  options.set_max_sessions_per_channel(max_sessions_per_channel)
+      .set_action_on_exhaustion(ActionOnExhaustion::FAIL);
   auto pool = MakeSessionPool(db, {mock}, options);
   std::vector<SessionHolder> sessions;
   std::vector<std::string> session_names;
@@ -226,8 +226,8 @@ TEST(SessionPool, MaxSessionsBlockUntilRelease) {
       .WillOnce(Return(ByMove(MakeSessionsResponse({"s1"}))));
 
   SessionPoolOptions options;
-  options.max_sessions_per_channel = max_sessions_per_channel;
-  options.action_on_exhaustion = ActionOnExhaustion::BLOCK;
+  options.set_max_sessions_per_channel(max_sessions_per_channel)
+      .set_action_on_exhaustion(ActionOnExhaustion::BLOCK);
   auto pool = MakeSessionPool(db, {mock}, options);
   auto session = pool->Allocate();
   ASSERT_STATUS_OK(session);
@@ -253,7 +253,7 @@ TEST(SessionPool, Labels) {
       .WillOnce(Return(ByMove(MakeSessionsResponse({"session1"}))));
 
   SessionPoolOptions options;
-  options.labels = labels;
+  options.set_labels(std::move(labels));
   auto pool = MakeSessionPool(db, {mock}, options);
   auto session = pool->Allocate();
   ASSERT_STATUS_OK(session);
@@ -301,9 +301,9 @@ TEST(SessionPool, MultipleChannelsPreAllocation) {
   SessionPoolOptions options;
   // note that min_sessions will effectively be reduced to 9
   // (max_sessions_per_channel * num_channels).
-  options.min_sessions = 20;
-  options.max_sessions_per_channel = 3;
-  options.action_on_exhaustion = ActionOnExhaustion::FAIL;
+  options.set_min_sessions(20)
+      .set_max_sessions_per_channel(3)
+      .set_action_on_exhaustion(ActionOnExhaustion::FAIL);
   auto pool = MakeSessionPool(db, {mock1, mock2, mock3}, options);
   std::vector<SessionHolder> sessions;
   std::vector<std::string> session_names;

--- a/google/cloud/spanner/session_pool_options.h
+++ b/google/cloud/spanner/session_pool_options.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_SESSION_POOL_OPTIONS_H_
 
 #include "google/cloud/spanner/version.h"
+#include <algorithm>
 #include <chrono>
 #include <map>
 #include <string>

--- a/google/cloud/spanner/session_pool_options.h
+++ b/google/cloud/spanner/session_pool_options.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_SESSION_POOL_OPTIONS_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_SESSION_POOL_OPTIONS_H_
 
+#include "google/cloud/spanner/version.h"
 #include <chrono>
 #include <map>
 #include <string>
@@ -27,35 +28,113 @@ inline namespace SPANNER_CLIENT_NS {
 // What action to take if the session pool is exhausted.
 enum class ActionOnExhaustion { BLOCK, FAIL };
 
-struct SessionPoolOptions {
-  // The minimum number of sessions to keep in the pool.
-  // Values <= 0 are treated as 0.
-  // This value will be reduced if it exceeds the overall limit on the number
-  // of sessions (`max_sessions_per_channel` * number of channels).
-  int min_sessions = 0;
+class SessionPoolOptions {
+ public:
+  /**
+   * Enforce the stated constraints on the option values, altering them if
+   * necessary. This can't be done in the setters, since we don't yet know
+   * the number of channels, and it would also constrain the order in which
+   * the fields must be set.
+   *
+   * @p num_channels the number of RPC channels in use by the pool.
+   */
+  SessionPoolOptions& EnforceConstraints(int num_channels) {
+    min_sessions_ = (std::max)(min_sessions_, 0);
+    max_sessions_per_channel_ = (std::max)(max_sessions_per_channel_, 1);
+    min_sessions_ =
+        (std::min)(min_sessions_, max_sessions_per_channel_ * num_channels);
+    max_idle_sessions_ = (std::max)(max_idle_sessions_, 0);
+    return *this;
+  }
 
-  // The maximum number of sessions to create on each channel.
-  // Values <= 1 are treated as 1.
-  int max_sessions_per_channel = 100;
+  /**
+   * Set the minimum number of sessions to keep in the pool.
+   * Values <= 0 are treated as 0.
+   * This value will effectively be reduced if it exceeds the overall limit on
+   * the number of sessions (`max_sessions_per_channel` * number of channels).
+   */
+  SessionPoolOptions& set_min_sessions(int count) {
+    min_sessions_ = count;
+    return *this;
+  }
+  /// Return the minimum number of sessions to keep in the pool.
+  int min_sessions() const { return min_sessions_; }
 
-  // The maximum number of sessions that can be in the pool in an idle state.
-  // Values <= 0 are treated as 0.
-  int max_idle_sessions = 0;
+  /**
+   * Set the maximum number of sessions to create on each channel.
+   * Values <= 1 are treated as 1.
+   */
+  SessionPoolOptions& set_max_sessions_per_channel(int count) {
+    max_sessions_per_channel_ = count;
+    return *this;
+  }
 
-  // Decide whether to block or fail on pool exhaustion.
-  ActionOnExhaustion action_on_exhaustion = ActionOnExhaustion::BLOCK;
+  /// Return the minimum number of sessions to keep in the pool.
+  int max_sessions_per_channel() const { return max_sessions_per_channel_; }
 
-  // This is the interval at which we refresh sessions so they don't get
-  // collected by the backend GC. The GC collects objects older than 60
-  // minutes, so any duration below that (less some slack to allow the calls
-  // to be made to refresh the sessions) should suffice.
-  std::chrono::minutes keep_alive_interval = std::chrono::minutes(55);
+  /**
+   * Set the maximum number of sessions to keep in the pool in an idle state.
+   * Values <= 0 are treated as 0.
+   */
+  SessionPoolOptions& set_max_idle_sessions(int count) {
+    max_idle_sessions_ = count;
+    return *this;
+  }
 
-  // The labels used when creating sessions within the pool.
-  //  * Label keys must match `[a-z]([-a-z0-9]{0,61}[a-z0-9])?`.
-  //  * Label values must match `([a-z]([-a-z0-9]{0,61}[a-z0-9])?)?`.
-  //  * The maximum number of labels is 64.
-  std::map<std::string, std::string> labels;
+  /// Return the maximum number of idle sessions to keep in the pool.
+  int max_idle_sessions() const { return max_idle_sessions_; }
+
+  /// Set whether to block or fail on pool exhaustion.
+  SessionPoolOptions& set_action_on_exhaustion(ActionOnExhaustion action) {
+    action_on_exhaustion_ = action;
+    return *this;
+  }
+
+  /**
+   * Return the action to take (BLOCK or FAIL) when attempting to allocate a
+   * session when the pool is exhausted.
+   */
+  ActionOnExhaustion action_on_exhaustion() const {
+    return action_on_exhaustion_;
+  }
+
+  /*
+   * Set the interval at which we refresh sessions so they don't get
+   * collected by the backend GC. The GC collects objects older than 60
+   * minutes, so any duration below that (less some slack to allow the calls
+   * to be made to refresh the sessions) should suffice.
+   */
+  SessionPoolOptions& set_keep_alive_interval(std::chrono::minutes minutes) {
+    keep_alive_interval_ = minutes;
+    return *this;
+  }
+
+  /// Return the interval at which we refresh sessions to prevent GC.
+  std::chrono::minutes keep_alive_interval() const {
+    return keep_alive_interval_;
+  }
+
+  /**
+   * Set the labels used when creating sessions within the pool.
+   *  * Label keys must match `[a-z]([-a-z0-9]{0,61}[a-z0-9])?`.
+   *  * Label values must match `([a-z]([-a-z0-9]{0,61}[a-z0-9])?)?`.
+   *  * The maximum number of labels is 64.
+   */
+  SessionPoolOptions& set_labels(std::map<std::string, std::string> labels) {
+    labels_ = std::move(labels);
+    return *this;
+  }
+
+  /// Return the labels used when creating sessions within the pool.
+  std::map<std::string, std::string> const& labels() const { return labels_; }
+
+ private:
+  int min_sessions_ = 0;
+  int max_sessions_per_channel_ = 100;
+  int max_idle_sessions_ = 0;
+  ActionOnExhaustion action_on_exhaustion_ = ActionOnExhaustion::BLOCK;
+  std::chrono::minutes keep_alive_interval_ = std::chrono::minutes(55);
+  std::map<std::string, std::string> labels_;
 };
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/session_pool_options.h
+++ b/google/cloud/spanner/session_pool_options.h
@@ -57,6 +57,7 @@ class SessionPoolOptions {
     min_sessions_ = count;
     return *this;
   }
+
   /// Return the minimum number of sessions to keep in the pool.
   int min_sessions() const { return min_sessions_; }
 

--- a/google/cloud/spanner/session_pool_options_test.cc
+++ b/google/cloud/spanner/session_pool_options_test.cc
@@ -1,0 +1,58 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/session_pool_options.h"
+#include "google/cloud/spanner/version.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+
+TEST(SessionPoolOptionsTest, MinSessions) {
+  SessionPoolOptions options;
+  options.set_min_sessions(-1).EnforceConstraints(/*num_channels=*/1);
+  EXPECT_EQ(0, options.min_sessions());
+}
+
+TEST(SessionPoolOptionsTest, MaxSessionsPerChannel) {
+  SessionPoolOptions options;
+  options.set_max_sessions_per_channel(0).EnforceConstraints(
+      /*num_channels=*/1);
+  EXPECT_EQ(1, options.max_sessions_per_channel());
+}
+
+TEST(SessionPoolOptionsTest, MaxIdleSessions) {
+  SessionPoolOptions options;
+  options.set_max_idle_sessions(-1).EnforceConstraints(
+      /*num_channels=*/1);
+  EXPECT_EQ(0, options.max_idle_sessions());
+}
+
+TEST(SessionPoolOptionsTest, MaxMinSessionsConflict) {
+  SessionPoolOptions options;
+  options.set_min_sessions(10)
+      .set_max_sessions_per_channel(2)
+      .EnforceConstraints(/*num_channels=*/3);
+  EXPECT_EQ(6, options.min_sessions());
+  EXPECT_EQ(2, options.max_sessions_per_channel());
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -59,6 +59,7 @@ spanner_client_unit_tests = [
     "retry_policy_test.cc",
     "row_test.cc",
     "query_partition_test.cc",
+    "session_pool_options_test.cc",
     "spanner_version_test.cc",
     "sql_statement_test.cc",
     "transaction_test.cc",


### PR DESCRIPTION
* This makes `SessionPoolOptions` similar to `ConnectionOptions`.
* Setters provide a "Builder" type interface.
* Enforcing constraints has been moved to the class itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1130)
<!-- Reviewable:end -->
