### PR TITLE
feat: more allowances for running integration tests against the emulator

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include <google/spanner/v1/result_set.pb.h>
 #include <algorithm>
@@ -182,6 +183,14 @@ int main(int argc, char* argv[]) {
       std::cout << "# Re-using existing database\n";
       database_created = false;
     } else {
+      auto emulator = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
+      if (emulator.has_value() &&
+          db.status().code() == google::cloud::StatusCode::kNotFound) {
+        // The emulator probably doesn't have the instance, and we don't care
+        // to create it as benchmarking the emulator is a non-goal. So, just
+        // succeed quietly.
+        return 0;
+      }
       std::cerr << "Error creating database: " << db.status() << "\n";
       return 1;
     }

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -121,6 +121,14 @@ int main(int argc, char* argv[]) {
       std::cout << "# Re-using existing database\n";
       database_created = false;
     } else {
+      auto emulator = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
+      if (emulator.has_value() &&
+          db.status().code() == google::cloud::StatusCode::kNotFound) {
+        // The emulator probably doesn't have the instance, and we don't care
+        // to create it as benchmarking the emulator is a non-goal. So, just
+        // succeed quietly.
+        return 0;
+      }
       std::cerr << "Error creating database: " << db.status() << "\n";
       return 1;
     }

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -112,6 +112,7 @@ TEST_F(InstanceAdminClientTest, InstanceReadOperations) {
   Instance in(project_id_, instance_id_);
 
   auto instance = client_.GetInstance(in);
+  if (emulator_ && instance.status().code() == StatusCode::kNotFound) return;
   EXPECT_STATUS_OK(instance);
   EXPECT_THAT(instance->name(), HasSubstr(project_id_));
   EXPECT_THAT(instance->name(), HasSubstr(instance_id_));

--- a/google/cloud/spanner/integration_tests/spanner_install_test.cc
+++ b/google/cloud/spanner/integration_tests/spanner_install_test.cc
@@ -63,11 +63,19 @@ int main(int argc, char* argv[]) try {
       if (full_name.find(substr) == std::string::npos) continue;
       names.push_back(full_name.substr(full_name.rfind('/') + 1));
     }
-    if (names.empty()) throw std::runtime_error("No instances in the project");
+    if (names.empty()) {
+      auto emulator = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
+      if (emulator.has_value()) {
+        std::cout << "No instances in the project within the emulator.\n";
+        return std::string{};
+      }
+      throw std::runtime_error("No instances in the project");
+    }
 
     return names[std::uniform_int_distribution<std::size_t>(
         0, names.size() - 1)(generator)];
   }();
+  if (instance_id.empty()) return 0;
 
   auto database_id =
       "db-" + google::cloud::internal::Sample(


### PR DESCRIPTION
* When the emulator doesn't have the `${GOOGLE_CLOUD_CPP_SPANNER_INSTANCE}`
  instance, short-circuit the `InstanceAdminClientTest.InstanceReadOperations`
  test, and also don't run the `spanner_client_benchmark_programs`.
* When the emulator doesn't have any instances, make `spanner_install_test`
  exit successfully.
* When the emulator doesn't have any "test-instance-*" instances, change
  `PickRandomInstance()` to create and return "test-instance-a".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1282)
<!-- Reviewable:end -->
