### PR TITLE
feat: mark not-found sessions as bad

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -183,12 +183,12 @@ StatusOr<CommitResult> Client::Commit(
     }
     if (internal::IsSessionNotFound(status)) {
       // Marks the session bad and creates a new Transaction for the next loop.
-      internal::Visit(
-          txn, [](internal::SessionHolder& s,
-                  google::spanner::v1::TransactionSelector&, std::int64_t) {
-            s->set_bad();
-            return true;
-          });
+      internal::Visit(txn, [](internal::SessionHolder& s,
+                              google::spanner::v1::TransactionSelector const&,
+                              std::int64_t) {
+        s->set_bad();
+        return true;
+      });
       txn = MakeReadWriteTransaction();
     } else {
       // Create a new transaction for the next loop, but share lock priority

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/internal/status_utils.h"
 #include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/spanner/transaction.h"
 #include "google/cloud/log.h"
 #include <grpcpp/grpcpp.h>
 #include <thread>
@@ -191,7 +192,7 @@ StatusOr<CommitResult> Client::Commit(
       });
       txn = MakeReadWriteTransaction();
     } else {
-      // Create a new transaction for the next loop, but share lock priority
+      // Create a new transaction for the next loop, but reuse the session
       // so that we have a slightly better chance of avoiding another abort.
       txn = MakeReadWriteTransaction(std::move(txn));
     }

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/spanner/internal/connection_impl.h"
 #include "google/cloud/spanner/internal/retry_loop.h"
 #include "google/cloud/spanner/internal/spanner_stub.h"
+#include "google/cloud/spanner/internal/status_utils.h"
 #include "google/cloud/spanner/retry_policy.h"
 #include "google/cloud/log.h"
 #include <grpcpp/grpcpp.h>
@@ -176,14 +177,25 @@ StatusOr<CommitResult> Client::Commit(
         return status;
       }
     }
-    // A transient failure (i.e., kAborted), so consider rerunning.
+    // A transient failure (e.g., kAborted), so consider rerunning.
     if (!rerun_policy->OnFailure(status)) {
       return status;  // reruns exhausted
     }
