### PR TITLE
chore: explain use of "performance-unnecessary-value-param"

### DIFF
--- a/google/cloud/spanner/transaction.h
+++ b/google/cloud/spanner/transaction.h
@@ -219,6 +219,9 @@ Transaction MakeSingleUseTransaction(T&& opts) {
 }
 
 template <typename Functor>
+// Pass `txn` by value, despite being used only once. This avoids the
+// possibility of `txn` being destroyed by `f` before `Visit()` can
+// return. Therefore, ...
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 VisitInvokeResult<Functor> Visit(Transaction txn, Functor&& f) {
   return txn.impl_->Visit(std::forward<Functor>(f));


### PR DESCRIPTION
For future reference, document the clang-tidy warning suppression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1244)
<!-- Reviewable:end -->
