### PR TITLE
feat: do not rethrow `RuntimeStatusError` from a `Commit()` mutator

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -178,6 +178,13 @@ StatusOr<CommitResult> Client::Commit(
 #endif
       mutations = mutator(txn);
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+    } catch (RuntimeStatusError const& error) {
+      // Treat this like mutator() returned a bad Status.
+      Status status = error.status();
+      if (status.ok()) {
+        status = Status(StatusCode::kUnknown, "OK Status thrown from mutator");
+      }
+      mutations = status;
     } catch (...) {
       auto rb_status = Rollback(txn);
       if (!RerunnablePolicy::IsOk(rb_status)) {

--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -461,7 +461,9 @@ class Client {
    * @param backoff_policy controls how long `Commit` waits between reruns.
    *
    * @throw Rethrows any exception thrown by @p `mutator` (after rolling back
-   *     the transaction).
+   *     the transaction). However, a `RuntimeStatusError` exception is
+   *     instead consumed and converted into a `mutator` return value of the
+   *     enclosed `Status`.
    */
   StatusOr<CommitResult> Commit(
       std::function<StatusOr<Mutations>(Transaction)> const& mutator,


### PR DESCRIPTION
Treat the exception thrown by the mutator as if the enclosed `Status`
had been returned instead (OK is converted to an "unknown" status).
This allows the transaction to be rerun (when the status is transient).

Fixes #1311.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1320)
<!-- Reviewable:end -->
