### PR TITLE
fix: avoid namespace aliases in header files

### DIFF
--- a/google/cloud/spanner/internal/instance_admin_logging.h
+++ b/google/cloud/spanner/internal/instance_admin_logging.h
@@ -25,8 +25,6 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-namespace gcsa = ::google::spanner::admin::instance::v1;
-
 /**
  * Implements the logging Decorator for InstanceAdminStub.
  */
@@ -46,26 +44,42 @@ class InstanceAdminLogging : public InstanceAdminStub {
    * Run the logging loop (if appropriate) for the child InstanceAdminStub.
    */
   ///
-  StatusOr<gcsa::Instance> GetInstance(
-      grpc::ClientContext&, gcsa::GetInstanceRequest const&) override;
+  StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::GetInstanceRequest const&) override;
 
   StatusOr<google::longrunning::Operation> CreateInstance(
-      grpc::ClientContext&, gcsa::CreateInstanceRequest const&) override;
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::CreateInstanceRequest const&)
+      override;
 
   StatusOr<google::longrunning::Operation> UpdateInstance(
-      grpc::ClientContext&, gcsa::UpdateInstanceRequest const&) override;
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::UpdateInstanceRequest const&)
+      override;
 
-  Status DeleteInstance(grpc::ClientContext&,
-                        gcsa::DeleteInstanceRequest const&) override;
+  Status DeleteInstance(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::DeleteInstanceRequest const&)
+      override;
 
-  StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
-      grpc::ClientContext&, gcsa::GetInstanceConfigRequest const&) override;
+  StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
+  GetInstanceConfig(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::GetInstanceConfigRequest const&)
+      override;
 
-  StatusOr<gcsa::ListInstanceConfigsResponse> ListInstanceConfigs(
-      grpc::ClientContext&, gcsa::ListInstanceConfigsRequest const&) override;
+  StatusOr<google::spanner::admin::instance::v1::ListInstanceConfigsResponse>
+  ListInstanceConfigs(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::ListInstanceConfigsRequest const&)
+      override;
 
-  StatusOr<gcsa::ListInstancesResponse> ListInstances(
-      grpc::ClientContext&, gcsa::ListInstancesRequest const&) override;
+  StatusOr<google::spanner::admin::instance::v1::ListInstancesResponse>
+  ListInstances(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::ListInstancesRequest const&)
+      override;
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext&,
@@ -83,6 +97,7 @@ class InstanceAdminLogging : public InstanceAdminStub {
       grpc::ClientContext& context,
       google::longrunning::GetOperationRequest const& request) override;
   //@}
+
  private:
   std::shared_ptr<InstanceAdminStub> child_;
   TracingOptions tracing_options_;

--- a/google/cloud/spanner/internal/instance_admin_metadata.h
+++ b/google/cloud/spanner/internal/instance_admin_metadata.h
@@ -23,8 +23,6 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-namespace gcsa = ::google::spanner::admin::instance::v1;
-
 /**
  * Implements the metadata Decorator for InstanceAdminStub.
  */
@@ -39,26 +37,42 @@ class InstanceAdminMetadata : public InstanceAdminStub {
    * @name Override the functions from `InstanceAdminStub`.
    */
   ///
-  StatusOr<gcsa::Instance> GetInstance(
-      grpc::ClientContext&, gcsa::GetInstanceRequest const&) override;
+  StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::GetInstanceRequest const&) override;
 
   StatusOr<google::longrunning::Operation> CreateInstance(
-      grpc::ClientContext&, gcsa::CreateInstanceRequest const&) override;
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::CreateInstanceRequest const&)
+      override;
 
   StatusOr<google::longrunning::Operation> UpdateInstance(
-      grpc::ClientContext&, gcsa::UpdateInstanceRequest const&) override;
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::UpdateInstanceRequest const&)
+      override;
 
