### PR TITLE
fix: only check for per-thread rusage in the benchmark that requires it

### DIFF
--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -18,9 +18,6 @@
 #include "google/cloud/internal/getenv.h"
 #include <functional>
 #include <sstream>
-#if GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
-#include <sys/resource.h>
-#endif  // GOOGLE_CLOUD_CPP_HAVE_GETRUSAGE
 
 namespace google {
 namespace cloud {
@@ -28,16 +25,6 @@ namespace spanner_benchmarks {
 inline namespace SPANNER_CLIENT_NS {
 
 namespace cs = google::cloud::spanner;
-
-namespace {
-bool SupportPerThreadUsage() {
-#if GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
-  return true;
-#else
-  return false;
-#endif  // GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
-}
-}  // namespace
 
 std::ostream& operator<<(std::ostream& os, Config const& config) {
   return os << "# Experiment: " << config.experiment
@@ -160,14 +147,6 @@ google::cloud::StatusOr<Config> ParseArgs(std::vector<std::string> args) {
     os << "The maximum number of threads (" << config.maximum_threads << ")"
        << " must be greater or equal than the minimum number of threads ("
        << config.minimum_threads << ")";
-    return invalid_argument(os.str());
-  }
-
-  if (!SupportPerThreadUsage() && config.maximum_threads > 1) {
-    std::ostringstream os;
-    os << "Your platform does not support per-thread getrusage() data."
-       << " The benchmark cannot run with more than one thread, and you"
-       << " set maximum threads to " << config.maximum_threads;
     return invalid_argument(os.str());
   }
 

--- a/google/cloud/spanner/benchmarks/benchmarks_config_test.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config_test.cc
@@ -55,14 +55,10 @@ TEST(BenchmarkConfigTest, ParseNone) {
 TEST(BenchmarkConfigTest, ParseThreads) {
   auto config = ParseArgs({"placeholder", "--project=test-project",
                            "--minimum-threads=4", "--maximum-threads=16"});
-#if GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
   ASSERT_STATUS_OK(config);
 
   EXPECT_EQ(4, config->minimum_threads);
   EXPECT_EQ(16, config->maximum_threads);
-#else
-  EXPECT_EQ(StatusCode::kInvalidArgument, config.status().code());
-#endif  // GOOGLE_CLOUD_CPP_HAVE_RUSAGE_THREAD
 }
 
 TEST(BenchmarkConfigTest, InvalidFlag) {


### PR DESCRIPTION
The `single_row_throughput_benchmark` doesn't use `getrusage()`, so
checking for it in `Config` unnecessarily precludes it from running
(i.e. when using `bazel` builds).

Instead, check in `multiple_rows_cpu_benchmark` which actually does care.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1186)
<!-- Reviewable:end -->
