### PR TITLE
ci: update builds to Python 3

### DIFF
--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -22,7 +22,8 @@ RUN dnf makecache && \
     dnf install -y abi-compliance-checker abi-dumper \
         clang clang-tools-extra cmake doxygen findutils gcc-c++ git \
         grpc-devel grpc-plugins libcxx-devel libcxxabi-devel libcurl-devel \
-        make openssl-devel pkgconfig protobuf-compiler python-pip ShellCheck \
+        make openssl-devel pkgconfig protobuf-compiler
+        python3 python3-pip ShellCheck \
         tar w3m wget zlib-devel
 
 # Install the the buildifier tool, which does not compile with the default
@@ -35,8 +36,8 @@ RUN chmod 755 /usr/bin/buildifier
 # Pin this to an specific version because the formatting changes when the
 # "latest" version is updated, and we do not want the builds to break just
 # because some third party changed something.
-RUN pip install --upgrade pip
-RUN pip install cmake_format==0.6.0
+RUN pip3 install --upgrade pip
+RUN pip3 install setuptools cmake_format==0.6.0
 
 # Download and compile googletest, we need a recent version.
 WORKDIR /var/tmp/build

--- a/ci/kokoro/Dockerfile.ubuntu
+++ b/ci/kokoro/Dockerfile.ubuntu
@@ -36,7 +36,8 @@ RUN apt-get update && \
         make \
         ninja-build \
         pkg-config \
-        python-pip \
+        python3 \
+        python3-pip \
         shellcheck \
         tar \
         unzip \
@@ -62,7 +63,7 @@ RUN chmod 755 /usr/bin/buildifier
 # "latest" version is updated, and we do not want the builds to break just
 # because some third party changed something.
 RUN pip install --upgrade pip
-RUN pip install cmake_format==0.6.0
+RUN pip3 install setuptools cmake_format==0.6.0
 
 WORKDIR /var/tmp/ci
 COPY install-bazel.sh /var/tmp/ci


### PR DESCRIPTION
Python 2.7 is EOL, and we need Python for cmake-format.

Part of the work for googleapis/google-cloud-cpp-common#194

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1332)
<!-- Reviewable:end -->
