### PR TITLE
fix: add missing call to google_cloud_cpp_spanner_deps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,10 +84,13 @@ the following commands to your `WORKSPACE` file:
 # Update the version and SHA256 digest as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp_spanner",
-    url = "http://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.2.0.tar.gz",
-    strip_prefix = "google-cloud-cpp-0.2.0",
-    sha256 = "TBD",
+    sha256 = "1dbca07e3f268ffab4461a1d98b16201adda4688866a1929ac71c22c46e4fe74",
+    strip_prefix = "google-cloud-cpp-spanner-0.6.0",
+    url = "https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.6.0.tar.gz",
 )
+
+load("@com_github_googleapis_google_cloud_cpp_spanner//bazel:google_cloud_cpp_spanner_deps.bzl", "google_cloud_cpp_spanner_deps")
+google_cloud_cpp_spanner_deps()
 
 # Configure @com_google_googleapis to only compile C++ and gRPC:
 load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")


### PR DESCRIPTION
Also update the version and use a working SHA256 in the example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1215)
<!-- Reviewable:end -->
