### PR TITLE
feat: use 1 client with multiple channels for the benchmark

### DIFF
--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -34,8 +34,8 @@ std::ostream& operator<<(std::ostream& os, Config const& config) {
             << "\n# Samples: " << config.samples
             << "\n# Minimum Threads: " << config.minimum_threads
             << "\n# Maximum Threads: " << config.maximum_threads
-            << "\n# Minimum Clients: " << config.minimum_clients
-            << "\n# Maximum Clients: " << config.maximum_clients
+            << "\n# Minimum Clients/Channels: " << config.minimum_clients
+            << "\n# Maximum Clients/Channels: " << config.maximum_clients
             << "\n# Iteration Duration: " << config.iteration_duration.count()
             << "s"
             << "\n# Table Size: " << config.table_size
@@ -87,11 +87,20 @@ google::cloud::StatusOr<Config> ParseArgs(std::vector<std::string> args) {
        [](Config& c, std::string const& v) {
          c.maximum_threads = std::stoi(v);
        }},
+      // TODO(#1193) keep the `channels` flags and remove the `clients` aliases.
       {"--minimum-clients=",
        [](Config& c, std::string const& v) {
          c.minimum_clients = std::stoi(v);
        }},
+      {"--minimum-channels=",
+       [](Config& c, std::string const& v) {
+         c.minimum_clients = std::stoi(v);
+       }},
       {"--maximum-clients=",
+       [](Config& c, std::string const& v) {
+         c.maximum_clients = std::stoi(v);
+       }},
+      {"--maximum-channels=",
        [](Config& c, std::string const& v) {
          c.maximum_clients = std::stoi(v);
        }},

--- a/google/cloud/spanner/benchmarks/benchmarks_config.h
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.h
@@ -38,6 +38,7 @@ struct Config {
 
   int minimum_threads = 1;
   int maximum_threads = 1;
+  // TODO(#1193) change these variable names from `*_clients` to `*_channels`
   int minimum_clients = 1;
   int maximum_clients = 1;
 


### PR DESCRIPTION
* factor Client creation code out to a helper
* make `InsertOrUpdateExperiment` use `DefaultPRNG` like the others
* remove superfluous mutex from `UpdateDmlExperiment::RunIteration`
* start to migrate from `minimum/maximum_clients` to `_channels`

Part of #1193

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1194)
<!-- Reviewable:end -->
