### PR TITLE
docs: use cmake-out directory and add how to obtain spanner

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ Or obtain the tarball release:
 ```bash
 mkdir -p $HOME/project
 wget -q https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.4.0.tar.gz
-tar -xf v0.4.0.tar.gz -C $HOME/project
+tar -xf v0.4.0.tar.gz -C $HOME/project --strip=1
 ```
 
 # Installing google-cloud-cpp-spanner

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,19 @@
+# Obtaining google-cloud-cpp-spanner
+
+There are two primary ways of obtaining `google-cloud-cpp-spanner`. You can use git:
+
+```bash
+git clone git@github.com:googleapis/google-cloud-cpp-spanner.git $HOME/project
+```
+
+Or obtain the tarball release:
+
+```bash
+mkdir -p $HOME/project
+wget -q https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.4.0.tar.gz
+tar -xf v0.4.0.tar.gz -C $HOME/project
+```
+
 # Installing google-cloud-cpp-spanner
 
 When built with Bazel or as a CMake super build `google-cloud-cpp-spanner`
@@ -224,12 +240,11 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -B/o
-cmake --build /o -- -j "${NCPU:-4}"
-cd /o
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
 ctest -LE integration-tests --output-on-failure
-cd $HOME/project
-sudo cmake --build /o --target install
+sudo cmake --build . --target install
 ```
 
 
@@ -362,12 +377,11 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -B/o
-cmake --build /o -- -j "${NCPU:-4}"
-cd /o
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
 ctest -LE integration-tests --output-on-failure
-cd $HOME/project
-sudo cmake --build /o --target install
+sudo cmake --build . --target install
 ```
 
 
@@ -472,12 +486,11 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -B/o
-cmake --build /o -- -j "${NCPU:-4}"
-cd /o
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
 ctest -LE integration-tests --output-on-failure
-cd $HOME/project
-sudo cmake --build /o --target install
+sudo cmake --build . --target install
 ```
 
 
@@ -597,12 +610,11 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -B/o
-cmake --build /o -- -j "${NCPU:-4}"
-cd /o
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
 ctest -LE integration-tests --output-on-failure
-cd $HOME/project
-sudo cmake --build /o --target install
+sudo cmake --build . --target install
 ```
 
 
@@ -680,12 +692,11 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -B/o
-cmake --build /o -- -j "${NCPU:-4}"
-cd /o
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
 ctest -LE integration-tests --output-on-failure
-cd $HOME/project
-sudo cmake --build /o --target install
+sudo cmake --build . --target install
 ```
 
 
@@ -797,12 +808,11 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -B/o
-cmake --build /o -- -j "${NCPU:-4}"
-cd /o
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
 ctest -LE integration-tests --output-on-failure
-cd $HOME/project
-sudo cmake --build /o --target install
+sudo cmake --build . --target install
 ```
 
 
@@ -919,12 +929,11 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -B/o
-cmake --build /o -- -j "${NCPU:-4}"
-cd /o
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
 ctest -LE integration-tests --output-on-failure
-cd $HOME/project
-sudo cmake --build /o --target install
+sudo cmake --build . --target install
 ```
 
 
@@ -1062,11 +1071,10 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -B/o
-cmake --build /o -- -j "${NCPU:-4}"
-cd /o
+cmake -H. -Bcmake-out
+cmake --build cmake-out -- -j "${NCPU:-4}"
+cd $HOME/project/cmake-out
 ctest -LE integration-tests --output-on-failure
-cd $HOME/project
-sudo cmake --build /o --target install
+sudo cmake --build . --target install
 ```
 

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -65,12 +65,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -159,12 +159,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -138,12 +138,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -99,12 +99,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -133,12 +133,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -100,12 +100,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -154,12 +154,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -98,12 +98,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -126,12 +126,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -141,12 +141,11 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -B/o
-RUN cmake --build /o -- -j "${NCPU:-4}"
-WORKDIR /o
+RUN cmake -H. -Bcmake-out
+RUN cmake --build cmake-out -- -j "${NCPU:-4}"
+WORKDIR /home/build/project/cmake-out
 RUN ctest -LE integration-tests --output-on-failure
-WORKDIR /home/build/project
-RUN cmake --build /o --target install
+RUN cmake --build . --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -31,7 +31,7 @@ Or obtain the tarball release:
 ```bash
 mkdir -p $HOME/project
 wget -q https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.4.0.tar.gz
-tar -xf v0.4.0.tar.gz -C $HOME/project
+tar -xf v0.4.0.tar.gz -C $HOME/project --strip=1
 ```
 
 # Installing google-cloud-cpp-spanner

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -18,6 +18,22 @@ set -eu
 readonly BINDIR=$(dirname "$0")
 
 cat <<'END_OF_PREAMBLE'
+# Obtaining google-cloud-cpp-spanner
+
+There are two primary ways of obtaining `google-cloud-cpp-spanner`. You can use git:
+
+```bash
+git clone git@github.com:googleapis/google-cloud-cpp-spanner.git $HOME/project
+```
+
+Or obtain the tarball release:
+
+```bash
+mkdir -p $HOME/project
+wget -q https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.4.0.tar.gz
+tar -xf v0.4.0.tar.gz -C $HOME/project
+```
+
 # Installing google-cloud-cpp-spanner
 
 When built with Bazel or as a CMake super build `google-cloud-cpp-spanner`


### PR DESCRIPTION
Fixes #1131

This regenerates the `INSTALL.md` and Dockerfiles to use the `cmake-out`
directory instead of `/o` like in common. This also adds a blurb at the
beginning on how to obtain spanner so that `$HOME/project` will exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1139)
<!-- Reviewable:end -->
