### PR TITLE
fix: associate each `Session` with a `Channel`

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -126,6 +126,7 @@ add_library(
     internal/api_client_header.cc
     internal/api_client_header.h
     internal/build_info.h
+    internal/channel.h
     internal/compiler_info.cc
     internal/compiler_info.h
     internal/connection_impl.cc

--- a/google/cloud/spanner/internal/channel.h
+++ b/google/cloud/spanner/internal/channel.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ struct Channel {
   /// @p stub_param must not be nullptr
   explicit Channel(std::shared_ptr<SpannerStub> stub_param)
       : stub(std::move(stub_param)) {}
+
+  // This class is not copyable or movable.
+  Channel(const Channel&) = delete;
+  Channel& operator=(const Channel&) = delete;
 
   std::shared_ptr<SpannerStub> const stub;
   int session_count = 0;

--- a/google/cloud/spanner/internal/channel.h
+++ b/google/cloud/spanner/internal/channel.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_CHANNEL_H
 
 #include "google/cloud/spanner/internal/spanner_stub.h"
+#include "google/cloud/spanner/version.h"
 #include <memory>
 
 namespace google {
@@ -28,7 +29,7 @@ namespace internal {
  * `Channel` represents a single gRPC Channel/Stub.
  */
 struct Channel {
-  /// @p stub must not be nullptr
+  /// @p stub_param must not be nullptr
   explicit Channel(std::shared_ptr<SpannerStub> stub_param)
       : stub(std::move(stub_param)) {}
 

--- a/google/cloud/spanner/internal/channel.h
+++ b/google/cloud/spanner/internal/channel.h
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/spanner/internal/session.h"
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_CHANNEL_H
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_CHANNEL_H
+
+#include "google/cloud/spanner/internal/spanner_stub.h"
+#include <memory>
 
 namespace google {
 namespace cloud {
@@ -20,14 +24,22 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 
-SessionHolder MakeDissociatedSessionHolder(std::string session_name) {
-  return SessionHolder(
-      new Session(std::move(session_name), /*channel=*/nullptr),
-      std::default_delete<Session>());
-}
+/**
+ * `Channel` represents a single gRPC Channel/Stub.
+ */
+struct Channel {
+  /// @p stub must not be nullptr
+  explicit Channel(std::shared_ptr<SpannerStub> stub_param)
+      : stub(std::move(stub_param)) {}
+
+  std::shared_ptr<SpannerStub> const stub;
+  int session_count = 0;
+};
 
 }  // namespace internal
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner
 }  // namespace cloud
 }  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_CHANNEL_H

--- a/google/cloud/spanner/internal/channel.h
+++ b/google/cloud/spanner/internal/channel.h
@@ -34,8 +34,8 @@ struct Channel {
       : stub(std::move(stub_param)) {}
 
   // This class is not copyable or movable.
-  Channel(const Channel&) = delete;
-  Channel& operator=(const Channel&) = delete;
+  Channel(Channel const&) = delete;
+  Channel& operator=(Channel const&) = delete;
 
   std::shared_ptr<SpannerStub> const stub;
   int session_count = 0;

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_SESSION_H
 
 #include "google/cloud/spanner/internal/channel.h"
-#include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/version.h"
 #include <atomic>
 #include <memory>

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_SESSION_H
 #define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_SESSION_H
 
+#include "google/cloud/spanner/internal/channel.h"
 #include "google/cloud/spanner/internal/spanner_stub.h"
 #include "google/cloud/spanner/version.h"
 #include <atomic>
@@ -35,9 +36,9 @@ namespace internal {
  */
 class Session {
  public:
-  Session(std::string session_name, std::shared_ptr<SpannerStub> stub)
+  Session(std::string session_name, std::shared_ptr<Channel> channel)
       : session_name_(std::move(session_name)),
-        stub_(std::move(stub)),
+        channel_(std::move(channel)),
         is_bad_(false) {}
 
   // Not copyable or moveable.
@@ -53,11 +54,11 @@ class Session {
   bool is_bad() const { return is_bad_.load(std::memory_order_relaxed); }
 
  private:
-  friend class SessionPool;  // for access to stub()
-  std::shared_ptr<SpannerStub> stub() const { return stub_; }
+  friend class SessionPool;  // for access to channel()
+  std::shared_ptr<Channel> const& channel() const { return channel_; }
 
   std::string const session_name_;
-  std::shared_ptr<SpannerStub> const stub_;
+  std::shared_ptr<Channel> const channel_;
   std::atomic<bool> is_bad_;
 };
 

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -35,6 +35,7 @@ spanner_client_hdrs = [
     "instance_admin_connection.h",
     "internal/api_client_header.h",
     "internal/build_info.h",
+    "internal/channel.h",
     "internal/compiler_info.h",
     "internal/connection_impl.h",
     "internal/database_admin_logging.h",


### PR DESCRIPTION
Factor the `SessionPool::ChannelInfo` struct out to a stand-alone
object, so we can store a `shared_ptr` to it in each `Session`.

This allows us to properly account for `Sessions` that are marked bad or
disassociated from the pool.  Previously, the per-Channel session count
was not being decremented in those cases.

Since the `Channel` also holds a `shared_ptr<Stub>`, we can eliminate
the `Session::stub_` member.

Fixes #1344

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1346)
<!-- Reviewable:end -->
