### PR TITLE
chore: update dependency versions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -206,9 +206,9 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -323,9 +323,9 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -412,9 +412,9 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -516,9 +516,9 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -578,9 +578,9 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -674,9 +674,9 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -775,9 +775,9 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -897,9 +897,9 @@ We need a recent version of the Google Cloud Platform proto C++ libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,6 +174,25 @@ these dependencies.
 - [CentOS 7](#centos-7)
 
 ### Fedora (30)
+Copyright 2019 Google LLC
+#
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+    http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#
+WARNING: This is an automatically generated file. Consider changing the
+    sources instead. You can find the source templates and scripts at:
+    https://github.com/googleapis/google-cloud-cpp-common/tree/master/ci/templates
+#
 
 Install the minimal development tools:
 
@@ -222,9 +241,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -244,6 +263,25 @@ sudo cmake --build cmake-out --target install
 
 
 ### openSUSE (Leap)
+Copyright 2019 Google LLC
+#
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+    http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#
+WARNING: This is an automatically generated file. Consider changing the
+    sources instead. You can find the source templates and scripts at:
+    https://github.com/googleapis/google-cloud-cpp-common/tree/master/ci/templates
+#
 
 Install the minimal development tools, libcurl and OpenSSL. The gRPC Makefile
 uses `which` to determine whether the compiler is available. Install this
@@ -339,9 +377,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -361,6 +399,25 @@ sudo cmake --build cmake-out --target install
 
 
 ### Ubuntu (18.04 - Bionic Beaver)
+Copyright 2019 Google LLC
+#
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+    http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#
+WARNING: This is an automatically generated file. Consider changing the
+    sources instead. You can find the source templates and scripts at:
+    https://github.com/googleapis/google-cloud-cpp-common/tree/master/ci/templates
+#
 
 Install the minimal development tools, libcurl, OpenSSL and libc-ares:
 
@@ -428,9 +485,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -450,6 +507,25 @@ sudo cmake --build cmake-out --target install
 
 
 ### Ubuntu (16.04 - Xenial Xerus)
+Copyright 2019 Google LLC
+#
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+    http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#
+WARNING: This is an automatically generated file. Consider changing the
+    sources instead. You can find the source templates and scripts at:
+    https://github.com/googleapis/google-cloud-cpp-common/tree/master/ci/templates
+#
 
 Install the minimal development tools, OpenSSL and libcurl:
 
@@ -532,9 +608,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -554,6 +630,25 @@ sudo cmake --build cmake-out --target install
 
 
 ### Debian (10 - Buster)
+Copyright 2019 Google LLC
+#
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+    http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#
+WARNING: This is an automatically generated file. Consider changing the
+    sources instead. You can find the source templates and scripts at:
+    https://github.com/googleapis/google-cloud-cpp-common/tree/master/ci/templates
+#
 
 Install the minimal development tools, libcurl, and OpenSSL:
 
@@ -594,9 +689,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -616,6 +711,25 @@ sudo cmake --build cmake-out --target install
 
 
 ### Debian (9 - Stretch)
+Copyright 2019 Google LLC
+#
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+    http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#
+WARNING: This is an automatically generated file. Consider changing the
+    sources instead. You can find the source templates and scripts at:
+    https://github.com/googleapis/google-cloud-cpp-common/tree/master/ci/templates
+#
 
 First install the development tools and libcurl.
 On Debian 9, libcurl links against openssl-1.0.2, and one must link
@@ -690,9 +804,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -712,6 +826,25 @@ sudo cmake --build cmake-out --target install
 
 
 ### CentOS (8)
+Copyright 2019 Google LLC
+#
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+    http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#
+WARNING: This is an automatically generated file. Consider changing the
+    sources instead. You can find the source templates and scripts at:
+    https://github.com/googleapis/google-cloud-cpp-common/tree/master/ci/templates
+#
 
 Install the minimal development tools, libcurl, OpenSSL, and the c-ares
 library (required by gRPC):
@@ -791,9 +924,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -813,6 +946,25 @@ sudo cmake --build cmake-out --target install
 
 
 ### CentOS (7)
+Copyright 2019 Google LLC
+#
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+#
+    http://www.apache.org/licenses/LICENSE-2.0
+#
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+#
+WARNING: This is an automatically generated file. Consider changing the
+    sources instead. You can find the source templates and scripts at:
+    https://github.com/googleapis/google-cloud-cpp-common/tree/master/ci/templates
+#
 
 First install the development tools and OpenSSL. The development tools
 distributed with CentOS 7 (notably CMake) are too old to build
@@ -913,9 +1065,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -42,11 +42,11 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_googleapis_google_cloud_cpp_common" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp_common",
-            strip_prefix = "google-cloud-cpp-common-0.20.0",
+            strip_prefix = "google-cloud-cpp-common-0.21.0",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz",
             ],
-            sha256 = "0f5a5e03a6447d68778b331cbc43ad4e9c27a519275261c4eb7b8f15d554cba3",
+            sha256 = "2e1cd2a97122a02fe3c58a997657a360e19ec9984b857197a9a193a07b4c092b",
         )
 
     # Load a version of googletest that we know works.
@@ -76,10 +76,10 @@ def google_cloud_cpp_spanner_deps():
         http_archive(
             name = "com_google_googleapis",
             urls = [
-                "https://github.com/googleapis/googleapis/archive/19c4589a3cb44b3679f7b3fba88365b3d055d5f8.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/e9e90a787703ec5d388902e2cb796aaed3a385b4.tar.gz",
             ],
-            strip_prefix = "googleapis-19c4589a3cb44b3679f7b3fba88365b3d055d5f8",
-            sha256 = "ef455e46cfb967962aef30248f1a2a69bc78b041e89b04644e24e7844f0215c4",
+            strip_prefix = "googleapis-e9e90a787703ec5d388902e2cb796aaed3a385b4",
+            sha256 = "4c0ba761e943b818cc8b242ed05d0cfdaaac7c4035a43eeab0820461c77619f0",
             build_file = "@com_github_googleapis_google_cloud_cpp_spanner//bazel:googleapis.BUILD",
         )
 

