### PR TITLE
doc: simplify install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -206,41 +206,6 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
-#### googletest
-
-We need a recent version of GoogleTest to compile the unit and integration
-tests.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
-#### benchmark
-
-We need a recent version of the Google microbenchmark support library.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
 #### google-cloud-cpp-common
 
 The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -251,9 +216,7 @@ cd $HOME/Downloads
 wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -265,11 +228,9 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
+sudo cmake --build cmake-out --target install
 ```
 
 
@@ -362,41 +323,6 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
-#### googletest
-
-We need a recent version of GoogleTest to compile the unit and integration
-tests.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
-#### benchmark
-
-We need a recent version of the Google microbenchmark support library.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
 #### google-cloud-cpp-common
 
 The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -407,9 +333,7 @@ cd $HOME/Downloads
 wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -421,11 +345,9 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
+sudo cmake --build cmake-out --target install
 ```
 
 
@@ -490,41 +412,6 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
-#### googletest
-
-We need a recent version of GoogleTest to compile the unit and integration
-tests.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
-#### benchmark
-
-We need a recent version of the Google microbenchmark support library.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
 #### google-cloud-cpp-common
 
 The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -535,9 +422,7 @@ cd $HOME/Downloads
 wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -549,11 +434,9 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
+sudo cmake --build cmake-out --target install
 ```
 
 
@@ -633,41 +516,6 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
-#### googletest
-
-We need a recent version of GoogleTest to compile the unit and integration
-tests.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
-#### benchmark
-
-We need a recent version of the Google microbenchmark support library.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
 #### google-cloud-cpp-common
 
 The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -678,9 +526,7 @@ cd $HOME/Downloads
 wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -692,11 +538,9 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
+sudo cmake --build cmake-out --target install
 ```
 
 
@@ -734,41 +578,6 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
-#### googletest
-
-We need a recent version of GoogleTest to compile the unit and integration
-tests.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
-#### benchmark
-
-We need a recent version of the Google microbenchmark support library.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
 #### google-cloud-cpp-common
 
 The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -779,9 +588,7 @@ cd $HOME/Downloads
 wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -793,11 +600,9 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
+sudo cmake --build cmake-out --target install
 ```
 
 
@@ -869,41 +674,6 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
-#### googletest
-
-We need a recent version of GoogleTest to compile the unit and integration
-tests.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
-#### benchmark
-
-We need a recent version of the Google microbenchmark support library.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
 #### google-cloud-cpp-common
 
 The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -914,9 +684,7 @@ cd $HOME/Downloads
 wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -928,11 +696,9 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
+sudo cmake --build cmake-out --target install
 ```
 
 
@@ -1009,41 +775,6 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
-#### googletest
-
-We need a recent version of GoogleTest to compile the unit and integration
-tests.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
-#### benchmark
-
-We need a recent version of the Google microbenchmark support library.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
 #### google-cloud-cpp-common
 
 The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -1054,9 +785,7 @@ cd $HOME/Downloads
 wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1068,11 +797,9 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
+sudo cmake --build cmake-out --target install
 ```
 
 
@@ -1170,41 +897,6 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
-#### googletest
-
-We need a recent version of GoogleTest to compile the unit and integration
-tests.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
-#### benchmark
-
-We need a recent version of the Google microbenchmark support library.
-
-```bash
-cd $HOME/Downloads
-wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-sudo ldconfig
-```
-
 #### google-cloud-cpp-common
 
 The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -1215,9 +907,7 @@ cd $HOME/Downloads
 wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
@@ -1229,10 +919,8 @@ We can now compile, test, and install `google-cloud-cpp-spanner`.
 
 ```bash
 cd $HOME/project
-cmake -H. -Bcmake-out
+cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 cmake --build cmake-out -- -j "${NCPU:-4}"
-cd $HOME/project/cmake-out
-ctest -LE integration-tests --output-on-failure
-sudo cmake --build . --target install
+sudo cmake --build cmake-out --target install
 ```
 

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -26,6 +26,17 @@ declare -A ORIGINAL_COPYRIGHT_YEAR=(
   [ubuntu-bionic]=2019
 )
 
+read_into_variable INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE <<'_EOF_'
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
+    tar -xf v0.19.0.tar.gz && \
+    cd google-cloud-cpp-common-0.19.0 && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+_EOF_
+
 BUILD_AND_TEST_PROJECT_FRAGMENT=$(replace_fragments \
       "INSTALL_CPP_CMAKEFILES_FROM_SOURCE" \
       "INSTALL_GOOGLETEST_FROM_SOURCE" \
@@ -37,23 +48,6 @@ BUILD_AND_TEST_PROJECT_FRAGMENT=$(replace_fragments \
 
 # ```bash
 @INSTALL_CPP_CMAKEFILES_FROM_SOURCE@
