### PR TITLE
chore: change Transaction's Visit to accept const-ref

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -194,7 +194,7 @@ StatusOr<CommitResult> Client::Commit(
     } else {
       // Create a new transaction for the next loop, but reuse the session
       // so that we have a slightly better chance of avoiding another abort.
-      txn = MakeReadWriteTransaction(std::move(txn));
+      txn = MakeReadWriteTransaction(txn);
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());
   }

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -175,7 +175,7 @@ TEST_F(ClientIntegrationTest, TransactionRollback) {
 
     // Share lock priority with the previous loop so that we have a slightly
     // better chance of avoiding StatusCode::kAborted from ExecuteDml().
-    txn = MakeReadWriteTransaction(std::move(txn));
+    txn = MakeReadWriteTransaction(txn);
 
     auto insert1 = client_->ExecuteDml(
         txn, SqlStatement("INSERT INTO Singers (SingerId, FirstName, LastName) "

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -104,8 +104,9 @@ ConnectionImpl::ConnectionImpl(Database db,
       tracing_options_(options.tracing_options()) {}
 
 RowStream ConnectionImpl::Read(ReadParams params) {
+  auto txn = params.transaction;
   return internal::Visit(
-      params.transaction,
+      txn,
       [this, &params](SessionHolder& session,
                       spanner_proto::TransactionSelector& s, std::int64_t) {
         return ReadImpl(session, s, std::move(params));
@@ -124,46 +125,51 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionRead(
 }
 
 RowStream ConnectionImpl::ExecuteQuery(SqlParams params) {
+  auto txn = params.transaction;
   return internal::Visit(
-      params.transaction, [this, &params](SessionHolder& session,
-                                          spanner_proto::TransactionSelector& s,
-                                          std::int64_t seqno) {
+      txn, [this, &params](SessionHolder& session,
+                           spanner_proto::TransactionSelector& s,
+                           std::int64_t seqno) {
         return ExecuteQueryImpl(session, s, seqno, std::move(params));
       });
 }
 
 StatusOr<DmlResult> ConnectionImpl::ExecuteDml(SqlParams params) {
+  auto txn = params.transaction;
   return internal::Visit(
-      params.transaction, [this, &params](SessionHolder& session,
-                                          spanner_proto::TransactionSelector& s,
-                                          std::int64_t seqno) {
+      txn, [this, &params](SessionHolder& session,
+                           spanner_proto::TransactionSelector& s,
+                           std::int64_t seqno) {
         return ExecuteDmlImpl(session, s, seqno, std::move(params));
       });
 }
 
 ProfileQueryResult ConnectionImpl::ProfileQuery(SqlParams params) {
+  auto txn = params.transaction;
   return internal::Visit(
-      params.transaction, [this, &params](SessionHolder& session,
-                                          spanner_proto::TransactionSelector& s,
-                                          std::int64_t seqno) {
+      txn, [this, &params](SessionHolder& session,
+                           spanner_proto::TransactionSelector& s,
+                           std::int64_t seqno) {
         return ProfileQueryImpl(session, s, seqno, std::move(params));
       });
 }
 
 StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDml(SqlParams params) {
+  auto txn = params.transaction;
   return internal::Visit(
-      params.transaction, [this, &params](SessionHolder& session,
-                                          spanner_proto::TransactionSelector& s,
-                                          std::int64_t seqno) {
+      txn, [this, &params](SessionHolder& session,
+                           spanner_proto::TransactionSelector& s,
+                           std::int64_t seqno) {
         return ProfileDmlImpl(session, s, seqno, std::move(params));
       });
 }
 
 StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSql(SqlParams params) {
+  auto txn = params.transaction;
   return internal::Visit(
-      params.transaction, [this, &params](SessionHolder& session,
-                                          spanner_proto::TransactionSelector& s,
-                                          std::int64_t seqno) {
+      txn, [this, &params](SessionHolder& session,
+                           spanner_proto::TransactionSelector& s,
+                           std::int64_t seqno) {
         return AnalyzeSqlImpl(session, s, seqno, std::move(params));
       });
 }
@@ -192,17 +198,19 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQuery(
 
 StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDml(
     ExecuteBatchDmlParams params) {
+  auto txn = params.transaction;
   return internal::Visit(
-      params.transaction, [this, &params](SessionHolder& session,
-                                          spanner_proto::TransactionSelector& s,
-                                          std::int64_t seqno) {
+      txn, [this, &params](SessionHolder& session,
+                           spanner_proto::TransactionSelector& s,
+                           std::int64_t seqno) {
         return ExecuteBatchDmlImpl(session, s, seqno, std::move(params));
       });
 }
 
 StatusOr<CommitResult> ConnectionImpl::Commit(CommitParams params) {
+  auto txn = params.transaction;
   return internal::Visit(
-      params.transaction,
+      txn,
       [this, &params](SessionHolder& session,
                       spanner_proto::TransactionSelector& s, std::int64_t) {
         return this->CommitImpl(session, s, std::move(params));

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -105,7 +105,7 @@ ConnectionImpl::ConnectionImpl(Database db,
 
 RowStream ConnectionImpl::Read(ReadParams params) {
   return internal::Visit(
-      std::move(params.transaction),
+      params.transaction,
       [this, &params](SessionHolder& session,
                       spanner_proto::TransactionSelector& s, std::int64_t) {
         return ReadImpl(session, s, std::move(params));
@@ -115,7 +115,7 @@ RowStream ConnectionImpl::Read(ReadParams params) {
 StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionRead(
     PartitionReadParams params) {
   return internal::Visit(
-      std::move(params.read_params.transaction),
+      params.read_params.transaction,
       [this, &params](SessionHolder& session,
                       spanner_proto::TransactionSelector& s, std::int64_t) {
         return PartitionReadImpl(session, s, params.read_params,
@@ -124,53 +124,48 @@ StatusOr<std::vector<ReadPartition>> ConnectionImpl::PartitionRead(
 }
 
 RowStream ConnectionImpl::ExecuteQuery(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ExecuteQueryImpl(session, s, seqno,
-                                                   std::move(params));
-                         });
+  return internal::Visit(
+      params.transaction, [this, &params](SessionHolder& session,
+                                          spanner_proto::TransactionSelector& s,
+                                          std::int64_t seqno) {
+        return ExecuteQueryImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<DmlResult> ConnectionImpl::ExecuteDml(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ExecuteDmlImpl(session, s, seqno,
-                                                 std::move(params));
-                         });
+  return internal::Visit(
+      params.transaction, [this, &params](SessionHolder& session,
+                                          spanner_proto::TransactionSelector& s,
+                                          std::int64_t seqno) {
+        return ExecuteDmlImpl(session, s, seqno, std::move(params));
+      });
 }
 
 ProfileQueryResult ConnectionImpl::ProfileQuery(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ProfileQueryImpl(session, s, seqno,
-                                                   std::move(params));
-                         });
+  return internal::Visit(
+      params.transaction, [this, &params](SessionHolder& session,
+                                          spanner_proto::TransactionSelector& s,
+                                          std::int64_t seqno) {
+        return ProfileQueryImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<ProfileDmlResult> ConnectionImpl::ProfileDml(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ProfileDmlImpl(session, s, seqno,
-                                                 std::move(params));
-                         });
+  return internal::Visit(
+      params.transaction, [this, &params](SessionHolder& session,
+                                          spanner_proto::TransactionSelector& s,
+                                          std::int64_t seqno) {
+        return ProfileDmlImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSql(SqlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return AnalyzeSqlImpl(session, s, seqno,
-                                                 std::move(params));
-                         });
+  return internal::Visit(
+      params.transaction, [this, &params](SessionHolder& session,
+                                          spanner_proto::TransactionSelector& s,
+                                          std::int64_t seqno) {
+        return AnalyzeSqlImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDml(
@@ -187,7 +182,7 @@ StatusOr<PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDml(
 StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQuery(
     PartitionQueryParams params) {
   return internal::Visit(
-      std::move(params.sql_params.transaction),
+      params.sql_params.transaction,
       [this, &params](SessionHolder& session,
                       spanner_proto::TransactionSelector& s, std::int64_t) {
         return PartitionQueryImpl(session, s, params.sql_params,
@@ -197,18 +192,17 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQuery(
 
 StatusOr<BatchDmlResult> ConnectionImpl::ExecuteBatchDml(
     ExecuteBatchDmlParams params) {
-  return internal::Visit(std::move(params.transaction),
-                         [this, &params](SessionHolder& session,
-                                         spanner_proto::TransactionSelector& s,
-                                         std::int64_t seqno) {
-                           return ExecuteBatchDmlImpl(session, s, seqno,
-                                                      std::move(params));
-                         });
+  return internal::Visit(
+      params.transaction, [this, &params](SessionHolder& session,
+                                          spanner_proto::TransactionSelector& s,
+                                          std::int64_t seqno) {
+        return ExecuteBatchDmlImpl(session, s, seqno, std::move(params));
+      });
 }
 
 StatusOr<CommitResult> ConnectionImpl::Commit(CommitParams params) {
   return internal::Visit(
-      std::move(params.transaction),
+      params.transaction,
       [this, &params](SessionHolder& session,
                       spanner_proto::TransactionSelector& s, std::int64_t) {
         return this->CommitImpl(session, s, std::move(params));
@@ -217,7 +211,7 @@ StatusOr<CommitResult> ConnectionImpl::Commit(CommitParams params) {
 
 Status ConnectionImpl::Rollback(RollbackParams params) {
   return internal::Visit(
-      std::move(params.transaction),
+      params.transaction,
       [this](SessionHolder& session, spanner_proto::TransactionSelector& s,
              std::int64_t) { return this->RollbackImpl(session, s); });
 }

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -70,8 +70,8 @@ class Client {
   }
 
   // User-visible read operation.
-  ResultSet Read(Transaction txn, std::string const& table, KeySet const& keys,
-                 std::vector<std::string> const& columns) {
+  ResultSet Read(Transaction const& txn, std::string const& table,
+                 KeySet const& keys, std::vector<std::string> const& columns) {
     auto read = [this, &table, &keys, &columns](SessionHolder& session,
                                                 TransactionSelector& selector,
                                                 std::int64_t seqno) {
@@ -80,7 +80,7 @@ class Client {
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     try {
 #endif
-      return internal::Visit(std::move(txn), std::move(read));
+      return internal::Visit(txn, std::move(read));
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     } catch (char const*) {
       return {};

--- a/google/cloud/spanner/transaction.h
+++ b/google/cloud/spanner/transaction.h
@@ -35,7 +35,7 @@ namespace internal {
 template <typename T>
 Transaction MakeSingleUseTransaction(T&&);
 template <typename Functor>
-VisitInvokeResult<Functor> Visit(Transaction, Functor&&);
+VisitInvokeResult<Functor> Visit(Transaction const&, Functor&&);
 Transaction MakeTransactionFromIds(std::string session_id,
                                    std::string transaction_id);
 }  // namespace internal
@@ -165,8 +165,8 @@ class Transaction {
   template <typename T>
   friend Transaction internal::MakeSingleUseTransaction(T&&);
   template <typename Functor>
-  friend internal::VisitInvokeResult<Functor> internal::Visit(Transaction,
-                                                              Functor&&);
+  friend internal::VisitInvokeResult<Functor> internal::Visit(
+      Transaction const&, Functor&&);
   friend Transaction internal::MakeTransactionFromIds(
       std::string session_id, std::string transaction_id);
 
@@ -205,7 +205,7 @@ inline Transaction MakeReadWriteTransaction(
  * success.
  */
 inline Transaction MakeReadWriteTransaction(
-    Transaction txn, Transaction::ReadWriteOptions opts = {}) {
+    Transaction const& txn, Transaction::ReadWriteOptions opts = {}) {
   return Transaction(txn, std::move(opts));
 }
 
@@ -219,7 +219,7 @@ Transaction MakeSingleUseTransaction(T&& opts) {
 }
 
 template <typename Functor>
-VisitInvokeResult<Functor> Visit(Transaction txn, Functor&& f) {
+VisitInvokeResult<Functor> Visit(Transaction const& txn, Functor&& f) {
   return txn.impl_->Visit(std::forward<Functor>(f));
 }
 


### PR DESCRIPTION
Without this change, clang-tidy's performance-unnecessary-value-param
checker warns that we're unnecessarily passing values around. This
change quiets the warning, and I think makes the API slighly simpler to
use since it doesn't require the caller to std::move in order to avoid
the unnecessary increment/decrement in Transaction::impl_.

Related to #355

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1237)
<!-- Reviewable:end -->
