### PR TITLE
fix: yet another Python 3 typo

### DIFF
--- a/ci/kokoro/Dockerfile.ubuntu
+++ b/ci/kokoro/Dockerfile.ubuntu
@@ -62,7 +62,7 @@ RUN chmod 755 /usr/bin/buildifier
 # Pin this to an specific version because the formatting changes when the
 # "latest" version is updated, and we do not want the builds to break just
 # because some third party changed something.
-RUN pip install --upgrade pip
+RUN pip3 install --upgrade pip
 RUN pip3 install setuptools cmake_format==0.6.0
 
 WORKDIR /var/tmp/ci


### PR DESCRIPTION
Part of the work for googleapis/google-cloud-cpp-common#194. Because the CI builds mask errors so easily, I manually rebuilt all the images associated with `ci/kokoro/docker/Dockerfile.*` files, using no caching information.  I really think we are good this time.

----
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1335)
<!-- Reviewable:end -->
