### PR TITLE
doc: update release version/SHA in .dox file

### DIFF
--- a/google/cloud/spanner/doc/spanner-main.dox
+++ b/google/cloud/spanner/doc/spanner-main.dox
@@ -113,9 +113,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Change the version and SHA256 hash as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp_spanner",
-    sha256 = "9d7bd3de8e38f7e4b3e917766ed08fd8c8ff59a8b2f0997c4b1cb781a6fd1558",
-    strip_prefix = "google-cloud-cpp-spanner-0.7.0",
-    url = "https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.7.0.tar.gz",
+    sha256 = "a833d3c1a6d127132e961350829babac521b62b4c837b88d7c219b400e98fed1",
+    strip_prefix = "google-cloud-cpp-spanner-0.8.0",
+    url = "https://github.com/googleapis/google-cloud-cpp-spanner/archive/v0.8.0.tar.gz",
 )
 @endcode
 


### PR DESCRIPTION
see #1288 

technically this should probably be done in the 0.8.0 branch as well, but not sure it's worthwhile as long as we're cutting one more release before GA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1292)
<!-- Reviewable:end -->
