### PR TITLE
cleanup: use same clang-tidy in all repositories

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,10 @@
 #  -google-readability-namespace-comments: the *_CLIENT_NS is a macro, and
 #      clang-tidy fails to match it against the initial value.
 #
+#  -modernize-use-trailing-return-type: clang-tidy recommends using
+#      `auto Foo() -> std::string { return ...; }`, we think the code is less
+#      readable in this form.
+#
 #  -modernize-return-braced-init-list: We think removing typenames and using
 #      only braced-init can hurt readability.
 #
@@ -36,6 +40,7 @@ Checks: >
   -modernize-return-braced-init-list,
   -performance-move-const-arg,
   -readability-named-parameter,
+  -modernize-use-trailing-return-type,
   -readability-braces-around-statements,
   -readability-magic-numbers,
   -readability-redundant-declaration

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -38,9 +38,9 @@ Checks: >
   -google-runtime-references,
   -misc-non-private-member-variables-in-classes,
   -modernize-return-braced-init-list,
+  -modernize-use-trailing-return-type,
   -performance-move-const-arg,
   -readability-named-parameter,
-  -modernize-use-trailing-return-type,
   -readability-braces-around-statements,
   -readability-magic-numbers,
   -readability-redundant-declaration

--- a/ci/kokoro/Dockerfile.ubuntu
+++ b/ci/kokoro/Dockerfile.ubuntu
@@ -44,27 +44,6 @@ RUN apt-get update && \
         wget \
         zlib1g-dev
 
-# By default, Ubuntu 18.04 does not install the alternatives for clang-format
-# and clang-tidy, so we need to manually install those.
-RUN if grep -q 18.04 /etc/lsb-release; then \
-      apt-get update && apt-get install --no-install-recommends -y clang-tidy clang-format-7; \
-      update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-6.0 100; \
-      update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7 100; \
-    fi
-
-# Install the the buildifier tool, which does not compile with the default
-# golang compiler for Ubuntu 16.04 and Ubuntu 18.04.
-RUN wget -q -O /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.17.2/buildifier
-RUN chmod 755 /usr/bin/buildifier
-
-# Install cmake_format to automatically format the CMake list files.
-#     https://github.com/cheshirekow/cmake_format
-# Pin this to an specific version because the formatting changes when the
-# "latest" version is updated, and we do not want the builds to break just
-# because some third party changed something.
-RUN pip3 install --upgrade pip
-RUN pip3 install setuptools cmake_format==0.6.8
-
 WORKDIR /var/tmp/ci
 COPY install-bazel.sh /var/tmp/ci
 RUN /var/tmp/ci/install-bazel.sh

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -74,7 +74,7 @@ if [[ "${BUILD_NAME}" = "clang-tidy" ]]; then
   # Compile with clang-tidy(1) turned on. The build treats clang-tidy warnings
   # as errors.
   export DISTRO=fedora-install
-  export DISTRO_VERSION=30
+  export DISTRO_VERSION=31
   export CC=clang
   export CXX=clang++
   export BUILD_TYPE=Debug


### PR DESCRIPTION
This repository was already using the clang-tidy distributed with
Fedora:30, just changing to Fedora:31 brings it in line with other
repositories (`-common`, `-pubsub`, and `-bigquery`).

Cleanup the ubuntu Dockerfile, removing the formatting tools that we do
not use in any of the builds based on that image.

Part of the work for googleapis/google-cloud-cpp-common#204

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1340)
<!-- Reviewable:end -->
