### PR TITLE
cleanup: simplify error handling in examples

### DIFF
--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -1081,8 +1081,7 @@ void ReadWriteTransaction(google::cloud::spanner::Client client) {
   };
 
   auto commit = client.Commit(
-      [&client, &get_current_budget](
-          spanner::Transaction const& txn) -> StatusOr<spanner::Mutations> {
+      [&client, &get_current_budget](spanner::Transaction const& txn) {
         auto b1 = get_current_budget(client, txn, 1, 1).value();
         auto b2 = get_current_budget(client, txn, 2, 2).value();
         std::int64_t transfer_amount = 200000;
@@ -1277,8 +1276,7 @@ void DmlStructs(google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
   std::int64_t rows_modified = 0;
   auto commit_result =
-      client.Commit([&client, &rows_modified](spanner::Transaction const& txn)
-                        -> google::cloud::StatusOr<spanner::Mutations> {
+      client.Commit([&client, &rows_modified](spanner::Transaction const& txn) {
         auto singer_info = std::make_tuple("Marc", "Richards");
         auto sql = spanner::SqlStatement(
             "UPDATE Singers SET FirstName = 'Keith' WHERE "


### PR DESCRIPTION
Now that the `Commit()` loop reruns when `StatusOr<T>::value()` throws
the "right" errors we can remove a bit of code from the samples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1322)
<!-- Reviewable:end -->
