### PR TITLE
refactor: add a factory method for `SessionPool`

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -95,10 +95,10 @@ ConnectionImpl::ConnectionImpl(Database db,
     : db_(std::move(db)),
       retry_policy_prototype_(std::move(retry_policy)),
       backoff_policy_prototype_(std::move(backoff_policy)),
-      session_pool_(std::make_shared<SessionPool>(
-          db_, std::move(stubs), std::move(session_pool_options),
-          retry_policy_prototype_->clone(),
-          backoff_policy_prototype_->clone())) {}
+      session_pool_(MakeSessionPool(db_, std::move(stubs),
+                                    std::move(session_pool_options),
+                                    retry_policy_prototype_->clone(),
+                                    backoff_policy_prototype_->clone())) {}
 
 RowStream ConnectionImpl::Read(ReadParams params) {
   return internal::Visit(

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -68,6 +68,9 @@ SessionPool::SessionPool(Database db,
 
 void SessionPool::Initialize() {
   // Eagerly initialize the pool with `min_sessions` sessions.
+  // TODO(#307) this was moved to `Initialize` in preparation of using
+  // `shared_from_this()` in the process of creating sessions, which cannot
+  // be done in the constructor.
   if (options_.min_sessions() > 0) {
     std::unique_lock<std::mutex> lk(mu_);
     int num_channels = static_cast<int>(channels_.size());

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -29,6 +29,17 @@ namespace internal {
 
 namespace spanner_proto = ::google::spanner::v1;
 
+std::shared_ptr<SessionPool> MakeSessionPool(
+    Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
+    SessionPoolOptions options, std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy) {
+  auto pool = std::make_shared<SessionPool>(
+      std::move(db), std::move(stubs), std::move(options),
+      std::move(retry_policy), std::move(backoff_policy));
+  pool->Initialize();
+  return pool;
+}
+
 SessionPool::SessionPool(Database db,
                          std::vector<std::shared_ptr<SpannerStub>> stubs,
                          SessionPoolOptions options,
@@ -53,27 +64,27 @@ SessionPool::SessionPool(Database db,
   // `channels_` is never resized after this point.
   next_dissociated_stub_channel_ = channels_.begin();
   next_channel_for_create_sessions_ = channels_.begin();
+}
 
-  if (options_.min_sessions() == 0) {
-    return;
-  }
-
+void SessionPool::Initialize() {
   // Eagerly initialize the pool with `min_sessions` sessions.
-  std::unique_lock<std::mutex> lk(mu_);
-  int num_channels = static_cast<int>(channels_.size());
-  int sessions_per_channel = options_.min_sessions() / num_channels;
-  // If the number of sessions doesn't divide evenly by the number of channels,
-  // add one extra session to the first `extra_sessions` channels.
-  int extra_sessions = options_.min_sessions() % num_channels;
-  for (auto& channel : channels_) {
-    int num_sessions = sessions_per_channel;
-    if (extra_sessions > 0) {
-      ++num_sessions;
-      --extra_sessions;
+  if (options_.min_sessions() > 0) {
+    std::unique_lock<std::mutex> lk(mu_);
+    int num_channels = static_cast<int>(channels_.size());
+    int sessions_per_channel = options_.min_sessions() / num_channels;
+    // If the number of sessions doesn't divide evenly by the number of
+    // channels, add one extra session to the first `extra_sessions` channels.
+    int extra_sessions = options_.min_sessions() % num_channels;
+    for (auto& channel : channels_) {
+      int num_sessions = sessions_per_channel;
+      if (extra_sessions > 0) {
+        ++num_sessions;
+        --extra_sessions;
+      }
+      // Just ignore failures; we'll try again when the caller requests a
+      // session, and we'll be in a position to return an error at that time.
+      (void)CreateSessions(lk, channel, options_.labels(), num_sessions);
     }
-    // Just ignore failures; we'll try again when the caller requests a
-    // session, and we'll be in a position to return an error at that time.
-    (void)CreateSessions(lk, channel, options_.labels(), num_sessions);
   }
 }
 

--- a/google/cloud/spanner/internal/session_pool_test.cc
+++ b/google/cloud/spanner/internal/session_pool_test.cc
@@ -65,7 +65,7 @@ spanner_proto::BatchCreateSessionsResponse MakeSessionsResponse(
 std::shared_ptr<SessionPool> MakeSessionPool(
     Database db, std::vector<std::shared_ptr<SpannerStub>> stubs,
     SessionPoolOptions options) {
-  return std::make_shared<SessionPool>(
+  return MakeSessionPool(
       std::move(db), std::move(stubs), std::move(options),
       google::cloud::internal::make_unique<LimitedTimeRetryPolicy>(
           std::chrono::minutes(10)),


### PR DESCRIPTION
I've been bitten a few times now by needing to call `shared_from_this()`
in the constructor (which doesn't work because the `shared_ptr` that's
going to hold `this` is not yet constructed), so this splits out code that
might need to do that into `Initialize()` which is called by the factory.

Session creation doesn't have to do it right now but it will, and we'll
also start the background thread processing from there... just wanted to
split this out in the interest of smaller CLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1148)
<!-- Reviewable:end -->
