### PR TITLE
fix: add :Z to volume mount

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -320,7 +320,7 @@ docker_flags=(
 
     # Mount the current directory (which is the top-level directory for the
     # project) as `/v` inside the docker image, and move to that directory.
-    "--volume" "${PWD}:/v"
+    "--volume" "${PWD}:/v:Z"
     "--workdir" "/v"
 
     # Mask any other builds that may exist at the same time. That is, these


### PR DESCRIPTION
On SELinux-enabled systems, if the `\$PWD` has any security contexts, mounting
the filesystem can result in permission denied errors. The solution is to
append `:Z` which will have the mounted filesystem share the security contexts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1149)
<!-- Reviewable:end -->
