### PR TITLE
fix: make c'tor explicit

### DIFF
--- a/google/cloud/spanner/bytes.h
+++ b/google/cloud/spanner/bytes.h
@@ -100,8 +100,8 @@ class Bytes {
       using pointer = value_type*;
       using reference = value_type&;
 
-      Iterator(std::string::const_iterator begin,
-               std::string::const_iterator end)
+      explicit Iterator(std::string::const_iterator begin,
+                        std::string::const_iterator end)
           : pos_(begin), end_(end), len_(0) {
         Fill();
       }


### PR DESCRIPTION
This prevents a upcoming warning when we enable clang-tidy on headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1241)
<!-- Reviewable:end -->
