### PR TITLE
doc: exclude benchmarks for doxygen docs

### DIFF
--- a/cmake/EnableDoxygen.cmake
+++ b/cmake/EnableDoxygen.cmake
@@ -67,6 +67,7 @@ else ()
         set(DOXYGEN_EXCLUDE_PATTERNS
             "*/google/cloud/spanner/README.md"
             "*/google/cloud/spanner/internal/*"
+            "*/google/cloud/spanner/benchmarks/*"
             "*/google/cloud/spanner/testing/*"
             "*/google/cloud/spanner/*_test.cc")
 


### PR DESCRIPTION
The classes in the benchmarks are not interesting for the user-facing
reference documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1208)
<!-- Reviewable:end -->
