### PR TITLE
fix: added connection_options_test back to build

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -300,6 +300,7 @@ function (spanner_client_define_tests)
     set(spanner_client_unit_tests
         # cmake-format: sortable
         client_test.cc
+        connection_options_test.cc
         database_test.cc
         database_admin_client_test.cc
         database_admin_connection_test.cc

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -18,6 +18,7 @@
 
 spanner_client_unit_tests = [
     "client_test.cc",
+    "connection_options_test.cc",
     "database_test.cc",
     "database_admin_client_test.cc",
     "database_admin_connection_test.cc",


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/googleapis/google-cloud-cpp-spanner/pull/1279

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1280)
<!-- Reviewable:end -->