--- a/ci/etc/kokoro/install/version-config.sh
+++ b/ci/etc/kokoro/install/version-config.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly GOOGLE_CLOUD_CPP_COMMON_VERSION=0.20.0
+readonly GOOGLE_CLOUD_CPP_COMMON_VERSION=0.21.0

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -38,21 +38,6 @@ RUN chmod 755 /usr/bin/buildifier
 RUN pip install --upgrade pip
 RUN pip install cmake_format==0.6.0
 
-# There is no Fedora package for CRC32C, download and install from source.
-WORKDIR /var/tmp/build
-RUN wget -q https://github.com/google/crc32c/archive/1.0.6.tar.gz
-RUN tar -xf 1.0.6.tar.gz
-WORKDIR /var/tmp/build/crc32c-1.0.6
-RUN cmake \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_SHARED_LIBS=yes \
-      -DCRC32C_BUILD_TESTS=OFF \
-      -DCRC32C_BUILD_BENCHMARKS=OFF \
-      -DCRC32C_USE_GLOG=OFF \
-      -H. -Bcmake-out/crc32c
-RUN cmake --build cmake-out/crc32c --target install -- -j $(nproc)
-RUN ldconfig
-
 # Download and compile googletest, we need a recent version.
 WORKDIR /var/tmp/build
 RUN wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz
@@ -77,9 +62,9 @@ RUN cmake --build cmake-out/benchmark --target install -- -j $(nproc)
 
 # Download and compile googleapis/cpp-cmakefiles:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz
-RUN tar -xf v0.4.1.tar.gz
-WORKDIR /var/tmp/build/cpp-cmakefiles-0.4.1
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz
+RUN tar -xf v0.5.0.tar.gz
+WORKDIR /var/tmp/build/cpp-cmakefiles-0.5.0
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \
@@ -91,9 +76,9 @@ RUN cmake --build cmake-out --target install
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz
-RUN tar -xf v0.20.0.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-common-0.20.0
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz
+RUN tar -xf v0.21.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.21.0
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -107,9 +107,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f1
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -123,9 +123,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -102,9 +102,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -86,9 +86,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f1
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -47,9 +47,9 @@ RUN apt update && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -63,9 +63,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -97,9 +97,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -81,9 +81,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f1
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -55,9 +55,9 @@ ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -71,9 +71,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -118,9 +118,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -102,9 +102,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f1
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -53,9 +53,9 @@ ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -69,9 +69,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -90,9 +90,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -74,9 +74,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f1
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -105,9 +105,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz && \
-    tar -xf v0.20.0.tar.gz && \
-    cd google-cloud-cpp-common-0.20.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
+    tar -xf v0.21.0.tar.gz && \
+    cd google-cloud-cpp-common-0.21.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -89,9 +89,9 @@ RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f1
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz && \
-    tar -xf v0.4.1.tar.gz && \
-    cd cpp-cmakefiles-0.4.1 && \
+RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz && \
+    tar -xf v0.5.0.tar.gz && \
+    cd cpp-cmakefiles-0.5.0 && \
     cmake -DBUILD_SHARED_LIBS=YES -H. -Bcmake-out && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -100,11 +100,8 @@ if ($LastExitCode) {
 
 Write-Host "Building vcpkg package versions."
 Get-Date -Format o
-$packages = @("zlib:x64-windows-static", "openssl:x64-windows-static",
-              "protobuf:x64-windows-static", "c-ares:x64-windows-static",
-              "grpc:x64-windows-static", "curl:x64-windows-static",
-              "gtest:x64-windows-static", "crc32c:x64-windows-static"
-              "benchmark:x64-windows-static", "googleapis:x64-windows-static",
+$packages = @("gtest:x64-windows-static", "benchmark:x64-windows-static",
+              "googleapis:x64-windows-static",
               "google-cloud-cpp-common[test]:x64-windows-static")
 foreach ($pkg in $packages) {
     .\vcpkg.exe install $pkg

--- a/super/external/google-cloud-cpp-common.cmake
+++ b/super/external/google-cloud-cpp-common.cmake
@@ -23,10 +23,10 @@ if (NOT TARGET google-cloud-cpp-common-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.20.0.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz"
     )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "0f5a5e03a6447d68778b331cbc43ad4e9c27a519275261c4eb7b8f15d554cba3")
+        "2e1cd2a97122a02fe3c58a997657a360e19ec9984b857197a9a193a07b4c092b")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()

--- a/super/external/googleapis.cmake
+++ b/super/external/googleapis.cmake
@@ -23,9 +23,9 @@ if (NOT TARGET googleapis-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
-        "https://github.com/googleapis/cpp-cmakefiles/archive/v0.4.1.tar.gz")
+        "https://github.com/googleapis/cpp-cmakefiles/archive/v0.5.0.tar.gz")
     set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
-        "e6368997126c8300c7b035564ada41fddd050a4c887125d5e2bd6dfbc895d65d")
+        "aa3cd3f19f16eb5d6cac8a0cd1332ebeb3774944535462fd6487949480a01c99")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
This updates the version used for the -common and googleapis
dependencies. It also removes (instead of updating) the crc32c
installations, as the library is not used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1326)
<!-- Reviewable:end -->