-  Status DeleteInstance(grpc::ClientContext&,
-                        gcsa::DeleteInstanceRequest const&) override;
+  Status DeleteInstance(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::DeleteInstanceRequest const&)
+      override;
 
-  StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
-      grpc::ClientContext&, gcsa::GetInstanceConfigRequest const&) override;
+  StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
+  GetInstanceConfig(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::GetInstanceConfigRequest const&)
+      override;
 
-  StatusOr<gcsa::ListInstanceConfigsResponse> ListInstanceConfigs(
-      grpc::ClientContext&, gcsa::ListInstanceConfigsRequest const&) override;
+  StatusOr<google::spanner::admin::instance::v1::ListInstanceConfigsResponse>
+  ListInstanceConfigs(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::ListInstanceConfigsRequest const&)
+      override;
 
-  StatusOr<gcsa::ListInstancesResponse> ListInstances(
-      grpc::ClientContext&, gcsa::ListInstancesRequest const&) override;
+  StatusOr<google::spanner::admin::instance::v1::ListInstancesResponse>
+  ListInstances(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::ListInstancesRequest const&)
+      override;
 
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext&,
@@ -76,6 +90,7 @@ class InstanceAdminMetadata : public InstanceAdminStub {
       grpc::ClientContext& context,
       google::longrunning::GetOperationRequest const& request) override;
   //@}
+
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);

--- a/google/cloud/spanner/internal/instance_admin_stub.h
+++ b/google/cloud/spanner/internal/instance_admin_stub.h
@@ -26,8 +26,6 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-namespace gcsa = ::google::spanner::admin::instance::v1;
-
 /**
  * Defines the low-level interface for instance administration RPCs.
  */
@@ -35,26 +33,37 @@ class InstanceAdminStub {
  public:
   virtual ~InstanceAdminStub() = 0;
 
-  virtual StatusOr<gcsa::Instance> GetInstance(
-      grpc::ClientContext&, gcsa::GetInstanceRequest const&) = 0;
+  virtual StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::GetInstanceRequest const&) = 0;
 
   virtual StatusOr<google::longrunning::Operation> CreateInstance(
-      grpc::ClientContext&, gcsa::CreateInstanceRequest const&) = 0;
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::CreateInstanceRequest const&) = 0;
 
   virtual StatusOr<google::longrunning::Operation> UpdateInstance(
-      grpc::ClientContext&, gcsa::UpdateInstanceRequest const&) = 0;
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::UpdateInstanceRequest const&) = 0;
 
-  virtual Status DeleteInstance(grpc::ClientContext&,
-                                gcsa::DeleteInstanceRequest const&) = 0;
+  virtual Status DeleteInstance(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::DeleteInstanceRequest const&) = 0;
 
-  virtual StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
-      grpc::ClientContext&, gcsa::GetInstanceConfigRequest const&) = 0;
+  virtual StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
+  GetInstanceConfig(grpc::ClientContext&,
+                    google::spanner::admin::instance::v1::
+                        GetInstanceConfigRequest const&) = 0;
 
-  virtual StatusOr<gcsa::ListInstanceConfigsResponse> ListInstanceConfigs(
-      grpc::ClientContext&, gcsa::ListInstanceConfigsRequest const&) = 0;
+  virtual StatusOr<
+      google::spanner::admin::instance::v1::ListInstanceConfigsResponse>
+  ListInstanceConfigs(grpc::ClientContext&,
+                      google::spanner::admin::instance::v1::
+                          ListInstanceConfigsRequest const&) = 0;
 
-  virtual StatusOr<gcsa::ListInstancesResponse> ListInstances(
-      grpc::ClientContext&, gcsa::ListInstancesRequest const&) = 0;
+  virtual StatusOr<google::spanner::admin::instance::v1::ListInstancesResponse>
+  ListInstances(
+      grpc::ClientContext&,
+      google::spanner::admin::instance::v1::ListInstancesRequest const&) = 0;
 
   virtual StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext&, google::iam::v1::GetIamPolicyRequest const&) = 0;

