### PR TITLE
feat: allow re-using a database across benchmark runs

### DIFF
--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -84,6 +84,8 @@ google::cloud::StatusOr<Config> ParseArgs(std::vector<std::string> args) {
        [](Config& c, std::string v) { c.project_id = std::move(v); }},
       {"--instance=",
        [](Config& c, std::string v) { c.instance_id = std::move(v); }},
+      {"--database=",
+       [](Config& c, std::string const& v) { c.database_id = std::move(v); }},
       {"--samples=",
        [](Config& c, std::string const& v) { c.samples = std::stoi(v); }},
       {"--iteration-duration=",

--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -173,14 +173,19 @@ int main(int argc, char* argv[]) {
   int exit_status = EXIT_SUCCESS;
 
   auto experiment = e->second(generator);
+  Status setup_status;
   if (database_created) {
-    auto status = experiment->SetUp(config, database);
-    if (!status.ok()) {
-      std::cout << "# Skipping experiment, SetUp() failed: " << status << "\n";
+    setup_status = experiment->SetUp(config, database);
+    if (!setup_status.ok()) {
+      std::cout << "# Skipping experiment, SetUp() failed: " << setup_status
+                << "\n";
       exit_status = EXIT_FAILURE;
-    } else {
-      status = experiment->Run(config, database);
-      if (!status.ok()) exit_status = EXIT_FAILURE;
+    }
+  }
+  if (setup_status.ok()) {
+    auto run_status = experiment->Run(config, database);
+    if (!run_status.ok()) exit_status = EXIT_FAILURE;
+    if (database_created) {
       (void)experiment->TearDown(config, database);
     }
   }

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -45,7 +45,7 @@ class Experiment {
   virtual ~Experiment() = default;
 
   virtual void SetUp(Config const& config,
-                     cloud_spanner::Database const& database) = 0;
+                     cloud_spanner::Database const& database, bool fill) = 0;
   virtual void Run(Config const& config,
                    cloud_spanner::Database const& database,
                    SampleSink const& sink) = 0;
@@ -83,10 +83,16 @@ int main(int argc, char* argv[]) {
     config.instance_id = *std::move(instance);
   }
 
-  cloud_spanner::Database database(
-      config.project_id, config.instance_id,
-      google::cloud::spanner_testing::RandomDatabaseName(generator));
-  config.database_id = database.database_id();
+  // If the user specified a database name on the command line, re-use it to
+  // reduce setup time when running the benchmark repeatedly. It's assumed that
+  // other flags related to database creation have not been changed across runs.
+  bool user_specified_database = !config.database_id.empty();
+  if (!user_specified_database) {
+    config.database_id =
+        google::cloud::spanner_testing::RandomDatabaseName(generator);
+  }
+  cloud_spanner::Database database(config.project_id, config.instance_id,
+                                   config.database_id);
 
   auto available = AvailableExperiments();
   auto e = available.find(config.experiment);
@@ -96,22 +102,30 @@ int main(int argc, char* argv[]) {
   }
 
   cloud_spanner::DatabaseAdminClient admin_client;
-  auto created =
+  auto create_future =
       admin_client.CreateDatabase(database, {R"sql(CREATE TABLE KeyValue (
                                 Key   INT64 NOT NULL,
                                 Data  STRING(1024),
                              ) PRIMARY KEY (Key))sql"});
   std::cout << "# Waiting for database creation to complete " << std::flush;
   for (;;) {
-    auto status = created.wait_for(std::chrono::seconds(1));
+    auto status = create_future.wait_for(std::chrono::seconds(1));
     if (status == std::future_status::ready) break;
     std::cout << '.' << std::flush;
   }
   std::cout << " DONE\n";
-  auto db = created.get();
+
+  bool database_created = true;
+  auto db = create_future.get();
   if (!db) {
-    std::cerr << "Error creating database: " << db.status() << "\n";
-    return 1;
+    if (user_specified_database &&
+        db.status().code() == google::cloud::StatusCode::kAlreadyExists) {
+      std::cout << "# Re-using existing database\n";
+      database_created = false;
+    } else {
+      std::cerr << "Error creating database: " << db.status() << "\n";
+      return 1;
+    }
   }
 
   std::cout << "ClientCount,ThreadCount,EventCount,ElapsedTime\n" << std::flush;
@@ -129,14 +143,18 @@ int main(int argc, char* argv[]) {
       };
 
   auto experiment = e->second;
-  experiment->SetUp(config, database);
+  experiment->SetUp(config, database, database_created);
   experiment->Run(config, database, cout_sink);
 
-  auto drop = admin_client.DropDatabase(database);
-  if (!drop.ok()) {
-    std::cerr << "# Error dropping database: " << drop << "\n";
+  if (!user_specified_database) {
+    auto drop = admin_client.DropDatabase(database);
+    if (!drop.ok()) {
+      std::cerr << "# Error dropping database: " << drop << "\n";
+    }
   }
-  std::cout << "# Experiment finished, database dropped\n";
+  std::cout << "# Experiment finished, "
+            << (user_specified_database ? "user-specified database kept\n"
+                                        : "database dropped\n");
   return 0;
 }
 
@@ -220,7 +238,7 @@ int ClientCount(Config const& config,
 
 class InsertOrUpdateExperiment : public Experiment {
  public:
-  void SetUp(Config const&, cloud_spanner::Database const&) override {}
+  void SetUp(Config const&, cloud_spanner::Database const&, bool) override {}
 
   void Run(Config const& config, cloud_spanner::Database const& database,
            SampleSink const& sink) override {
@@ -318,14 +336,16 @@ class ReadExperiment : public Experiment {
  public:
   ReadExperiment() : generator_(std::random_device{}()) {}
 
-  void SetUp(Config const& config,
-             cloud_spanner::Database const& database) override {
+  void SetUp(Config const& config, cloud_spanner::Database const& database,
+             bool fill) override {
     std::string value = [this] {
       std::lock_guard<std::mutex> lk(mu_);
       return google::cloud::internal::Sample(
           generator_, 1024, "#@$%^&*()-=+_0123456789[]{}|;:,./<>?");
     }();
-    FillTable(config, database, mu_, value);
+    if (fill) {
+      FillTable(config, database, mu_, value);
+    }
   }
 
   void Run(Config const& config, cloud_spanner::Database const& database,
@@ -429,14 +449,16 @@ class UpdateDmlExperiment : public Experiment {
  public:
   UpdateDmlExperiment() : generator_(std::random_device{}()) {}
 
-  void SetUp(Config const& config,
-             cloud_spanner::Database const& database) override {
+  void SetUp(Config const& config, cloud_spanner::Database const& database,
+             bool fill) override {
     std::string value = [this] {
       std::lock_guard<std::mutex> lk(mu_);
       return google::cloud::internal::Sample(
           generator_, 1024, "#@$%^&*()-=+_0123456789[]{}|;:,./<>?");
     }();
-    FillTable(config, database, mu_, value);
+    if (fill) {
+      FillTable(config, database, mu_, value);
+    }
   }
 
   void Run(Config const& config, cloud_spanner::Database const& database,
@@ -545,14 +567,16 @@ class SelectExperiment : public Experiment {
  public:
   SelectExperiment() : generator_(std::random_device{}()) {}
 
-  void SetUp(Config const& config,
-             cloud_spanner::Database const& database) override {
+  void SetUp(Config const& config, cloud_spanner::Database const& database,
+             bool fill) override {
     std::string value = [this] {
       std::lock_guard<std::mutex> lk(mu_);
       return google::cloud::internal::Sample(
           generator_, 1024, "#@$%^&*()-=+_0123456789[]{}|;:,./<>?");
     }();
-    FillTable(config, database, mu_, value);
+    if (fill) {
+      FillTable(config, database, mu_, value);
+    }
   }
 
   void Run(Config const& config, cloud_spanner::Database const& database,
@@ -568,7 +592,6 @@ class SelectExperiment : public Experiment {
       std::cout << '.' << std::flush;
     }
     std::cout << " DONE\n";
-
     std::uniform_int_distribution<int> thread_count_gen(config.minimum_threads,
                                                         config.maximum_threads);
 
@@ -654,7 +677,10 @@ class SelectExperiment : public Experiment {
 
 class RunAllExperiment : public Experiment {
  public:
-  void SetUp(Config const&, cloud_spanner::Database const&) override {}
+  void SetUp(Config const&, cloud_spanner::Database const&,
+             bool fill) override {
+    fill_ = fill;
+  }
 
   void Run(Config const& cfg, cloud_spanner::Database const& database,
            SampleSink const& sink) override {
@@ -668,10 +694,13 @@ class RunAllExperiment : public Experiment {
       config.iteration_duration = std::chrono::seconds(1);
       std::cout << "# Smoke test for experiment: " << kv.first << "\n";
       // TODO(#1119) - tests disabled until we can stay within admin op quota
-      kv.second->SetUp(config, database);
+      kv.second->SetUp(config, database, fill_);
       kv.second->Run(config, database, sink);
     }
   }
+
+ private:
+  bool fill_ = true;
 };
 
 std::map<std::string, std::shared_ptr<Experiment>> AvailableExperiments() {


### PR DESCRIPTION
If the user specifies a non-empty `--database <database_name>` on the command
line, it will be re-used across runs. The database will be created and
populated if it doesn't already exist (i.e. on the first run) but it
will not be dropped at the end of the run as it normally would be.  This
saves a lot of setup time if you're running the benchmark repeatedly.

Otherwise, the behavior is unchanged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1174)
<!-- Reviewable:end -->
