### PR TITLE
refactor!: prepare for new field in SqlParams

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -86,6 +86,7 @@ RowStream Client::ExecuteQuery(SqlStatement statement) {
   return conn_->ExecuteQuery(
       {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        std::move(statement),
+       {},
        {}});
 }
 
@@ -94,13 +95,14 @@ RowStream Client::ExecuteQuery(
   return conn_->ExecuteQuery(
       {internal::MakeSingleUseTransaction(std::move(transaction_options)),
        std::move(statement),
+       {},
        {}});
 }
 
 RowStream Client::ExecuteQuery(Transaction transaction,
                                SqlStatement statement) {
   return conn_->ExecuteQuery(
-      {std::move(transaction), std::move(statement), {}});
+      {std::move(transaction), std::move(statement), {}, {}});
 }
 
 RowStream Client::ExecuteQuery(QueryPartition const& partition) {
@@ -111,6 +113,7 @@ ProfileQueryResult Client::ProfileQuery(SqlStatement statement) {
   return conn_->ProfileQuery(
       {internal::MakeSingleUseTransaction(Transaction::ReadOnlyOptions()),
        std::move(statement),
+       {},
        {}});
 }
 
@@ -119,13 +122,14 @@ ProfileQueryResult Client::ProfileQuery(
   return conn_->ProfileQuery(
       {internal::MakeSingleUseTransaction(std::move(transaction_options)),
        std::move(statement),
+       {},
        {}});
 }
 
 ProfileQueryResult Client::ProfileQuery(Transaction transaction,
                                         SqlStatement statement) {
   return conn_->ProfileQuery(
-      {std::move(transaction), std::move(statement), {}});
+      {std::move(transaction), std::move(statement), {}, {}});
 }
 
 StatusOr<std::vector<QueryPartition>> Client::PartitionQuery(
@@ -137,17 +141,20 @@ StatusOr<std::vector<QueryPartition>> Client::PartitionQuery(
 
 StatusOr<DmlResult> Client::ExecuteDml(Transaction transaction,
                                        SqlStatement statement) {
-  return conn_->ExecuteDml({std::move(transaction), std::move(statement), {}});
+  return conn_->ExecuteDml(
+      {std::move(transaction), std::move(statement), {}, {}});
 }
 
 StatusOr<ProfileDmlResult> Client::ProfileDml(Transaction transaction,
                                               SqlStatement statement) {
-  return conn_->ProfileDml({std::move(transaction), std::move(statement), {}});
+  return conn_->ProfileDml(
+      {std::move(transaction), std::move(statement), {}, {}});
 }
 
 StatusOr<ExecutionPlan> Client::AnalyzeSql(Transaction transaction,
                                            SqlStatement statement) {
-  return conn_->AnalyzeSql({std::move(transaction), std::move(statement), {}});
+  return conn_->AnalyzeSql(
+      {std::move(transaction), std::move(statement), {}, {}});
 }
 
 StatusOr<BatchDmlResult> Client::ExecuteBatchDml(

--- a/google/cloud/spanner/connection.h
+++ b/google/cloud/spanner/connection.h
@@ -87,6 +87,8 @@ class Connection {
   struct SqlParams {
     Transaction transaction;
     SqlStatement statement;
+    struct {
+    } placeholder_do_not_use_name_will_change;
     google::cloud::optional<std::string> partition_token;
   };
 

--- a/google/cloud/spanner/query_partition.cc
+++ b/google/cloud/spanner/query_partition.cc
@@ -99,7 +99,9 @@ QueryPartition MakeQueryPartition(std::string const& transaction_id,
 Connection::SqlParams MakeSqlParams(QueryPartition const& query_partition) {
   return {internal::MakeTransactionFromIds(query_partition.session_id(),
                                            query_partition.transaction_id()),
-          query_partition.sql_statement(), query_partition.partition_token()};
+          query_partition.sql_statement(),
+          {},
+          query_partition.partition_token()};
 }
 
 }  // namespace internal


### PR DESCRIPTION
We're going to be adding a new field to SqlParams fairly soon, so to
prevent an API break later, this PR adds a dummy field in the struct so
that we can take the API breakage now rather than later. The struct
field is named such that users *should* not use it by name, but its
existence should require that it gets default initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1265)
<!-- Reviewable:end -->
