### PR TITLE
doc: on Windows run bazel test before bazel run

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ in the [release notes](README.md#release-notes) below.
 [![CI status docker/check-api][docker/check-api-shield]][docker/check-api-link]
 [![CI status docker/clang-3.8][docker/clang-3.8-shield]][docker/clang-3.8-link]
 [![CI status docker/clang-tidy][docker/clang-tidy-shield]][docker/clang-tidy-link]
-[![CI status docker/cmake][docker/cmake-shield]][docker/cmake-link]
 [![CI status docker/cmake-super][docker/cmake-super-shield]][docker/cmake-super-link]
+[![CI status docker/cmake][docker/cmake-shield]][docker/cmake-link]
 [![CI status docker/coverage][docker/coverage-shield]][docker/coverage-link]
 [![CI status docker/cxx17][docker/cxx17-shield]][docker/cxx17-link]
 [![CI status docker/gcc-4.8][docker/gcc-4.8-shield]][docker/gcc-4.8-link]
@@ -157,6 +157,7 @@ limits.
 
 ```console
 mkdir C:\b
+bazel --output_user_root=C:\b test //google/cloud/spanner/sampoles:samples
 bazel --output_user_root=C:\b build //google/cloud/spanner/samples:samples
 ```
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ limits.
 
 ```console
 mkdir C:\b
-bazel --output_user_root=C:\b test //google/cloud/spanner/sampoles:samples
+bazel --output_user_root=C:\b test //google/cloud/spanner/samples:samples
 bazel --output_user_root=C:\b build //google/cloud/spanner/samples:samples
 ```
 

--- a/ci/test-readme/generate-readme.sh
+++ b/ci/test-readme/generate-readme.sh
@@ -95,7 +95,7 @@ limits.
 
 ```console
 mkdir C:\b
-bazel --output_user_root=C:\b test //google/cloud/spanner/sampoles:samples
+bazel --output_user_root=C:\b test //google/cloud/spanner/samples:samples
 bazel --output_user_root=C:\b build //google/cloud/spanner/samples:samples
 ```
 

--- a/ci/test-readme/generate-readme.sh
+++ b/ci/test-readme/generate-readme.sh
@@ -95,6 +95,7 @@ limits.
 
 ```console
 mkdir C:\b
+bazel --output_user_root=C:\b test //google/cloud/spanner/sampoles:samples
 bazel --output_user_root=C:\b build //google/cloud/spanner/samples:samples
 ```
 


### PR DESCRIPTION
It seems that it is necessary to use `bazel test` before `bazel run`
on Windows. Bazel creates a `tw.exe` file during the `test` step, which
is needed (but not created) in the `bazel run` step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1287)
<!-- Reviewable:end -->