+    if (internal::IsSessionNotFound(status)) {
+      // Marks the session bad and creates a new Transaction for the next loop.
+      internal::Visit(
+          txn, [](internal::SessionHolder& s,
+                  google::spanner::v1::TransactionSelector&, std::int64_t) {
+            s->set_bad();
+            return true;
+          });
+      txn = MakeReadWriteTransaction();
+    } else {
+      // Create a new transaction for the next loop, but share lock priority
+      // so that we have a slightly better chance of avoiding another abort.
+      txn = MakeReadWriteTransaction(std::move(txn));
+    }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());
-    // Create a new transaction for the next loop, but share lock priority
-    // so that we have a slightly better chance of avoiding another abort.
-    txn = MakeReadWriteTransaction(std::move(txn));
   }
 }
 

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -187,7 +187,7 @@ StatusOr<CommitResult> Client::Commit(
       internal::Visit(txn, [](internal::SessionHolder& s,
                               google::spanner::v1::TransactionSelector const&,
                               std::int64_t) {
-        s->set_bad();
+        if (s) s->set_bad();
         return true;
       });
       txn = MakeReadWriteTransaction();

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -783,9 +783,10 @@ TEST(ClientTest, CommitMutatorSessionNotFound) {
 
   int n = 0;
   auto mutator = [&n](Transaction const& txn) -> StatusOr<Mutations> {
+    EXPECT_THAT(txn, DoesNotHaveSession());
     SetSessionName(txn, "session-" + std::to_string(++n));
     if (n < 3) return Status(StatusCode::kNotFound, "Session not found");
-    return Mutations{MakeDeleteMutation("table", KeySet::All())};
+    return Mutations{};
   };
 
   Client client(conn);
@@ -811,8 +812,9 @@ TEST(ClientTest, CommitSessionNotFound) {
 
   int n = 0;
   auto mutator = [&n](Transaction const& txn) -> StatusOr<Mutations> {
+    EXPECT_THAT(txn, DoesNotHaveSession());
     SetSessionName(txn, "session-" + std::to_string(++n));
-    return Mutations{MakeDeleteMutation("table", KeySet::All())};
+    return Mutations{};
   };
 
   Client client(conn);

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -770,6 +770,57 @@ TEST(ClientTest, CommitMutatorSessionAffinity) {
   EXPECT_EQ(*timestamp, result->commit_timestamp);
 }
 
+TEST(ClientTest, CommitMutatorSessionNotFound) {
+  auto timestamp = internal::TimestampFromString("2019-08-14T21:16:21.123Z");
+  ASSERT_STATUS_OK(timestamp);
+
+  auto conn = std::make_shared<MockConnection>();
+  EXPECT_CALL(*conn, Commit(_))
+      .WillOnce([&timestamp](Connection::CommitParams const& cp) {
+        EXPECT_THAT(cp.transaction, HasSession("session-3"));
+        return CommitResult{*timestamp};
+      });
+
+  int n = 0;
+  auto mutator = [&n](Transaction const& txn) -> StatusOr<Mutations> {
+    SetSessionName(txn, "session-" + std::to_string(++n));
+    if (n < 3) return Status(StatusCode::kNotFound, "Session not found");
+    return Mutations{MakeDeleteMutation("table", KeySet::All())};
+  };
+
+  Client client(conn);
+  auto result = client.Commit(mutator);
+  EXPECT_STATUS_OK(result);
+  EXPECT_EQ(*timestamp, result->commit_timestamp);
+}
+
+TEST(ClientTest, CommitSessionNotFound) {
+  auto timestamp = internal::TimestampFromString("2019-08-14T21:16:21.123Z");
+  ASSERT_STATUS_OK(timestamp);
+
+  auto conn = std::make_shared<MockConnection>();
+  EXPECT_CALL(*conn, Commit(_))
+      .WillOnce([](Connection::CommitParams const& cp) {
+        EXPECT_THAT(cp.transaction, HasSession("session-1"));
+        return Status(StatusCode::kNotFound, "Session not found");
+      })
+      .WillOnce([&timestamp](Connection::CommitParams const& cp) {
+        EXPECT_THAT(cp.transaction, HasSession("session-2"));
+        return CommitResult{*timestamp};
+      });
+
+  int n = 0;
+  auto mutator = [&n](Transaction const& txn) -> StatusOr<Mutations> {
+    SetSessionName(txn, "session-" + std::to_string(++n));
+    return Mutations{MakeDeleteMutation("table", KeySet::All())};
+  };
+
+  Client client(conn);
+  auto result = client.Commit(mutator);
+  EXPECT_STATUS_OK(result);
+  EXPECT_EQ(*timestamp, result->commit_timestamp);
+}
+
 }  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -46,12 +46,12 @@ class Session {
 
   std::string const& session_name() const { return session_name_; }
 
-  void set_bad() { is_bad_.store(true, std::memory_order_release); }
+  void set_bad() { is_bad_.store(true, std::memory_order_relaxed); }
 
  private:
   friend class SessionPool;
   std::shared_ptr<SpannerStub> stub() const { return stub_; }
-  bool is_bad() const { return is_bad_.load(std::memory_order_acquire); }
+  bool is_bad() const { return is_bad_.load(std::memory_order_relaxed); }
 
   std::string const session_name_;
   std::shared_ptr<SpannerStub> const stub_;

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -53,7 +53,7 @@ class Session {
   bool is_bad() const { return is_bad_.load(std::memory_order_relaxed); }
 
  private:
-  friend class SessionPool;
+  friend class SessionPool;  // for access to stub()
   std::shared_ptr<SpannerStub> stub() const { return stub_; }
 
   std::string const session_name_;

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/version.h"
+#include <atomic>
 #include <memory>
 #include <string>
 #include <utility>
@@ -33,7 +34,9 @@ namespace internal {
 class Session {
  public:
   Session(std::string session_name, std::shared_ptr<SpannerStub> stub) noexcept
-      : session_name_(std::move(session_name)), stub_(std::move(stub)) {}
+      : session_name_(std::move(session_name)),
+        stub_(std::move(stub)),
+        is_bad_(false) {}
 
   // Not copyable or moveable.
   Session(Session const&) = delete;
@@ -43,12 +46,16 @@ class Session {
 
   std::string const& session_name() const { return session_name_; }
 
+  void set_bad() { is_bad_.store(true, std::memory_order_release); }
+
  private:
-  friend class SessionPool;  // for access to stub()
+  friend class SessionPool;
   std::shared_ptr<SpannerStub> stub() const { return stub_; }
+  bool is_bad() const { return is_bad_.load(std::memory_order_acquire); }
 
   std::string const session_name_;
   std::shared_ptr<SpannerStub> const stub_;
+  std::atomic<bool> is_bad_;
 };
 
 /**

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -30,6 +30,8 @@ namespace internal {
 
 /**
  * A class that represents a Session.
+ *
+ * This class is thread-safe.
  */
 class Session {
  public:
@@ -46,12 +48,13 @@ class Session {
 
   std::string const& session_name() const { return session_name_; }
 
+  // Note: the "bad" state only transitions from false to true.
   void set_bad() { is_bad_.store(true, std::memory_order_relaxed); }
+  bool is_bad() const { return is_bad_.load(std::memory_order_relaxed); }
 
  private:
   friend class SessionPool;
   std::shared_ptr<SpannerStub> stub() const { return stub_; }
-  bool is_bad() const { return is_bad_.load(std::memory_order_relaxed); }
 
   std::string const session_name_;
   std::shared_ptr<SpannerStub> const stub_;


### PR DESCRIPTION
This fixes part of #914 

A followup PR will need to have the SessionPool look at this Session::bad() bit and remove it from the pool (or something).

Note: much of this was pair-programmed with @devbww

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1138)
<!-- Reviewable:end -->
