### PR TITLE
feat: add a `Commit()` helper that takes the `Mutations` directly

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -251,6 +251,10 @@ StatusOr<CommitResult> Client::Commit(
                 std::move(default_commit_backoff_policy));
 }
 
+StatusOr<CommitResult> Client::Commit(Mutations mutations) {
+  return Commit([&mutations](Transaction const&) { return mutations; });
+}
+
 StatusOr<CommitResult> Client::Commit(Transaction transaction,
                                       Mutations mutations) {
   return conn_->Commit({std::move(transaction), std::move(mutations)});

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -481,13 +481,10 @@ class Client {
       std::function<StatusOr<Mutations>(Transaction)> const& mutator);
 
   /**
-   * Commits a read-write transaction.
+   * Commits the given @p mutations atomically in order.
    *
-   * Same as above, with a mutator that returns @p mutations.
-   *
-   * @param mutations The mutations to be executed when this transaction
-   *     commits. All mutations are applied atomically, in the order they
-   *     appear in this list.
+   * This function uses the re-run loop described above with the default
+   * policies.
    */
   StatusOr<CommitResult> Commit(Mutations mutations);
 

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -483,6 +483,17 @@ class Client {
   /**
    * Commits a read-write transaction.
    *
+   * Same as above, with a mutator that returns @p mutations.
+   *
+   * @param mutations The mutations to be executed when this transaction
+   *     commits. All mutations are applied atomically, in the order they
+   *     appear in this list.
+   */
+  StatusOr<CommitResult> Commit(Mutations mutations);
+
+  /**
+   * Commits a read-write transaction.
+   *
    * The commit might return a `kAborted` error. This can occur at any time.
    * Commonly the cause is conflicts with concurrent transactions, however
    * it can also happen for a variety of other reasons. If `Commit` returns


### PR DESCRIPTION
This convenience function saves the user from having to create a
small, but non-trivial lambda.

Fixes #1315.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1319)
<!-- Reviewable:end -->
