### PR TITLE
feat: optimistic concurrency control loop for IAM

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -206,7 +206,8 @@ add_library(
     value.h
     version.cc
     version.h
-    version_info.h)
+    version_info.h
+    iam_updater.h)
 target_include_directories(
     spanner_client
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(
     database_admin_connection.h
     date.cc
     date.h
+    iam_updater.h
     instance.cc
     instance.h
     instance_admin_client.cc
@@ -206,8 +207,7 @@ add_library(
     value.h
     version.cc
     version.h
-    version_info.h
-    iam_updater.h)
+    version_info.h)
 target_include_directories(
     spanner_client
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -64,6 +64,57 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
   return conn_->SetIamPolicy({std::move(db), std::move(policy)});
 }
 
+StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
+    Database const& db, IamUpdater const& updater) {
+  auto const rerun_maximum_duration = std::chrono::minutes(15);
+  auto default_rerun_policy =
+      LimitedTimeTransactionRerunPolicy(rerun_maximum_duration).clone();
+
+  auto const backoff_initial_delay = std::chrono::milliseconds(1000);
+  auto const backoff_maximum_delay = std::chrono::minutes(5);
+  auto const backoff_scaling = 2.0;
+  auto default_backoff_policy =
+      ExponentialBackoffPolicy(backoff_initial_delay, backoff_maximum_delay,
+                               backoff_scaling)
+          .clone();
+
+  return SetIamPolicy(db, updater, std::move(default_rerun_policy),
+                      std::move(default_backoff_policy));
+}
+
+StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
+    Database const& db, IamUpdater const& updater,
+    std::unique_ptr<TransactionRerunPolicy> rerun_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy) {
+  using RerunnablePolicy = internal::SafeTransactionRerun;
+
+  Status last_status =
+      Status(StatusCode::kUnknown, "Exhausted before first call");
+  for (; !rerun_policy->IsExhausted();
+       std::this_thread::sleep_for(backoff_policy->OnCompletion())) {
+    auto current_policy = GetIamPolicy(db);
+    if (!current_policy) {
+      last_status = std::move(current_policy).status();
+    } else {
+      auto etag = current_policy->etag();
+      auto desired = updater(*current_policy);
+      if (!desired.has_value()) {
+        return current_policy;
+      }
+      desired->set_etag(std::move(etag));
+      auto result = SetIamPolicy(db, *std::move(desired));
+      if (RerunnablePolicy::IsOk(result.status())) {
+        return result;
+      }
+      last_status = std::move(result).status();
+    }
+    if (!rerun_policy->OnFailure(last_status)) {
+      return last_status;
+    }
+  }
+  return last_status;
+}
+
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DatabaseAdminClient::TestIamPermissions(Database db,
                                         std::vector<std::string> permissions) {

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -88,8 +88,7 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
     std::unique_ptr<BackoffPolicy> backoff_policy) {
   using RerunnablePolicy = internal::SafeTransactionRerun;
 
-  Status last_status =
-      Status(StatusCode::kUnknown, "Exhausted before first call");
+  Status last_status;
   do {
     auto current_policy = GetIamPolicy(db);
     if (!current_policy) {

--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -232,9 +232,6 @@ class DatabaseAdminClient {
    * Therefore, the underlying RPCs are only retried if the field is set, and
    * the function returns the first RPC error in any other case.
    *
-   * @par Example
-   * @snippet samples.cc add-database-reader-on-database
-   *
    * @see The [Cloud Spanner
    *     documentation](https://cloud.google.com/spanner/docs/iam) for a
    *     description of the roles and permissions supported by Cloud Spanner.
@@ -260,6 +257,18 @@ class DatabaseAdminClient {
    *
    * The function returns the final IAM policy, or an error if the rerun policy
    * for the underlying connection has expired.
+   *
+   * @par Idempotency
+   * This function always sets the `etag` field on the policy, so the underlying
+   * RPCs are retried automatically.
+   *
+   * @par Example
+   * @snippet samples.cc add-database-reader-on-database
+   *
+   * @param db the identifier for the database where you want to change the IAM
+   *     policy.
+   * @param updater a callback to modify the policy.  Return an unset optional
+   *     to indicate that no changes to the policy are needed.
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(Database const& db,
                                                  IamUpdater const& updater);

--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_connection.h"
+#include "google/cloud/spanner/iam_updater.h"
 #include "google/cloud/spanner/instance.h"
 #include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
@@ -243,6 +244,38 @@ class DatabaseAdminClient {
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       Database db, google::iam::v1::Policy policy);
+
+  /**
+   * Updates the IAM policy for an instance using an optimistic concurrency
+   * control loop.
+   *
+   * This function repeatedly reads the current IAM policy in @p in, and then
+   * calls the @p updater with the this policy. The @p updater returns an empty
+   * optional if no changes are required, or it returns the new desired value
+   * for the IAM policy. This function then updates the policy.
+   *
+   * Updating an IAM policy can fail with retryable errors or can be aborted
+   * because there were simultaneous changes the to IAM policy. In these cases
+   * this function reruns the loop until it succeeds.
+   *
+   * The function returns the final IAM policy, or an error if the rerun policy
+   * for the underlying connection has expired.
+   */
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(Database const& db,
+                                                 IamUpdater const& updater);
+
+  /**
+   * @copydoc SetIamPolicy(Database const&,IamUpdater const&)
+   *
+   * @param rerun_policy controls for how long (or how many times) the updater
+   *     will be rerun after the IAM policy update aborts.
+   * @param backoff_policy controls how long `SetIamPolicy` waits between
+   *     reruns.
+   */
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      Database const& db, IamUpdater const& updater,
+      std::unique_ptr<TransactionRerunPolicy> rerun_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy);
 
   /**
    * Get the subset of the permissions the caller has on the given database.

--- a/google/cloud/spanner/database_admin_client.h
+++ b/google/cloud/spanner/database_admin_client.h
@@ -246,7 +246,7 @@ class DatabaseAdminClient {
    * Updates the IAM policy for an instance using an optimistic concurrency
    * control loop.
    *
-   * This function repeatedly reads the current IAM policy in @p in, and then
+   * This function repeatedly reads the current IAM policy in @p db, and then
    * calls the @p updater with the this policy. The @p updater returns an empty
    * optional if no changes are required, or it returns the new desired value
    * for the IAM policy. This function then updates the policy.

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -25,7 +25,9 @@ namespace {
 
 using ::google::cloud::spanner_mocks::MockDatabaseAdminConnection;
 using ::testing::_;
+using ::testing::AtLeast;
 using ::testing::ElementsAre;
+using ::testing::HasSubstr;
 namespace gcsa = ::google::spanner::admin::database::v1;
 
 /// @test Verify DatabaseAdminClient uses CreateDatabase() correctly.
@@ -188,6 +190,126 @@ TEST(DatabaseAdminClientTest, SetIamPolicy) {
   DatabaseAdminClient client(std::move(mock));
   auto response = client.SetIamPolicy(expected_db, google::iam::v1::Policy{});
   EXPECT_STATUS_OK(response);
+}
+
+TEST(DatabaseAdminClientTest, SetIamPolicyOccGetFailure) {
+  Database const db("test-project", "test-instance", "test-database");
+  auto mock = std::make_shared<MockDatabaseAdminConnection>();
+  EXPECT_CALL(*mock, GetIamPolicy(_))
+      .WillOnce([&db](DatabaseAdminConnection::GetIamPolicyParams const& p) {
+        EXPECT_EQ(db, p.database);
+        return Status(StatusCode::kPermissionDenied, "uh-oh");
+      });
+
+  DatabaseAdminClient client(mock);
+  auto actual = client.SetIamPolicy(db, [](google::iam::v1::Policy const&) {
+    return optional<google::iam::v1::Policy>{};
+  });
+  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+}
+
+TEST(DatabaseAdminClientTest, SetIamPolicyOccNoUpdates) {
+  Database const db("test-project", "test-instance", "test-database");
+  auto mock = std::make_shared<MockDatabaseAdminConnection>();
+  EXPECT_CALL(*mock, GetIamPolicy(_))
+      .WillOnce([&db](DatabaseAdminConnection::GetIamPolicyParams const& p) {
+        EXPECT_EQ(db, p.database);
+        google::iam::v1::Policy r;
+        r.set_etag("test-etag");
+        return r;
+      });
+  EXPECT_CALL(*mock, SetIamPolicy(_)).Times(0);
+
+  DatabaseAdminClient client(mock);
+  auto actual = client.SetIamPolicy(db, [](google::iam::v1::Policy p) {
+    EXPECT_EQ("test-etag", p.etag());
+    return optional<google::iam::v1::Policy>{};
+  });
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ("test-etag", actual->etag());
+}
+
+std::unique_ptr<TransactionRerunPolicy> RerunPolicyForTesting() {
+  return LimitedErrorCountTransactionRerunPolicy(/*maximum_failures=*/3)
+      .clone();
+}
+
+std::unique_ptr<BackoffPolicy> BackoffPolicyForTesting() {
+  return ExponentialBackoffPolicy(
+             /*initial_delay=*/std::chrono::microseconds(1),
+             /*maximum_delay=*/std::chrono::microseconds(1), /*scaling=*/2.0)
+      .clone();
+}
+
+TEST(DatabaseAdminClientTest, SetIamPolicyOccRetryAborted) {
+  Database const db("test-project", "test-instance", "test-database");
+  auto mock = std::make_shared<MockDatabaseAdminConnection>();
+  EXPECT_CALL(*mock, GetIamPolicy(_))
+      .WillOnce([&db](DatabaseAdminConnection::GetIamPolicyParams const& p) {
+        EXPECT_EQ(db, p.database);
+        google::iam::v1::Policy r;
+        r.set_etag("test-etag-1");
+        return r;
+      })
+      .WillOnce([&db](DatabaseAdminConnection::GetIamPolicyParams const& p) {
+        EXPECT_EQ(db, p.database);
+        google::iam::v1::Policy r;
+        r.set_etag("test-etag-2");
+        return r;
+      });
+  EXPECT_CALL(*mock, SetIamPolicy(_))
+      .WillOnce([&db](DatabaseAdminConnection::SetIamPolicyParams const& p) {
+        EXPECT_EQ(db, p.database);
+        EXPECT_EQ("test-etag-1", p.policy.etag());
+        return Status(StatusCode::kAborted, "aborted");
+      })
+      .WillOnce([&db](DatabaseAdminConnection::SetIamPolicyParams const& p) {
+        EXPECT_EQ(db, p.database);
+        EXPECT_EQ("test-etag-2", p.policy.etag());
+        google::iam::v1::Policy r;
+        r.set_etag("test-etag-3");
+        return r;
+      });
+
+  DatabaseAdminClient client(mock);
+  int counter = 0;
+  auto actual = client.SetIamPolicy(
+      db,
+      [&counter](google::iam::v1::Policy p) {
+        EXPECT_EQ("test-etag-" + std::to_string(++counter), p.etag());
+        return p;
+      },
+      RerunPolicyForTesting(), BackoffPolicyForTesting());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ("test-etag-3", actual->etag());
+}
+
+TEST(DatabaseAdminClientTest, SetIamPolicyOccRetryAbortedTooManyFailures) {
+  Database const db("test-project", "test-instance", "test-database");
+  auto mock = std::make_shared<MockDatabaseAdminConnection>();
+  EXPECT_CALL(*mock, GetIamPolicy(_))
+      .WillRepeatedly(
+          [&db](DatabaseAdminConnection::GetIamPolicyParams const& p) {
+            EXPECT_EQ(db, p.database);
+            google::iam::v1::Policy r;
+            r.set_etag("test-etag-1");
+            return r;
+          });
+  EXPECT_CALL(*mock, SetIamPolicy(_))
+      .Times(AtLeast(2))
+      .WillRepeatedly(
+          [&db](DatabaseAdminConnection::SetIamPolicyParams const& p) {
+            EXPECT_EQ(db, p.database);
+            EXPECT_EQ("test-etag-1", p.policy.etag());
+            return Status(StatusCode::kAborted, "test-msg");
+          });
+
+  DatabaseAdminClient client(mock);
+  auto actual = client.SetIamPolicy(
+      db, [](google::iam::v1::Policy p) { return p; }, RerunPolicyForTesting(),
+      BackoffPolicyForTesting());
+  EXPECT_EQ(StatusCode::kAborted, actual.status().code());
+  EXPECT_THAT(actual.status().message(), HasSubstr("test-msg"));
 }
 
 /// @test Verify DatabaseAdminClient uses TestIamPermissions() correctly.

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -186,7 +186,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicy) {
             return p.policy;
           });
   DatabaseAdminClient client(std::move(mock));
-  auto response = client.SetIamPolicy(expected_db, {});
+  auto response = client.SetIamPolicy(expected_db, google::iam::v1::Policy{});
   EXPECT_STATUS_OK(response);
 }
 

