### PR TITLE
feat: support environment-variable override of default endpoint

### DIFF
--- a/google/cloud/spanner/connection_options.cc
+++ b/google/cloud/spanner/connection_options.cc
@@ -22,7 +22,10 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 
 std::string ConnectionOptionsTraits::default_endpoint() {
-  return "spanner.googleapis.com";
+  auto default_endpoint = google::cloud::internal::GetEnv(
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
+  return default_endpoint.has_value() ? *default_endpoint
+                                      : "spanner.googleapis.com";
 }
 
 std::string ConnectionOptionsTraits::user_agent_prefix() {

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -57,6 +57,15 @@ TEST(ConnectionOptionsTraits, UserAgentPrefix) {
   EXPECT_EQ("test-prefix/1.2.3 " + actual, options.user_agent_prefix());
 }
 
+TEST(DefaultEndpoint, EnvironmentWorks) {
+  EXPECT_NE("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());
+  EnvironmentVariableRestore restore(
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
+  google::cloud::internal::SetEnv("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT",
+                                  "invalid-endpoint");
+  EXPECT_EQ("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());
+}
+
 TEST(EmulatorOverrides, EnvironmentWorks) {
   // When SPANNER_EMULATOR_HOST is set, the original endpoint is reset to
   // ${SPANNER_EMULATOR_HOST}, and the original credentials are reset to


### PR DESCRIPTION
`${GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT}` can override the
default endpoint `spanner.googleapis.com`.

Fixes #1255.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1283)
<!-- Reviewable:end -->
