### PR TITLE
testing: allow build.sh to run arbitrary commands in the container

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -365,6 +365,8 @@ echo "================================================================"
 if [[ $# -ge 2 ]]; then
   echo "Running the given command '" "${@:2}" "' in the container $(date)."
   readonly commands=( "${@:2}" )
+  # Delete the container after exit.
+  docker_flags+=("--rm")
 else
   echo "Running the full build $(date)."
   readonly commands=(

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -348,6 +348,9 @@ docker_flags=(
     "--volume" "/v/cmake-out/home"
     "--volume" "/v/cmake-out"
     "--volume" "${PWD}/${BUILD_OUTPUT}:/v/${BUILD_OUTPUT}"
+
+    # No need to preserve the container.
+    "--rm"
 )
 
 # When running the builds from the command-line they get a tty, and the scripts
@@ -363,10 +366,8 @@ fi
 # appropriate arguments.
 echo "================================================================"
 if [[ $# -ge 2 ]]; then
-  echo "Running the given command '" "${@:2}" "' in the container $(date)."
+  echo "Running the given commands '" "${@:2}" "' in the container $(date)."
   readonly commands=( "${@:2}" )
-  # Delete the container after exit.
-  docker_flags+=("--rm")
 else
   echo "Running the full build $(date)."
   readonly commands=(


### PR DESCRIPTION
It will allow running arbitrary commands in the corresponding container. Some examples:

```sh
ci/kokoro/docker/build.sh clang-tidy bash
```

```sh
ci/kokoro/docker/build.sh clang-tidy ls -al
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1168)
<!-- Reviewable:end -->
