### PR TITLE
bug: be careful with by-reference captures in a Commit() mutator

### DIFF
--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -442,6 +442,7 @@ void CheckExecuteQueryWithSingleUseOptions(
       [&expected_rows](Transaction const&) -> StatusOr<Mutations> {
         InsertMutationBuilder insert("Singers",
                                      {"SingerId", "FirstName", "LastName"});
+        expected_rows.clear();
         for (int i = 1; i != 10; ++i) {
           auto s = std::to_string(i);
           auto row = RowValues{Value(i), Value("test-fname-" + s),


### PR DESCRIPTION
A `Commit()` mutator may be re-run, so users need to be careful
with any state shared between runs.  In this case we do not want
to accumulate expected results across re-runs, so clear the vector
of expected rows each time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1163)
<!-- Reviewable:end -->
