### PR TITLE
refactor!: remove c'tors from Connection::* param structs

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -34,8 +34,11 @@ RowStream Client::Read(std::string table, KeySet keys,
                        ReadOptions read_options) {
   return conn_->Read(
       {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       std::move(table), std::move(keys), std::move(columns),
-       std::move(read_options)});
+       std::move(table),
+       std::move(keys),
+       std::move(columns),
+       std::move(read_options),
+       {}});
 }
 
 RowStream Client::Read(Transaction::SingleUseOptions transaction_options,
@@ -44,15 +47,22 @@ RowStream Client::Read(Transaction::SingleUseOptions transaction_options,
                        ReadOptions read_options) {
   return conn_->Read(
       {internal::MakeSingleUseTransaction(std::move(transaction_options)),
-       std::move(table), std::move(keys), std::move(columns),
-       std::move(read_options)});
+       std::move(table),
+       std::move(keys),
+       std::move(columns),
+       std::move(read_options),
+       {}});
 }
 
 RowStream Client::Read(Transaction transaction, std::string table, KeySet keys,
                        std::vector<std::string> columns,
                        ReadOptions read_options) {
-  return conn_->Read({std::move(transaction), std::move(table), std::move(keys),
-                      std::move(columns), std::move(read_options)});
+  return conn_->Read({std::move(transaction),
+                      std::move(table),
+                      std::move(keys),
+                      std::move(columns),
+                      std::move(read_options),
+                      {}});
 }
 
 RowStream Client::Read(ReadPartition const& read_partition) {
@@ -63,10 +73,13 @@ StatusOr<std::vector<ReadPartition>> Client::PartitionRead(
     Transaction transaction, std::string table, KeySet keys,
     std::vector<std::string> columns, ReadOptions read_options,
     PartitionOptions const& partition_options) {
-  return conn_->PartitionRead(
-      {{std::move(transaction), std::move(table), std::move(keys),
-        std::move(columns), std::move(read_options)},
-       partition_options});
+  return conn_->PartitionRead({{std::move(transaction),
+                                std::move(table),
+                                std::move(keys),
+                                std::move(columns),
+                                std::move(read_options),
+                                {}},
+                               partition_options});
 }
 
 RowStream Client::ExecuteQuery(SqlStatement statement) {

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -85,19 +85,22 @@ StatusOr<std::vector<ReadPartition>> Client::PartitionRead(
 RowStream Client::ExecuteQuery(SqlStatement statement) {
   return conn_->ExecuteQuery(
       {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       std::move(statement)});
+       std::move(statement),
+       {}});
 }
 
 RowStream Client::ExecuteQuery(
     Transaction::SingleUseOptions transaction_options, SqlStatement statement) {
   return conn_->ExecuteQuery(
       {internal::MakeSingleUseTransaction(std::move(transaction_options)),
-       std::move(statement)});
+       std::move(statement),
+       {}});
 }
 
 RowStream Client::ExecuteQuery(Transaction transaction,
                                SqlStatement statement) {
-  return conn_->ExecuteQuery({std::move(transaction), std::move(statement)});
+  return conn_->ExecuteQuery(
+      {std::move(transaction), std::move(statement), {}});
 }
 
 RowStream Client::ExecuteQuery(QueryPartition const& partition) {
@@ -107,41 +110,44 @@ RowStream Client::ExecuteQuery(QueryPartition const& partition) {
 ProfileQueryResult Client::ProfileQuery(SqlStatement statement) {
   return conn_->ProfileQuery(
       {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       std::move(statement)});
+       std::move(statement),
+       {}});
 }
 
 ProfileQueryResult Client::ProfileQuery(
     Transaction::SingleUseOptions transaction_options, SqlStatement statement) {
   return conn_->ProfileQuery(
       {internal::MakeSingleUseTransaction(std::move(transaction_options)),
-       std::move(statement)});
+       std::move(statement),
+       {}});
 }
 
 ProfileQueryResult Client::ProfileQuery(Transaction transaction,
                                         SqlStatement statement) {
-  return conn_->ProfileQuery({std::move(transaction), std::move(statement)});
+  return conn_->ProfileQuery(
+      {std::move(transaction), std::move(statement), {}});
 }
 
 StatusOr<std::vector<QueryPartition>> Client::PartitionQuery(
     Transaction transaction, SqlStatement statement,
     PartitionOptions const& partition_options) {
   return conn_->PartitionQuery(
-      {{std::move(transaction), std::move(statement)}, partition_options});
+      {{std::move(transaction), std::move(statement), {}}, partition_options});
 }
 
 StatusOr<DmlResult> Client::ExecuteDml(Transaction transaction,
                                        SqlStatement statement) {
-  return conn_->ExecuteDml({std::move(transaction), std::move(statement)});
+  return conn_->ExecuteDml({std::move(transaction), std::move(statement), {}});
 }
 
 StatusOr<ProfileDmlResult> Client::ProfileDml(Transaction transaction,
                                               SqlStatement statement) {
-  return conn_->ProfileDml({std::move(transaction), std::move(statement)});
+  return conn_->ProfileDml({std::move(transaction), std::move(statement), {}});
 }
 
 StatusOr<ExecutionPlan> Client::AnalyzeSql(Transaction transaction,
                                            SqlStatement statement) {
-  return conn_->AnalyzeSql({std::move(transaction), std::move(statement)});
+  return conn_->AnalyzeSql({std::move(transaction), std::move(statement), {}});
 }
 
 StatusOr<BatchDmlResult> Client::ExecuteBatchDml(

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -401,7 +401,7 @@ TEST(ClientTest, CommitMutatorSuccess) {
 
   auto conn = std::make_shared<MockConnection>();
   Transaction txn = MakeReadWriteTransaction();  // dummy
-  Connection::ReadParams actual_read_params{txn, {}, {}, {}, {}};
+  Connection::ReadParams actual_read_params{txn, {}, {}, {}, {}, {}};
   Connection::CommitParams actual_commit_params{txn, {}};
 
   auto source = make_unique<MockResultSetSource>();
@@ -451,7 +451,7 @@ TEST(ClientTest, CommitMutatorSuccess) {
 TEST(ClientTest, CommitMutatorRollback) {
   auto conn = std::make_shared<MockConnection>();
   Transaction txn = MakeReadWriteTransaction();  // dummy
-  Connection::ReadParams actual_read_params{txn, {}, {}, {}, {}};
+  Connection::ReadParams actual_read_params{txn, {}, {}, {}, {}, {}};
 
   auto source = make_unique<MockResultSetSource>();
   spanner_proto::ResultSetMetadata metadata;
@@ -497,7 +497,7 @@ TEST(ClientTest, CommitMutatorRollback) {
 TEST(ClientTest, CommitMutatorRollbackError) {
   auto conn = std::make_shared<MockConnection>();
   Transaction txn = MakeReadWriteTransaction();  // dummy
-  Connection::ReadParams actual_read_params{txn, {}, {}, {}, {}};
+  Connection::ReadParams actual_read_params{txn, {}, {}, {}, {}, {}};
 
   auto source = make_unique<MockResultSetSource>();
   spanner_proto::ResultSetMetadata metadata;

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -74,16 +74,6 @@ class Connection {
     std::vector<std::string> columns;
     ReadOptions read_options;
     google::cloud::optional<std::string> partition_token;
-
-    ReadParams(Transaction transaction, std::string table, KeySet keys,
-               std::vector<std::string> columns, ReadOptions read_options,
-               google::cloud::optional<std::string> partition_token = {})
-        : transaction(std::move(transaction)),
-          table(std::move(table)),
-          keys(std::move(keys)),
-          columns(std::move(columns)),
-          read_options(std::move(read_options)),
-          partition_token(std::move(partition_token)) {}
   };
 
   /// Wrap the arguments to `PartitionRead()`.

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -88,12 +88,6 @@ class Connection {
     Transaction transaction;
     SqlStatement statement;
     google::cloud::optional<std::string> partition_token;
-
-    SqlParams(Transaction transaction, SqlStatement statement,
-              google::cloud::optional<std::string> partition_token = {})
-        : transaction(std::move(transaction)),
-          statement(std::move(statement)),
-          partition_token(std::move(partition_token)) {}
   };
 
   /// Wrap the arguments to `ExecutePartitionedDml()`.

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -388,7 +388,8 @@ TEST(ConnectionImplTest, ExecuteQueryGetSessionFailure) {
 
   auto rows = conn->ExecuteQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       SqlStatement("select * from table")});
+       SqlStatement("select * from table"),
+       {}});
   for (auto& row : rows) {
     EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
     EXPECT_THAT(row.status().message(), HasSubstr("uh-oh in GetSession"));
@@ -418,7 +419,8 @@ TEST(ConnectionImplTest, ExecuteQueryStreamingReadFailure) {
 
   auto rows = conn->ExecuteQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       SqlStatement("select * from table")});
+       SqlStatement("select * from table"),
+       {}});
   for (auto& row : rows) {
     EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
     EXPECT_THAT(row.status().message(),
@@ -470,7 +472,8 @@ TEST(ConnectionImplTest, ExecuteQueryReadSuccess) {
 
   auto rows = conn->ExecuteQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       SqlStatement("select * from table")});
+       SqlStatement("select * from table"),
+       {}});
   using RowType = std::tuple<std::int64_t, std::string>;
   auto expected = std::vector<RowType>{
       RowType(12, "Steve"),
@@ -511,7 +514,8 @@ TEST(ConnectionImplTest, ExecuteQueryImplicitBeginTransaction) {
       .WillOnce(Return(ByMove(std::move(grpc_reader))));
 
   Transaction txn = MakeReadOnlyTransaction(Transaction::ReadOnlyOptions());
-  auto rows = conn->ExecuteQuery({txn, SqlStatement("select * from table")});
+  auto rows =
+      conn->ExecuteQuery({txn, SqlStatement("select * from table"), {}});
   for (auto& row : rows) {
     EXPECT_STATUS_OK(row);
   }
@@ -531,7 +535,8 @@ TEST(ConnectionImplTest, ExecuteDmlGetSessionFailure) {
           });
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->ExecuteDml({txn, SqlStatement("delete * from table"), {}});
 
   EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in GetSession"));
@@ -557,7 +562,8 @@ TEST(ConnectionImplTest, ExecuteDmlDeleteSuccess) {
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce(Return(response));
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->ExecuteDml({txn, SqlStatement("delete * from table"), {}});
 
   ASSERT_STATUS_OK(result);
   EXPECT_EQ(result->RowsModified(), 42);
@@ -576,7 +582,8 @@ TEST(ConnectionImplTest, ExecuteDmlDeletePermanentFailure) {
           Return(Status(StatusCode::kPermissionDenied, "uh-oh in ExecuteDml")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->ExecuteDml({txn, SqlStatement("delete * from table"), {}});
 
   EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in ExecuteDml"));
@@ -596,7 +603,8 @@ TEST(ConnectionImplTest, ExecuteDmlDeleteTooManyTransientFailures) {
           Return(Status(StatusCode::kUnavailable, "try-again in ExecuteDml")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->ExecuteDml({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->ExecuteDml({txn, SqlStatement("delete * from table"), {}});
 
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("try-again in ExecuteDml"));
@@ -654,7 +662,8 @@ TEST(ConnectionImplTest, ProfileQuerySuccess) {
 
   auto result = conn->ProfileQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       SqlStatement("select * from table")});
+       SqlStatement("select * from table"),
+       {}});
   using RowType = std::tuple<std::int64_t, std::string>;
   auto expected = std::vector<RowType>{
       RowType(12, "Steve"),
@@ -700,7 +709,8 @@ TEST(ConnectionImplTest, ProfileQueryGetSessionFailure) {
 
   auto result = conn->ProfileQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       SqlStatement("select * from table")});
+       SqlStatement("select * from table"),
+       {}});
   for (auto& row : result) {
     EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
     EXPECT_THAT(row.status().message(), HasSubstr("uh-oh in GetSession"));
@@ -730,7 +740,8 @@ TEST(ConnectionImplTest, ProfileQueryStreamingReadFailure) {
 
   auto result = conn->ProfileQuery(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       SqlStatement("select * from table")});
+       SqlStatement("select * from table"),
+       {}});
   for (auto& row : result) {
     EXPECT_EQ(StatusCode::kPermissionDenied, row.status().code());
     EXPECT_THAT(row.status().message(),
@@ -751,7 +762,8 @@ TEST(ConnectionImplTest, ProfileDmlGetSessionFailure) {
           });
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->ProfileDml({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->ProfileDml({txn, SqlStatement("delete * from table"), {}});
 
   EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in GetSession"));
@@ -786,7 +798,8 @@ TEST(ConnectionImplTest, ProfileDmlDeleteSuccess) {
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce(Return(response));
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->ProfileDml({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->ProfileDml({txn, SqlStatement("delete * from table"), {}});
 
   ASSERT_STATUS_OK(result);
   EXPECT_EQ(result->RowsModified(), 42);
@@ -830,7 +843,8 @@ TEST(ConnectionImplTest, ProfileDmlDeletePermanentFailure) {
           Return(Status(StatusCode::kPermissionDenied, "uh-oh in ExecuteDml")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->ProfileDml({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->ProfileDml({txn, SqlStatement("delete * from table"), {}});
 
   EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in ExecuteDml"));
@@ -858,7 +872,8 @@ TEST(ConnectionImplTest, ProfileDmlDeleteTooManyTransientFailures) {
           Return(Status(StatusCode::kUnavailable, "try-again in ExecuteDml")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->ProfileDml({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->ProfileDml({txn, SqlStatement("delete * from table"), {}});
 
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("try-again in ExecuteDml"));
@@ -891,7 +906,8 @@ TEST(ConnectionImplTest, AnalyzeSqlSuccess) {
 
   auto result = conn->AnalyzeSql(
       {MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
-       SqlStatement("select * from table")});
+       SqlStatement("select * from table"),
+       {}});
 
   google::spanner::v1::QueryPlan expected_plan;
   ASSERT_TRUE(TextFormat::ParseFromString(
@@ -917,7 +933,8 @@ TEST(ConnectionImplTest, AnalyzeSqlGetSessionFailure) {
           });
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->AnalyzeSql({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->AnalyzeSql({txn, SqlStatement("delete * from table"), {}});
 
   EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in GetSession"));
@@ -944,7 +961,8 @@ TEST(ConnectionImplTest, AnalyzeSqlDeletePermanentFailure) {
           Return(Status(StatusCode::kPermissionDenied, "uh-oh in ExecuteDml")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->AnalyzeSql({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->AnalyzeSql({txn, SqlStatement("delete * from table"), {}});
 
   EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("uh-oh in ExecuteDml"));
@@ -972,7 +990,8 @@ TEST(ConnectionImplTest, AnalyzeSqlDeleteTooManyTransientFailures) {
           Return(Status(StatusCode::kUnavailable, "try-again in ExecuteDml")));
 
   Transaction txn = MakeReadWriteTransaction(Transaction::ReadWriteOptions());
-  auto result = conn->AnalyzeSql({txn, SqlStatement("delete * from table")});
+  auto result =
+      conn->AnalyzeSql({txn, SqlStatement("delete * from table"), {}});
 
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr("try-again in ExecuteDml"));
@@ -1831,7 +1850,9 @@ TEST(ConnectionImplTest, PartitionQuerySuccess) {
 
   SqlStatement sql_statement("select * from table");
   StatusOr<std::vector<QueryPartition>> result = conn->PartitionQuery(
-      {{MakeReadOnlyTransaction(Transaction::ReadOnlyOptions()), sql_statement},
+      {{MakeReadOnlyTransaction(Transaction::ReadOnlyOptions()),
+        sql_statement,
+        {}},
        PartitionOptions()});
   ASSERT_STATUS_OK(result);
 
@@ -1863,7 +1884,8 @@ TEST(ConnectionImplTest, PartitionQueryPermanentFailure) {
 
   StatusOr<std::vector<QueryPartition>> result = conn->PartitionQuery(
       {{MakeReadOnlyTransaction(Transaction::ReadOnlyOptions()),
-        SqlStatement("select * from table")},
+        SqlStatement("select * from table"),
+        {}},
        PartitionOptions()});
   EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr(failed_status.message()));
@@ -1889,7 +1911,8 @@ TEST(ConnectionImplTest, PartitionQueryTooManyTransientFailures) {
 
   StatusOr<std::vector<QueryPartition>> result = conn->PartitionQuery(
       {{MakeReadOnlyTransaction(Transaction::ReadOnlyOptions()),
-        SqlStatement("select * from table")},
+        SqlStatement("select * from table"),
+        {}},
        PartitionOptions()});
   EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
   EXPECT_THAT(result.status().message(), HasSubstr(failed_status.message()));
@@ -2172,7 +2195,7 @@ TEST(ConnectionImplTest, ExecuteQuerySessionNotFound) {
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
-  auto response = GetSingularRow(conn->ExecuteQuery({txn, SqlStatement()}));
+  auto response = GetSingularRow(conn->ExecuteQuery({txn, SqlStatement(), {}}));
   EXPECT_FALSE(response.ok());
   auto status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
@@ -2197,7 +2220,7 @@ TEST(ConnectionImplTest, ProfileQuerySessionNotFound) {
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
-  auto response = GetSingularRow(conn->ProfileQuery({txn, SqlStatement()}));
+  auto response = GetSingularRow(conn->ProfileQuery({txn, SqlStatement(), {}}));
   EXPECT_FALSE(response.ok());
   auto status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
@@ -2221,7 +2244,7 @@ TEST(ConnectionImplTest, ExecuteDmlSessionNotFound) {
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
-  auto response = conn->ExecuteDml({txn, SqlStatement()});
+  auto response = conn->ExecuteDml({txn, SqlStatement(), {}});
   EXPECT_FALSE(response.ok());
   auto status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
@@ -2245,7 +2268,7 @@ TEST(ConnectionImplTest, ProfileDmlSessionNotFound) {
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
-  auto response = conn->ProfileDml({txn, SqlStatement()});
+  auto response = conn->ProfileDml({txn, SqlStatement(), {}});
   EXPECT_FALSE(response.ok());
   auto status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
@@ -2269,7 +2292,7 @@ TEST(ConnectionImplTest, AnalyzeSqlSessionNotFound) {
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
-  auto response = conn->AnalyzeSql({txn, SqlStatement()});
+  auto response = conn->AnalyzeSql({txn, SqlStatement(), {}});
   EXPECT_FALSE(response.ok());
   auto status = response.status();
   EXPECT_TRUE(IsSessionNotFound(status)) << status;
@@ -2293,7 +2316,7 @@ TEST(ConnectionImplTest, PartitionQuerySessionNotFound) {
   auto conn = MakeLimitedRetryConnection(db, mock);
   auto txn = MakeReadWriteTransaction();
   SetTransactionId(txn, "test-txn-id");
-  auto sql_params = Connection::SqlParams(txn, SqlStatement());
+  auto sql_params = Connection::SqlParams{txn, SqlStatement(), {}};
   auto response = conn->PartitionQuery({sql_params, {}});
   EXPECT_FALSE(response.ok());
   auto status = response.status();

--- a/google/cloud/spanner/read_partition.cc
+++ b/google/cloud/spanner/read_partition.cc
@@ -81,12 +81,14 @@ ReadPartition MakeReadPartition(std::string transaction_id,
 }
 
 Connection::ReadParams MakeReadParams(ReadPartition const& read_partition) {
-  return Connection::ReadParams(
+  return Connection::ReadParams{
       MakeTransactionFromIds(read_partition.SessionId(),
                              read_partition.TransactionId()),
-      read_partition.TableName(), FromProto(read_partition.KeySet()),
-      read_partition.ColumnNames(), read_partition.ReadOptions(),
-      read_partition.PartitionToken());
+      read_partition.TableName(),
+      FromProto(read_partition.KeySet()),
+      read_partition.ColumnNames(),
+      read_partition.ReadOptions(),
+      read_partition.PartitionToken()};
 }
 
 }  // namespace internal


### PR DESCRIPTION
# Background

https://github.com/googleapis/google-cloud-cpp-spanner/blob/master/google/cloud/spanner/connection.h defines the `Connection` interface, which allows us and our customers to mock out the Spanner "backend" for easier unit testing. That interface defines several `FooParms` structs, which hold all the parameters for each of the virtual methods. Most of those structs are normal/trivial structs, i.e., *they do not have constructors*.

However, we do have two structs that have constructors: 
https://github.com/googleapis/google-cloud-cpp-spanner/blob/01f634f75a08dc4cc98949ff0ad2a554100f31d4/google/cloud/spanner/connection.h#L78

and

https://github.com/googleapis/google-cloud-cpp-spanner/blob/01f634f75a08dc4cc98949ff0ad2a554100f31d4/google/cloud/spanner/connection.h#L102

These exist for convenience because the `partition_token` struct field is optional.

# Proposal

This PR proposes to remove the constructors to make all the params structs the same. This means that all callers constructing the Params will need to specify all fields, including the `partition_token`. But this is the same for all the other params structs already.

This doesn't prevent us from ever adding a constructor back at some point in the future, for example, if we decide that we need to add another *optional* member to a struct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1257)
<!-- Reviewable:end -->