-# ```
-
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-@INSTALL_GOOGLETEST_FROM_SOURCE@
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-@INSTALL_GOOGLE_BENCHMARK_FROM_SOURCE@
 # ```
 
 # #### google-cloud-cpp-common
@@ -74,11 +68,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -116,41 +116,6 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
     ldconfig
 # ```
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 # The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -161,9 +126,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -178,11 +141,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -95,41 +95,6 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
     ldconfig
 # ```
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 # The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -140,9 +105,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -157,11 +120,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -56,41 +56,6 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
     ldconfig
 # ```
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 # The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -101,9 +66,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -118,11 +81,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -90,41 +90,6 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
     ldconfig
 # ```
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 # The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -135,9 +100,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -152,11 +115,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -64,41 +64,6 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
     ldconfig
 # ```
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 # The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -109,9 +74,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -126,11 +89,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -111,41 +111,6 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
     ldconfig
 # ```
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 # The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -156,9 +121,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -173,11 +136,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -62,41 +62,6 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
     ldconfig
 # ```
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 # The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -107,9 +72,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -124,11 +87,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -83,41 +83,6 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
     ldconfig
 # ```
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 # The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -128,9 +93,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -145,11 +108,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -98,41 +98,6 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
     ldconfig
 # ```
 
-# #### googletest
-
-# We need a recent version of GoogleTest to compile the unit and integration
-# tests.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz && \
-    tar -xf release-1.10.0.tar.gz && \
-    cd googletest-release-1.10.0 && \
-    cmake -DCMAKE_BUILD_TYPE="Release" -DBUILD_SHARED_LIBS=yes -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
-# #### benchmark
-
-# We need a recent version of the Google microbenchmark support library.
-
-# ```bash
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/benchmark/archive/v1.5.0.tar.gz && \
-    tar -xf v1.5.0.tar.gz && \
-    cd benchmark-1.5.0 && \
-    cmake \
-        -DCMAKE_BUILD_TYPE="Release" \
-        -DBUILD_SHARED_LIBS=yes \
-        -DBENCHMARK_ENABLE_TESTING=OFF \
-        -H. -Bcmake-out && \
-    cmake --build cmake-out -- -j ${NCPU:-4} && \
-    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
-    ldconfig
-# ```
-
 # #### google-cloud-cpp-common
 
 # The project also depends on google-cloud-cpp-common, the libraries shared by
@@ -143,9 +108,7 @@ WORKDIR /var/tmp/build
 RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
     tar -xf v0.19.0.tar.gz && \
     cd google-cloud-cpp-common-0.19.0 && \
-    cmake -H. -Bcmake-out \
-        -DBUILD_TESTING=OFF \
-        -DGOOGLE_CLOUD_CPP_TESTING_UTIL_ENABLE_INSTALL=ON && \
+    cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
@@ -160,11 +123,9 @@ FROM devtools AS install
 # ```bash
 WORKDIR /home/build/project
 COPY . /home/build/project
-RUN cmake -H. -Bcmake-out
+RUN cmake -H. -Bcmake-out -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
 RUN cmake --build cmake-out -- -j "${NCPU:-4}"
-WORKDIR /home/build/project/cmake-out
-RUN ctest -LE integration-tests --output-on-failure
-RUN cmake --build . --target install
+RUN cmake --build cmake-out --target install
 # ```
 
 ## [END INSTALL.md]


### PR DESCRIPTION
When installing the library, do not run the unit tests or benchmarks.
This removes two steps from the installation instructions, even the more
difficult platforms have about 10 steps, so 2 steps is a significant
change.

This test theoretically reduces the testing coverage, as it disables unit
tests in a number of platforms. We think the risk is low, as the same unit
tests pass in many other builds, and we are running at least one smoke
test for the `ci/kokoro/install` builds.

This fixes #1216 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1268)
<!-- Reviewable:end -->
