### PR TITLE
bug: number of channels was inadvertently limited to 1

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -246,7 +246,7 @@ std::shared_ptr<Connection> MakeConnection(
     std::unique_ptr<RetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy) {
   std::vector<std::shared_ptr<internal::SpannerStub>> stubs;
-  int num_channels = std::min(connection_options.num_channels(), 1);
+  int num_channels = std::max(connection_options.num_channels(), 1);
   stubs.reserve(num_channels);
   for (int channel_id = 0; channel_id < num_channels; ++channel_id) {
     stubs.push_back(


### PR DESCRIPTION
The intent was to ensure the number of channels was "at least one",
but instead actually made it "at most one".

There is no test for this because client_test uses the Client
constructor directly. We should try to add one, but let's fix
this obvious bug first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1169)
<!-- Reviewable:end -->
