### PR TITLE
ci: workaround a bug in gRPC < 1.15.0

### DIFF
--- a/ci/kokoro/windows/bazel/build.bat
+++ b/ci/kokoro/windows/bazel/build.bat
@@ -52,6 +52,11 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 echo "Running integration tests"
 call "%KOKORO_GFILE_DIR%/spanner-integration-tests-config.bat"
 
+@REM TODO(#1034) - Cleanup this workaround after we upgrade gRPC.
+@REM Before 1.25.0 gRPC sometimes crashes when using the c-ares resolver on
+@REM Windows
+set GRPC_DNS_RESOLVER=native
+
 @rem It seems like redirecting to a file is the easiest way to store the
 @rem command output to a variable.
 bazel --output_user_root=C:\b info output_base > t:\bazel-info.txt

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -30,6 +30,11 @@ set GOOGLE_APPLICATION_CREDENTIALS=%KOKORO_GFILE_DIR%\spanner-credentials.json
 set GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes
 set GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=T:\src\github\vcpkg\installed\x64-windows-static\share\grpc\roots.pem
 
+@REM TODO(#1034) - Cleanup this workaround after we upgrade gRPC.
+@REM Before 1.25.0 gRPC sometimes crashes when using the c-ares resolver on
+@REM Windows
+set GRPC_DNS_RESOLVER=native
+
 echo %date% %time%
 powershell -exec bypass ci\kokoro\windows\build-dependencies.ps1
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
Before 1.25.0 gRPC sometimes crashes when using the c-ares DNS resolver
on Windows, see grpc/grpc#18461 for more details.

I think this will minimize the problems reported in #1034

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1158)
<!-- Reviewable:end -->