--- a/google/cloud/spanner/testing/mock_instance_admin_stub.h
+++ b/google/cloud/spanner/testing/mock_instance_admin_stub.h
@@ -23,32 +23,44 @@ namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
-namespace gcsa = ::google::spanner::admin::instance::v1;
-
 class MockInstanceAdminStub
     : public google::cloud::spanner::internal::InstanceAdminStub {
  public:
-  MOCK_METHOD2(GetInstance,
-               StatusOr<gcsa::Instance>(grpc::ClientContext&,
-                                        gcsa::GetInstanceRequest const&));
-  MOCK_METHOD2(CreateInstance,
-               StatusOr<google::longrunning::Operation>(
-                   grpc::ClientContext&, gcsa::CreateInstanceRequest const&));
-  MOCK_METHOD2(UpdateInstance,
-               StatusOr<google::longrunning::Operation>(
-                   grpc::ClientContext&, gcsa::UpdateInstanceRequest const&));
-  MOCK_METHOD2(DeleteInstance, Status(grpc::ClientContext&,
-                                      gcsa::DeleteInstanceRequest const&));
-  MOCK_METHOD2(GetInstanceConfig, StatusOr<gcsa::InstanceConfig>(
-                                      grpc::ClientContext&,
-                                      gcsa::GetInstanceConfigRequest const&));
-  MOCK_METHOD2(ListInstanceConfigs,
-               StatusOr<gcsa::ListInstanceConfigsResponse>(
-                   grpc::ClientContext&,
-                   gcsa::ListInstanceConfigsRequest const&));
-  MOCK_METHOD2(ListInstances,
-               StatusOr<gcsa::ListInstancesResponse>(
-                   grpc::ClientContext&, gcsa::ListInstancesRequest const&));
+  MOCK_METHOD2(
+      GetInstance,
+      StatusOr<google::spanner::admin::instance::v1::Instance>(
+          grpc::ClientContext&,
+          google::spanner::admin::instance::v1::GetInstanceRequest const&));
+  MOCK_METHOD2(
+      CreateInstance,
+      StatusOr<google::longrunning::Operation>(
+          grpc::ClientContext&,
+          google::spanner::admin::instance::v1::CreateInstanceRequest const&));
+  MOCK_METHOD2(
+      UpdateInstance,
+      StatusOr<google::longrunning::Operation>(
+          grpc::ClientContext&,
+          google::spanner::admin::instance::v1::UpdateInstanceRequest const&));
+  MOCK_METHOD2(
+      DeleteInstance,
+      Status(
+          grpc::ClientContext&,
+          google::spanner::admin::instance::v1::DeleteInstanceRequest const&));
+  MOCK_METHOD2(GetInstanceConfig,
+               StatusOr<google::spanner::admin::instance::v1::InstanceConfig>(
+                   grpc::ClientContext&, google::spanner::admin::instance::v1::
+                                             GetInstanceConfigRequest const&));
+  MOCK_METHOD2(
+      ListInstanceConfigs,
+      StatusOr<
+          google::spanner::admin::instance::v1::ListInstanceConfigsResponse>(
+          grpc::ClientContext&, google::spanner::admin::instance::v1::
+                                    ListInstanceConfigsRequest const&));
+  MOCK_METHOD2(
+      ListInstances,
+      StatusOr<google::spanner::admin::instance::v1::ListInstancesResponse>(
+          grpc::ClientContext&,
+          google::spanner::admin::instance::v1::ListInstancesRequest const&));
   MOCK_METHOD2(GetIamPolicy, StatusOr<google::iam::v1::Policy>(
                                  grpc::ClientContext&,
                                  google::iam::v1::GetIamPolicyRequest const&));


### PR DESCRIPTION
Even when they are in an anonymous namespace, and especially when
the aliases do not have unique names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1274)
<!-- Reviewable:end -->
