### PR TITLE
chore: remove g::protobuf::Duration to std::chrono::nanoseconds conv

### DIFF
--- a/google/cloud/spanner/internal/time.cc
+++ b/google/cloud/spanner/internal/time.cc
@@ -43,11 +43,6 @@ google::protobuf::Duration ToProto(std::chrono::nanoseconds ns) {
   return proto;
 }
 
-std::chrono::nanoseconds FromProto(google::protobuf::Duration const& proto) {
-  return std::chrono::seconds(proto.seconds()) +
-         std::chrono::nanoseconds(proto.nanos());
-}
-
 //
 // Timestamp
 //

--- a/google/cloud/spanner/internal/time.h
+++ b/google/cloud/spanner/internal/time.h
@@ -35,11 +35,6 @@ namespace internal {
 google::protobuf::Duration ToProto(std::chrono::nanoseconds ns);
 
 /**
- * Convert a google::protobuf::Duration to a std::chrono::nanoseconds.
- */
-std::chrono::nanoseconds FromProto(google::protobuf::Duration const& proto);
-
-/**
  * Convert a google::cloud::spanner::Timestamp to a google::protobuf::Timestamp.
  */
 google::protobuf::Timestamp ToProto(Timestamp ts);

--- a/google/cloud/spanner/internal/time_test.cc
+++ b/google/cloud/spanner/internal/time_test.cc
@@ -77,54 +77,6 @@ TEST(Duration, ToProto) {
   EXPECT_EQ(234567890, d.nanos());
 }
 
-TEST(Duration, FromProto) {
-  google::protobuf::Duration d;
-
-  d.set_seconds(-1);
-  d.set_nanos(-234567890);
-  EXPECT_EQ(std::chrono::nanoseconds(-1234567890), FromProto(d));
-
-  d.set_seconds(-1);
-  d.set_nanos(-1);
-  EXPECT_EQ(std::chrono::nanoseconds(-1000000001), FromProto(d));
-
-  d.set_seconds(-1);
-  d.set_nanos(0);
-  EXPECT_EQ(std::chrono::nanoseconds(-1000000000), FromProto(d));
-
-  d.set_seconds(0);
-  d.set_nanos(-999999999);
-  EXPECT_EQ(std::chrono::nanoseconds(-999999999), FromProto(d));
-
-  d.set_seconds(0);
-  d.set_nanos(-1);
-  EXPECT_EQ(std::chrono::nanoseconds(-1), FromProto(d));
-
-  d.set_seconds(0);
-  d.set_nanos(0);
-  EXPECT_EQ(std::chrono::nanoseconds(0), FromProto(d));
-
-  d.set_seconds(0);
-  d.set_nanos(1);
-  EXPECT_EQ(std::chrono::nanoseconds(1), FromProto(d));
-
-  d.set_seconds(0);
-  d.set_nanos(999999999);
-  EXPECT_EQ(std::chrono::nanoseconds(999999999), FromProto(d));
-
-  d.set_seconds(1);
-  d.set_nanos(0);
-  EXPECT_EQ(std::chrono::nanoseconds(1000000000), FromProto(d));
-
-  d.set_seconds(1);
-  d.set_nanos(1);
-  EXPECT_EQ(std::chrono::nanoseconds(1000000001), FromProto(d));
-
-  d.set_seconds(1);
-  d.set_nanos(234567890);
-  EXPECT_EQ(std::chrono::nanoseconds(1234567890), FromProto(d));
-}
-
 TEST(Time, ToProto) {
   google::protobuf::Timestamp ts;
 


### PR DESCRIPTION
We don't use `FromProto(google::protobuf::Duration const&)`, and not
having it sidesteps the issue that the result may not be representable
as a `std::chrono::nanoseconds`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1140)
<!-- Reviewable:end -->
