### PR TITLE
chore: silence clang-tidy warning on internal::Visit

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -194,7 +194,7 @@ StatusOr<CommitResult> Client::Commit(
     } else {
       // Create a new transaction for the next loop, but reuse the session
       // so that we have a slightly better chance of avoiding another abort.
-      txn = MakeReadWriteTransaction(std::move(txn));
+      txn = MakeReadWriteTransaction(txn);
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());
   }

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -175,7 +175,7 @@ TEST_F(ClientIntegrationTest, TransactionRollback) {
 
     // Share lock priority with the previous loop so that we have a slightly
     // better chance of avoiding StatusCode::kAborted from ExecuteDml().
-    txn = MakeReadWriteTransaction(std::move(txn));
+    txn = MakeReadWriteTransaction(txn);
 
     auto insert1 = client_->ExecuteDml(
         txn, SqlStatement("INSERT INTO Singers (SingerId, FirstName, LastName) "

--- a/google/cloud/spanner/transaction.h
+++ b/google/cloud/spanner/transaction.h
@@ -205,7 +205,7 @@ inline Transaction MakeReadWriteTransaction(
  * success.
  */
 inline Transaction MakeReadWriteTransaction(
-    Transaction txn, Transaction::ReadWriteOptions opts = {}) {
+    Transaction const& txn, Transaction::ReadWriteOptions opts = {}) {
   return Transaction(txn, std::move(opts));
 }
 
@@ -219,6 +219,7 @@ Transaction MakeSingleUseTransaction(T&& opts) {
 }
 
 template <typename Functor>
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 VisitInvokeResult<Functor> Visit(Transaction txn, Functor&& f) {
   return txn.impl_->Visit(std::forward<Functor>(f));
 }


### PR DESCRIPTION
This fix will silence clang-tidy's `performance-unnecessary-value-param` warning when run on our headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1239)
<!-- Reviewable:end -->
