### PR TITLE
ci: upgrade protobuf to v3.11.3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -102,12 +102,8 @@ load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_com
 google_cloud_cpp_common_deps()
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 grpc_deps()
-load("@upb//bazel:workspace_deps.bzl", "upb_deps")
-upb_deps()
-load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-apple_rules_dependencies()
-load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
-apple_support_dependencies()
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+grpc_extra_deps()
 ```
 
 Then you can link the libraries from your `BUILD` files:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,15 +39,6 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
 
-# Call the workspace dependency functions defined, but not invoked, in grpc_deps.bzl.
-load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
-upb_deps()
-
-load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-
-apple_rules_dependencies()
-
-load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
-
-apple_support_dependencies()
+grpc_extra_deps()

--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -83,8 +83,18 @@ def google_cloud_cpp_spanner_deps():
             build_file = "@com_github_googleapis_google_cloud_cpp_spanner//bazel:googleapis.BUILD",
         )
 
+    # Load protobuf.
+    if "com_google_protobuf" not in native.existing_rules():
+        http_archive(
+            name = "com_google_protobuf",
+            strip_prefix = "protobuf-3.11.3",
+            urls = [
+                "https://github.com/google/protobuf/archive/v3.11.3.tar.gz",
+            ],
+            sha256 = "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
+        )
+
     # Load gRPC and its dependencies, using a similar pattern to this function.
-    # This implictly loads "com_google_protobuf", which we use.
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",

--- a/ci/test-install/WORKSPACE
+++ b/ci/test-install/WORKSPACE
@@ -57,15 +57,6 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
 
-# Call the workspace dependency functions defined, but not invoked, in grpc_deps.bzl.
-load("@upb//bazel:workspace_deps.bzl", "upb_deps")
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
-upb_deps()
-
-load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-
-apple_rules_dependencies()
-
-load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
-
-apple_support_dependencies()
+grpc_extra_deps()

--- a/ci/test-readme/generate-install.sh
+++ b/ci/test-readme/generate-install.sh
@@ -122,12 +122,8 @@ load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_com
 google_cloud_cpp_common_deps()
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 grpc_deps()
-load("@upb//bazel:workspace_deps.bzl", "upb_deps")
-upb_deps()
-load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-apple_rules_dependencies()
-load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
-apple_support_dependencies()
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+grpc_extra_deps()
 ```
 
 Then you can link the libraries from your `BUILD` files:

--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -141,6 +141,10 @@ google_cloud_cpp_deps()
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()
 ```
 
 You can now use the library as a dependency in your BUILD files, for example:


### PR DESCRIPTION
Upgrade protobuf to 3.11.3, this is needed to build with the latest and
greatest googleapis on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1247)
<!-- Reviewable:end -->
