### PR TITLE
chore: migrate to `testing_util::ScopedEnvironment`

### DIFF
--- a/google/cloud/spanner/benchmarks/benchmarks_config_test.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config_test.cc
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/benchmarks/benchmarks_config.h"
-#include "google/cloud/internal/setenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/environment_variable_restore.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -46,8 +45,7 @@ TEST(BenchmarkConfigTest, ParseAll) {
 }
 
 TEST(BenchmarkConfigTest, ParseNone) {
-  testing_util::EnvironmentVariableRestore restore("GOOGLE_CLOUD_PROJECT");
-  internal::SetEnv("GOOGLE_CLOUD_PROJECT", "test-project");
+  testing_util::ScopedEnvironment env("GOOGLE_CLOUD_PROJECT", "test-project");
   auto config = ParseArgs({"placeholder"});
   EXPECT_STATUS_OK(config);
 }

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -14,8 +14,7 @@
 
 #include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/internal/compiler_info.h"
-#include "google/cloud/internal/setenv.h"
-#include "google/cloud/testing_util/environment_variable_restore.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -24,7 +23,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
-using ::google::cloud::testing_util::EnvironmentVariableRestore;
+using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::HasSubstr;
 using ::testing::StartsWith;
 
@@ -59,10 +58,8 @@ TEST(ConnectionOptionsTraits, UserAgentPrefix) {
 
 TEST(DefaultEndpoint, EnvironmentWorks) {
   EXPECT_NE("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());
-  EnvironmentVariableRestore restore(
-      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT");
-  google::cloud::internal::SetEnv("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT",
-                                  "invalid-endpoint");
+  ScopedEnvironment env("GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT",
+                        "invalid-endpoint");
   EXPECT_EQ("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());
 }
 
@@ -70,8 +67,7 @@ TEST(EmulatorOverrides, EnvironmentWorks) {
   // When SPANNER_EMULATOR_HOST is set, the original endpoint is reset to
   // ${SPANNER_EMULATOR_HOST}, and the original credentials are reset to
   // grpc::InsecureChannelCredentials().
-  EnvironmentVariableRestore restore("SPANNER_EMULATOR_HOST");
-  google::cloud::internal::SetEnv("SPANNER_EMULATOR_HOST", "localhost:9010");
+  ScopedEnvironment env("SPANNER_EMULATOR_HOST", "localhost:9010");
   ConnectionOptions options(std::shared_ptr<grpc::ChannelCredentials>{});
   options = internal::EmulatorOverrides(options);
   EXPECT_NE(std::shared_ptr<grpc::ChannelCredentials>{}, options.credentials());


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1284)
<!-- Reviewable:end -->
