### PR TITLE
fix!: avoid single-arg forwarding c'tor

### DIFF
--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -403,7 +403,7 @@ TEST(TupleStreamIterator, Error) {
   EXPECT_EQ(it, end);
 }
 
-TEST(StreamOf, Basics) {
+TEST(TupleStream, Basics) {
   std::vector<Row> rows;
   rows.emplace_back(MakeTestRow(1, "foo", true));
   rows.emplace_back(MakeTestRow(2, "bar", true));
@@ -438,7 +438,7 @@ TEST(StreamOf, Basics) {
   EXPECT_EQ(it, end);
 }
 
-TEST(StreamOf, RangeForLoop) {
+TEST(TupleStream, RangeForLoop) {
   std::vector<Row> rows;
   rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
   rows.emplace_back(MakeTestRow({{"num", Value(3)}}));
@@ -454,7 +454,7 @@ TEST(StreamOf, RangeForLoop) {
   EXPECT_EQ(product, 30);
 }
 
-TEST(StreamOf, IterationError) {
+TEST(TupleStream, IterationError) {
   std::vector<StatusOr<Row>> rows;
   rows.emplace_back(MakeTestRow(1, "foo", true));
   rows.emplace_back(Status(StatusCode::kUnknown, "some error"));
@@ -463,7 +463,7 @@ TEST(StreamOf, IterationError) {
   RowRange range(MakeRowStreamIteratorSource(rows));
 
   using RowType = std::tuple<std::int64_t, std::string, bool>;
-  StreamOf<RowType> stream(range);
+  auto stream = StreamOf<RowType>(range);
 
   auto end = stream.end();
   auto it = stream.begin();


### PR DESCRIPTION
Single-argument forwarding constructors can hide implicitly generated
copy/move constructors. Even if this issue is avoided with the proper
use of SFINAE, clang-tidy may still complain (incorrectly, I think).
http://clang.llvm.org/extra/clang-tidy/checks/bugprone-forwarding-reference-overload.html

To fix this I renamed the class `StreamOf` -> `TupleStream`. I then
changed its constructor to accept two iterators instead of a single
range. Then I added a `StreamOf<T>()` non-member factory function. This
should make it so our existing uses all continue to work.

So, this really shouldn't be much of an API break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1233)
<!-- Reviewable:end -->