--- a/google/cloud/spanner/database_admin_client_test.cc
+++ b/google/cloud/spanner/database_admin_client_test.cc
@@ -221,7 +221,7 @@ TEST(DatabaseAdminClientTest, SetIamPolicyOccNoUpdates) {
   EXPECT_CALL(*mock, SetIamPolicy(_)).Times(0);
 
   DatabaseAdminClient client(mock);
-  auto actual = client.SetIamPolicy(db, [](google::iam::v1::Policy p) {
+  auto actual = client.SetIamPolicy(db, [](google::iam::v1::Policy const& p) {
     EXPECT_EQ("test-etag", p.etag());
     return optional<google::iam::v1::Policy>{};
   });

--- a/google/cloud/spanner/iam_updater.h
+++ b/google/cloud/spanner/iam_updater.h
@@ -1,0 +1,35 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_IAM_UPDATER_H_
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_IAM_UPDATER_H_
+
+#include "google/cloud/optional.h"
+#include <google/iam/v1/policy.pb.h>
+#include <functional>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+
+using IamUpdater =
+    std::function<optional<google::iam::v1::Policy>(google::iam::v1::Policy)>;
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_IAM_UPDATER_H_

--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -67,6 +67,57 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
   return conn_->SetIamPolicy({in.FullName(), std::move(policy)});
 }
 
+StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
+    Instance const& in, IamUpdater const& updater) {
+  auto const rerun_maximum_duration = std::chrono::minutes(15);
+  auto default_rerun_policy =
+      LimitedTimeTransactionRerunPolicy(rerun_maximum_duration).clone();
+
+  auto const backoff_initial_delay = std::chrono::milliseconds(1000);
+  auto const backoff_maximum_delay = std::chrono::minutes(5);
+  auto const backoff_scaling = 2.0;
+  auto default_backoff_policy =
+      ExponentialBackoffPolicy(backoff_initial_delay, backoff_maximum_delay,
+                               backoff_scaling)
+          .clone();
+
+  return SetIamPolicy(in, updater, std::move(default_rerun_policy),
+                      std::move(default_backoff_policy));
+}
+
+StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
+    Instance const& in, IamUpdater const& updater,
+    std::unique_ptr<TransactionRerunPolicy> rerun_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy) {
+  using RerunnablePolicy = internal::SafeTransactionRerun;
+
+  Status last_status =
+      Status(StatusCode::kUnknown, "Exhausted before first call");
+  for (; !rerun_policy->IsExhausted();
+       std::this_thread::sleep_for(backoff_policy->OnCompletion())) {
+    auto current_policy = GetIamPolicy(in);
+    if (!current_policy) {
+      last_status = std::move(current_policy).status();
+    } else {
+      auto etag = current_policy->etag();
+      auto desired = updater(*current_policy);
+      if (!desired.has_value()) {
+        return current_policy;
+      }
+      desired->set_etag(std::move(etag));
+      auto result = SetIamPolicy(in, *std::move(desired));
+      if (RerunnablePolicy::IsOk(result.status())) {
+        return result;
+      }
+      last_status = std::move(result).status();
+    }
+    if (!rerun_policy->OnFailure(last_status)) {
+      return last_status;
+    }
+  }
+  return last_status;
+}
+
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 InstanceAdminClient::TestIamPermissions(Instance const& in,
                                         std::vector<std::string> permissions) {

--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -93,8 +93,7 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
 
   Status last_status =
       Status(StatusCode::kUnknown, "Exhausted before first call");
-  for (; !rerun_policy->IsExhausted();
-       std::this_thread::sleep_for(backoff_policy->OnCompletion())) {
+  do {
     auto current_policy = GetIamPolicy(in);
     if (!current_policy) {
       last_status = std::move(current_policy).status();
@@ -111,10 +110,9 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
       }
       last_status = std::move(result).status();
     }
-    if (!rerun_policy->OnFailure(last_status)) {
-      return last_status;
-    }
-  }
+    if (!rerun_policy->OnFailure(last_status)) break;
+    std::this_thread::sleep_for(backoff_policy->OnCompletion());
+  } while (!rerun_policy->IsExhausted());
   return last_status;
 }
 

