### PR TITLE
chore: upgrade dep to g-c-c-common v0.20

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -216,9 +216,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -333,9 +333,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -422,9 +422,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -526,9 +526,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -588,9 +588,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -684,9 +684,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -785,9 +785,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -907,9 +907,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -42,11 +42,11 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_googleapis_google_cloud_cpp_common" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp_common",
-            strip_prefix = "google-cloud-cpp-common-0.19.0",
+            strip_prefix = "google-cloud-cpp-common-0.20.0",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz",
             ],
-            sha256 = "40dc0d1465a04939bada7bab280d24ee9fe33b3370e2ab4422bb51c1ed4977c8",
+            sha256 = "0f5a5e03a6447d68778b331cbc43ad4e9c27a519275261c4eb7b8f15d554cba3",
         )
 
     # Load a version of googletest that we know works.

--- a/ci/etc/kokoro/install/project-config.sh
+++ b/ci/etc/kokoro/install/project-config.sh
@@ -28,9 +28,9 @@ declare -A ORIGINAL_COPYRIGHT_YEAR=(
 
 read_into_variable INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE <<'_EOF_'
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -91,9 +91,9 @@ RUN cmake --build cmake-out --target install
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz
-RUN tar -xf v0.19.0.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-common-0.19.0
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz
+RUN tar -xf v0.20.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.20.0
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -123,9 +123,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -102,9 +102,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -63,9 +63,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -97,9 +97,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -71,9 +71,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -118,9 +118,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -69,9 +69,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -90,9 +90,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -105,9 +105,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz && \
-    tar -xf v0.19.0.tar.gz && \
-    cd google-cloud-cpp-common-0.19.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
+    tar -xf v0.20.0.tar.gz && \
+    cd google-cloud-cpp-common-0.20.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/super/external/google-cloud-cpp-common.cmake
+++ b/super/external/google-cloud-cpp-common.cmake
@@ -23,10 +23,10 @@ if (NOT TARGET google-cloud-cpp-common-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.19.0.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz"
     )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "40dc0d1465a04939bada7bab280d24ee9fe33b3370e2ab4422bb51c1ed4977c8")
+        "0f5a5e03a6447d68778b331cbc43ad4e9c27a519275261c4eb7b8f15d554cba3")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
Note: `INSTALL_GOOGLE_CLOUD_CPP_COMMON_FROM_SOURCE` is
currently overridden in `ci/etc/kokoro/install/project-config.sh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1281)
<!-- Reviewable:end -->
