### PR TITLE
doc: fix INSTALL instructions for Bazel

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,9 +84,9 @@ the following commands to your `WORKSPACE` file:
 # Update the version and SHA256 digest as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp_spanner",
-    url = "http://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.2.0.tar.gz",
-    strip_prefix = "google-cloud-cpp-0.2.0",
-    sha256 = "TBD",
+    sha256 = "1dbca07e3f268ffab4461a1d98b16201adda4688866a1929ac71c22c46e4fe74",
+    strip_prefix = "google-cloud-cpp-spanner-0.6.0",
+    url = "https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.6.0.tar.gz",
 )
 
 # Configure @com_google_googleapis to only compile C++ and gRPC:
@@ -228,6 +228,7 @@ wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \
         -DBUILD_SHARED_LIBS=yes \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -383,6 +384,7 @@ wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \
         -DBUILD_SHARED_LIBS=yes \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -510,6 +512,7 @@ wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \
         -DBUILD_SHARED_LIBS=yes \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -652,6 +655,7 @@ wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \
         -DBUILD_SHARED_LIBS=yes \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -752,6 +756,7 @@ wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \
         -DBUILD_SHARED_LIBS=yes \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -886,6 +891,7 @@ wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \
         -DBUILD_SHARED_LIBS=yes \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -1025,6 +1031,7 @@ wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \
         -DBUILD_SHARED_LIBS=yes \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -1185,6 +1192,7 @@ wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
     cmake \
         -DCMAKE_BUILD_TYPE="Release" \
         -DBUILD_SHARED_LIBS=yes \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
         -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,7 @@
-# Obtaining google-cloud-cpp-spanner
+# Installing google-cloud-cpp-spanner
+
+<!-- This is an automatically generated file -->
+<!-- Make changes in ci/test-readme/generate-install.sh -->
 
 There are two primary ways of obtaining `google-cloud-cpp-spanner`. You can use git:
 

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -104,9 +104,9 @@ the following commands to your `WORKSPACE` file:
 # Update the version and SHA256 digest as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp_spanner",
-    url = "http://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.2.0.tar.gz",
-    strip_prefix = "google-cloud-cpp-0.2.0",
-    sha256 = "TBD",
+    sha256 = "1dbca07e3f268ffab4461a1d98b16201adda4688866a1929ac71c22c46e4fe74",
+    strip_prefix = "google-cloud-cpp-spanner-0.6.0",
+    url = "https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.6.0.tar.gz",
 )
 
 # Configure @com_google_googleapis to only compile C++ and gRPC:

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -18,7 +18,10 @@ set -eu
 readonly BINDIR=$(dirname "$0")
 
 cat <<'END_OF_PREAMBLE'
-# Obtaining google-cloud-cpp-spanner
+# Installing google-cloud-cpp-spanner
+
+<!-- This is an automatically generated file -->
+<!-- Make changes in ci/test-readme/generate-install.sh -->
 
 There are two primary ways of obtaining `google-cloud-cpp-spanner`. You can use git:
 

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -110,9 +110,9 @@ and install the library, for example:
 # Change the version and SHA256 hash as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp_spanner",
-    url = "https://github.com/googleapis/google-cloud-cpp-spanner/archive/e2e73b6b044233a51d00090f1f09cd1b7b3af76b.tar.gz",
-    strip_prefix = "google-cloud-cpp-spanner-e2e73b6b044233a51d00090f1f09cd1b7b3af76b",
-    sha256 = "f1b4f3a35b89545d904a9484f38b984cd21f1d8c2e50f9ab21f3ba988cfe11e2",
+    sha256 = "1dbca07e3f268ffab4461a1d98b16201adda4688866a1929ac71c22c46e4fe74",
+    strip_prefix = "google-cloud-cpp-spanner-0.6.0",
+    url = "https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.6.0.tar.gz",
 )
 @endcode
 


### PR DESCRIPTION
Use a real release and SHA256 for the `google-cloud-cpp-spanner` release.
Updated `INSTALL.md` with the latest changes.

Many thanks to @agasparovic-sabre for pointing out this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1226)
<!-- Reviewable:end -->