--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -91,8 +91,7 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
     std::unique_ptr<BackoffPolicy> backoff_policy) {
   using RerunnablePolicy = internal::SafeTransactionRerun;
 
-  Status last_status =
-      Status(StatusCode::kUnknown, "Exhausted before first call");
+  Status last_status;
   do {
     auto current_policy = GetIamPolicy(in);
     if (!current_policy) {

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INSTANCE_ADMIN_CLIENT_H_
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INSTANCE_ADMIN_CLIENT_H_
 
+#include "google/cloud/spanner/iam_updater.h"
 #include "google/cloud/spanner/instance.h"
 #include "google/cloud/spanner/instance_admin_connection.h"
 #include "google/cloud/status_or.h"
@@ -57,7 +58,6 @@ inline namespace SPANNER_CLIENT_NS {
  * [spanner-doc-link]:
  * https://cloud.google.com/spanner/docs/api-libraries-overview
  */
-
 class InstanceAdminClient {
  public:
   explicit InstanceAdminClient(std::shared_ptr<InstanceAdminConnection> conn)
@@ -234,6 +234,38 @@ class InstanceAdminClient {
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       Instance const& in, google::iam::v1::Policy policy);
+
+  /**
+   * Updates the IAM policy for an instance using an optimistic concurrency
+   * control loop.
+   *
+   * This function repeatedly reads the current IAM policy in @p in, and then
+   * calls the @p updater with the this policy. The @p updater returns an empty
+   * optional if no changes are required, or it returns the new desired value
+   * for the IAM policy. This function then updates the policy.
+   *
+   * Updating an IAM policy can fail with retryable errors or can be aborted
+   * because there were simultaneous changes the to IAM policy. In these cases
+   * this function reruns the loop until it succeeds.
+   *
+   * The function returns the final IAM policy, or an error if the rerun policy
+   * for the underlying connection has expired.
+   */
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(Instance const& in,
+                                                 IamUpdater const& updater);
+
+  /**
+   * @copydoc SetIamPolicy(Instance const&,IamUpdater const&)
+   *
+   * @param rerun_policy controls for how long (or how many times) the updater
+   *     will be rerun after the IAM policy update aborts.
+   * @param backoff_policy controls how long `SetIamPolicy` waits between
+   *     reruns.
+   */
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      Instance const& in, IamUpdater const& updater,
+      std::unique_ptr<TransactionRerunPolicy> rerun_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy);
 
   /**
    * Get the subset of the permissions the caller has on the given instance.

--- a/google/cloud/spanner/instance_admin_client.h
+++ b/google/cloud/spanner/instance_admin_client.h
@@ -250,6 +250,15 @@ class InstanceAdminClient {
    *
    * The function returns the final IAM policy, or an error if the rerun policy
    * for the underlying connection has expired.
+   *
+   * @par Idempotency
+   * This function always sets the `etag` field on the policy, so the underlying
+   * RPCs are retried automatically.
+   *
+   * @param in the identifier for the instance where you want to change the IAM
+   *     policy.
+   * @param updater a callback to modify the policy.  Return an unset optional
+   *     to indicate that no changes to the policy are needed.
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(Instance const& in,
                                                  IamUpdater const& updater);

--- a/google/cloud/spanner/instance_admin_client_test.cc
+++ b/google/cloud/spanner/instance_admin_client_test.cc
@@ -156,8 +156,8 @@ TEST(InstanceAdminClientTest, SetIamPolicy) {
       });
 
   InstanceAdminClient client(mock);
-  auto actual =
-      client.SetIamPolicy(Instance("test-project", "test-instance"), {});
+  auto actual = client.SetIamPolicy(Instance("test-project", "test-instance"),
+                                    google::iam::v1::Policy{});
   EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
 }
 

--- a/google/cloud/spanner/instance_admin_client_test.cc
+++ b/google/cloud/spanner/instance_admin_client_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/spanner/mocks/mock_instance_admin_connection.h"
+#include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -24,7 +25,9 @@ namespace {
 
 using spanner_mocks::MockInstanceAdminConnection;
 using ::testing::_;
+using ::testing::AtLeast;
 using ::testing::ElementsAre;
+using ::testing::HasSubstr;
 namespace gcsa = google::spanner::admin::instance::v1;
 
 TEST(InstanceAdminClientTest, CopyAndMove) {
@@ -159,6 +162,133 @@ TEST(InstanceAdminClientTest, SetIamPolicy) {
   auto actual = client.SetIamPolicy(Instance("test-project", "test-instance"),
                                     google::iam::v1::Policy{});
   EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+}
+
+TEST(InstanceAdminClientTest, SetIamPolicyOccGetFailure) {
+  auto mock = std::make_shared<MockInstanceAdminConnection>();
+  EXPECT_CALL(*mock, GetIamPolicy(_))
+      .WillOnce([](InstanceAdminConnection::GetIamPolicyParams const& p) {
+        EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
+        EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
+        return Status(StatusCode::kPermissionDenied, "uh-oh");
+      });
+
+  InstanceAdminClient client(mock);
+  auto actual = client.SetIamPolicy(
+      Instance("test-project", "test-instance"), [](google::iam::v1::Policy) {
+        return optional<google::iam::v1::Policy>{};
+      });
+  EXPECT_EQ(StatusCode::kPermissionDenied, actual.status().code());
+}
+
+TEST(InstanceAdminClientTest, SetIamPolicyOccNoUpdates) {
+  auto mock = std::make_shared<MockInstanceAdminConnection>();
+  EXPECT_CALL(*mock, GetIamPolicy(_))
+      .WillOnce([](InstanceAdminConnection::GetIamPolicyParams const& p) {
+        EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
+        EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
+        google::iam::v1::Policy r;
+        r.set_etag("test-etag");
+        return r;
+      });
+  EXPECT_CALL(*mock, SetIamPolicy(_)).Times(0);
+
+  InstanceAdminClient client(mock);
+  auto actual = client.SetIamPolicy(
+      Instance("test-project", "test-instance"), [](google::iam::v1::Policy p) {
+        EXPECT_EQ("test-etag", p.etag());
+        return optional<google::iam::v1::Policy>{};
+      });
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ("test-etag", actual->etag());
+}
+
+std::unique_ptr<TransactionRerunPolicy> RerunPolicyForTesting() {
+  return LimitedErrorCountTransactionRerunPolicy(/*maximum_failures=*/3)
+      .clone();
+}
+
+std::unique_ptr<BackoffPolicy> BackoffPolicyForTesting() {
+  return ExponentialBackoffPolicy(
+             /*initial_delay=*/std::chrono::microseconds(1),
+             /*maximum_delay=*/std::chrono::microseconds(1), /*scaling=*/2.0)
+      .clone();
+}
+
+TEST(InstanceAdminClientTest, SetIamPolicyOccRetryAborted) {
+  auto mock = std::make_shared<MockInstanceAdminConnection>();
+  EXPECT_CALL(*mock, GetIamPolicy(_))
+      .WillOnce([](InstanceAdminConnection::GetIamPolicyParams const& p) {
+        EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
+        EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
+        google::iam::v1::Policy r;
+        r.set_etag("test-etag-1");
+        return r;
+      })
+      .WillOnce([](InstanceAdminConnection::GetIamPolicyParams const& p) {
+        EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
+        EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
+        google::iam::v1::Policy r;
+        r.set_etag("test-etag-2");
+        return r;
+      });
+  EXPECT_CALL(*mock, SetIamPolicy(_))
+      .WillOnce([](InstanceAdminConnection::SetIamPolicyParams const& p) {
+        EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
+        EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
+        EXPECT_EQ("test-etag-1", p.policy.etag());
+        return Status(StatusCode::kAborted, "aborted");
+      })
+      .WillOnce([](InstanceAdminConnection::SetIamPolicyParams const& p) {
+        EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
+        EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
+        EXPECT_EQ("test-etag-2", p.policy.etag());
+        google::iam::v1::Policy r;
+        r.set_etag("test-etag-3");
+        return r;
+      });
+
+  InstanceAdminClient client(mock);
+  int counter = 0;
+  auto actual = client.SetIamPolicy(
+      Instance("test-project", "test-instance"),
+      [&counter](google::iam::v1::Policy p) {
+        EXPECT_EQ("test-etag-" + std::to_string(++counter), p.etag());
+        return p;
+      },
+      RerunPolicyForTesting(), BackoffPolicyForTesting());
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ("test-etag-3", actual->etag());
+}
+
+TEST(InstanceAdminClientTest, SetIamPolicyOccRetryAbortedTooManyFailures) {
+  auto mock = std::make_shared<MockInstanceAdminConnection>();
+  EXPECT_CALL(*mock, GetIamPolicy(_))
+      .WillRepeatedly([](InstanceAdminConnection::GetIamPolicyParams const& p) {
+        EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
+        EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
+        google::iam::v1::Policy r;
+        r.set_etag("test-etag-1");
+        return r;
+      });
+  EXPECT_CALL(*mock, SetIamPolicy(_))
+  .Times(AtLeast(2))
+      .WillRepeatedly([](InstanceAdminConnection::SetIamPolicyParams const& p) {
+        EXPECT_THAT(p.instance_name, HasSubstr("test-project"));
+        EXPECT_THAT(p.instance_name, HasSubstr("test-instance"));
+        EXPECT_EQ("test-etag-1", p.policy.etag());
+        return Status(StatusCode::kAborted, "test-msg");
+      });
+
+  InstanceAdminClient client(mock);
+  auto actual = client.SetIamPolicy(
+      Instance("test-project", "test-instance"),
+      [](google::iam::v1::Policy p) {
+        return p;
+      },
+      RerunPolicyForTesting(), BackoffPolicyForTesting());
+  EXPECT_EQ(StatusCode::kAborted, actual.status().code());
+  EXPECT_THAT(actual.status().message(), HasSubstr("test-msg"));
 }
 
 TEST(InstanceAdminClientTest, TestIamPermissions) {

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -90,7 +90,7 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
   EXPECT_EQ(0, current_policy->bindings_size());
 
   std::string const reader_role = "roles/spanner.databaseReader";
-  std::string const writer_role = "roles/spanner.databaseWriter";
+  std::string const writer_role = "roles/spanner.databaseUser";
   std::string const expected_member =
       "serviceAccount:" + test_iam_service_account;
   auto& binding = *current_policy->add_bindings();
@@ -119,9 +119,9 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
   ASSERT_STATUS_OK(updated_policy);
   EXPECT_EQ(2, updated_policy->bindings_size());
   ASSERT_EQ(writer_role, updated_policy->bindings().Get(1).role());
-  ASSERT_EQ(2, updated_policy->bindings().Get(1).members().size());
+  ASSERT_EQ(1, updated_policy->bindings().Get(1).members().size());
   ASSERT_EQ(expected_member,
-            updated_policy->bindings().Get(1).members().Get(1));
+            updated_policy->bindings().Get(1).members().Get(0));
 
   // Fetch the Iam Policy again.
   current_policy = client.GetIamPolicy(db);

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -89,20 +89,39 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
   ASSERT_STATUS_OK(current_policy);
   EXPECT_EQ(0, current_policy->bindings_size());
 
-  std::string const expected_role = "roles/spanner.databaseReader";
+  std::string const reader_role = "roles/spanner.databaseReader";
+  std::string const writer_role = "roles/spanner.databaseWriter";
   std::string const expected_member =
       "serviceAccount:" + test_iam_service_account;
   auto& binding = *current_policy->add_bindings();
-  binding.set_role(expected_role);
+  binding.set_role(reader_role);
   *binding.add_members() = expected_member;
 
   auto updated_policy = client.SetIamPolicy(db, *current_policy);
   ASSERT_STATUS_OK(updated_policy);
   EXPECT_EQ(1, updated_policy->bindings_size());
-  ASSERT_EQ(expected_role, updated_policy->bindings().Get(0).role());
+  ASSERT_EQ(reader_role, updated_policy->bindings().Get(0).role());
   ASSERT_EQ(1, updated_policy->bindings().Get(0).members().size());
   ASSERT_EQ(expected_member,
             updated_policy->bindings().Get(0).members().Get(0));
+
+  // Perform a different update using the the OCC loop API:
+  updated_policy =
+      client.SetIamPolicy(db, [&test_iam_service_account,
+                               &writer_role](google::iam::v1::Policy current) {
+        std::string const expected_member =
+            "serviceAccount:" + test_iam_service_account;
+        auto& binding = *current.add_bindings();
+        binding.set_role(writer_role);
+        *binding.add_members() = expected_member;
+        return current;
+      });
+  ASSERT_STATUS_OK(updated_policy);
+  EXPECT_EQ(2, updated_policy->bindings_size());
+  ASSERT_EQ(writer_role, updated_policy->bindings().Get(1).role());
+  ASSERT_EQ(2, updated_policy->bindings().Get(1).members().size());
+  ASSERT_EQ(expected_member,
+            updated_policy->bindings().Get(1).members().Get(1));
 
   // Fetch the Iam Policy again.
   current_policy = client.GetIamPolicy(db);

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -229,6 +229,12 @@ TEST_F(InstanceAdminClientTest, InstanceIam) {
     auto updated_policy = client_.SetIamPolicy(in, *actual_policy);
     ASSERT_STATUS_OK(updated_policy);
     EXPECT_FALSE(actual_policy->etag().empty());
+
+    // Repeat the test using the OCC API.
+    updated_policy =
+        client_.SetIamPolicy(in, [](google::iam::v1::Policy p) { return p; });
+    ASSERT_STATUS_OK(updated_policy);
+    EXPECT_FALSE(actual_policy->etag().empty());
   }
 
   auto actual = client_.TestIamPermissions(

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -266,42 +266,42 @@ void AddDatabaseReader(google::cloud::spanner::InstanceAdminClient client,
                        std::string const& instance_id,
                        std::string const& new_reader) {
   google::cloud::spanner::Instance in(project_id, instance_id);
+  auto result = client.SetIamPolicy(
+      in,
+      [&new_reader](google::iam::v1::Policy current)
+          -> google::cloud::optional<google::iam::v1::Policy> {
+        // Find (or create) the binding for "roles/spanner.databaseReader".
+        auto& binding = [&current]() -> google::iam::v1::Binding& {
+          auto role_pos = std::find_if(
+              current.mutable_bindings()->begin(),
+              current.mutable_bindings()->end(),
+              [](google::iam::v1::Binding const& b) {
+                return b.role() == "roles/spanner.databaseReader" &&
+                       !b.has_condition();
+              });
+          if (role_pos != current.mutable_bindings()->end()) {
+            return *role_pos;
+          }
+          auto& binding = *current.add_bindings();
+          binding.set_role("roles/spanner.databaseReader");
+          return binding;
+        }();
 
-  auto current = client.GetIamPolicy(in);
-  if (!current) throw std::runtime_error(current.status().message());
+        auto member_pos = std::find(binding.members().begin(),
+                                    binding.members().end(), new_reader);
+        if (member_pos != binding.members().end()) {
+          std::cout << "The entity " << new_reader
+                    << " is already a database reader:\n"
+                    << current.DebugString();
+          return {};
+        }
+        if (member_pos == binding.members().end()) {
+          binding.add_members(new_reader);
+        }
+        return current;
+      });
 
-  // Find (or create) the binding for "roles/spanner.databaseReader".
-  auto& binding = [&current]() -> google::iam::v1::Binding& {
-    auto role_pos =
-        std::find_if(current->mutable_bindings()->begin(),
-                     current->mutable_bindings()->end(),
-                     [](google::iam::v1::Binding const& b) {
-                       return b.role() == "roles/spanner.databaseReader" &&
-                              !b.has_condition();
-                     });
-    if (role_pos != current->mutable_bindings()->end()) {
-      return *role_pos;
-    }
-    auto& binding = *current->add_bindings();
-    binding.set_role("roles/spanner.databaseReader");
-    return binding;
-  }();
-
-  auto member_pos =
-      std::find(binding.members().begin(), binding.members().end(), new_reader);
-  if (member_pos != binding.members().end()) {
-    std::cout << "The entity " << new_reader
-              << " is already a database reader:\n"
-              << current->DebugString();
-    return;
-  }
-  if (member_pos == binding.members().end()) {
-    binding.add_members(new_reader);
-  }
-
-  auto result = client.SetIamPolicy(in, *std::move(current));
   if (!result) throw std::runtime_error(result.status().message());
-
   std::cout << "Successfully added " << new_reader
             << " to the database reader role:\n"
             << result->DebugString() << "\n";
@@ -325,29 +325,33 @@ void RemoveDatabaseReader(google::cloud::spanner::InstanceAdminClient client,
                           std::string const& reader) {
   google::cloud::spanner::Instance in(project_id, instance_id);
 
-  auto current = client.GetIamPolicy(in);
-  if (!current) throw std::runtime_error(current.status().message());
+  auto result = client.SetIamPolicy(
+      in,
+      [&reader](google::iam::v1::Policy current)
+          -> google::cloud::optional<google::iam::v1::Policy> {
+        // Find the binding for "roles/spanner.databaseReader".
+        auto role_pos =
+            std::find_if(current.mutable_bindings()->begin(),
+                         current.mutable_bindings()->end(),
+                         [](google::iam::v1::Binding const& b) {
+                           return b.role() == "roles/spanner.databaseReader" &&
+                                  !b.has_condition();
+                         });
+        if (role_pos == current.mutable_bindings()->end()) {
+          std::cout << "Nothing to do as the roles/spanner.databaseReader role "
+                       "is empty\n";
+          return {};
+        }
+        role_pos->mutable_members()->erase(
+            std::remove(role_pos->mutable_members()->begin(),
+                        role_pos->mutable_members()->end(), reader),
+            role_pos->mutable_members()->end());
 
-  // Find the binding for "roles/spanner.databaseReader".
-  auto role_pos = std::find_if(
-      current->mutable_bindings()->begin(), current->mutable_bindings()->end(),
-      [](google::iam::v1::Binding const& b) {
-        return b.role() == "roles/spanner.databaseReader" && !b.has_condition();
+        return current;
       });
-  if (role_pos == current->mutable_bindings()->end()) {
-    std::cout
-        << "Nothing to do as the roles/spanner.databaseReader role is empty\n";
-    return;
-  }
-  role_pos->mutable_members()->erase(
-      std::remove(role_pos->mutable_members()->begin(),
-                  role_pos->mutable_members()->end(), reader),
-      role_pos->mutable_members()->end());
 
-  auto result = client.SetIamPolicy(in, *std::move(current));
   if (!result) throw std::runtime_error(result.status().message());
-
-  std::cout << "Successfully remove " << reader
+  std::cout << "Successfully removed " << reader
             << " from the database reader role:\n"
             << result->DebugString() << "\n";
 }

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -295,9 +295,7 @@ void AddDatabaseReader(google::cloud::spanner::InstanceAdminClient client,
                     << current.DebugString();
           return {};
         }
-        if (member_pos == binding.members().end()) {
-          binding.add_members(new_reader);
-        }
+        binding.add_members(new_reader);
         return current;
       });
 
@@ -663,10 +661,8 @@ void AddDatabaseReaderOnDatabase(
               << current->DebugString();
     return;
   }
-  if (member_pos == binding.members().end()) {
-    binding.add_members(new_reader);
-  }
 
+  binding.add_members(new_reader);
   auto result = client.SetIamPolicy(database, *std::move(current));
   if (!result) throw std::runtime_error(result.status().message());
 

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -30,6 +30,7 @@ spanner_client_hdrs = [
     "database_admin_client.h",
     "database_admin_connection.h",
     "date.h",
+    "iam_updater.h",
     "instance.h",
     "instance_admin_client.h",
     "instance_admin_connection.h",
@@ -82,7 +83,6 @@ spanner_client_hdrs = [
     "value.h",
     "version.h",
     "version_info.h",
-    "iam_updater.h",
 ]
 
 spanner_client_srcs = [

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -82,6 +82,7 @@ spanner_client_hdrs = [
     "value.h",
     "version.h",
     "version_info.h",
+    "iam_updater.h",
 ]
 
 spanner_client_srcs = [


### PR DESCRIPTION
Adds functions to DatabaseAdminClient and InstanceAdminClient that run a
optimistic concurrency control (OCC) loop for IAM updates. That makes
the customer code a bit easier to write and less error prone. This is
analogous to the Commit() loops for the spanner::Client.

This fixes #613 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1162)
<!-- Reviewable:end -->
