### PR TITLE
feat: Keep track of the last time a `Session` was used

### DIFF
--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/internal/channel.h"
 #include "google/cloud/spanner/version.h"
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
@@ -38,7 +39,8 @@ class Session {
   Session(std::string session_name, std::shared_ptr<Channel> channel)
       : session_name_(std::move(session_name)),
         channel_(std::move(channel)),
-        is_bad_(false) {}
+        is_bad_(false),
+        last_use_time_(std::chrono::system_clock::now()) {}
 
   // Not copyable or moveable.
   Session(Session const&) = delete;
@@ -53,12 +55,23 @@ class Session {
   bool is_bad() const { return is_bad_.load(std::memory_order_relaxed); }
 
  private:
-  friend class SessionPool;  // for access to channel()
+  // Give `SessionPool` access to the private methods below.
+  friend class SessionPool;
   std::shared_ptr<Channel> const& channel() const { return channel_; }
+
+  // The caller is responsible for ensuring these methods are used in a
+  // thread-safe manner (i.e. using external locking).
+  std::chrono::system_clock::time_point last_use_time() const {
+    return last_use_time_;
+  }
+  void reset_last_use_time() {
+    last_use_time_ = std::chrono::system_clock::now();
+  }
 
   std::string const session_name_;
   std::shared_ptr<Channel> const channel_;
   std::atomic<bool> is_bad_;
+  std::chrono::system_clock::time_point last_use_time_;
 };
 
 /**

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -64,7 +64,7 @@ class Session {
   std::chrono::steady_clock::time_point last_use_time() const {
     return last_use_time_;
   }
-  void reset_last_use_time() {
+  void update_last_use_time() {
     last_use_time_ = std::chrono::steady_clock::now();
   }
 

--- a/google/cloud/spanner/internal/session.h
+++ b/google/cloud/spanner/internal/session.h
@@ -40,7 +40,7 @@ class Session {
       : session_name_(std::move(session_name)),
         channel_(std::move(channel)),
         is_bad_(false),
-        last_use_time_(std::chrono::system_clock::now()) {}
+        last_use_time_(std::chrono::steady_clock::now()) {}
 
   // Not copyable or moveable.
   Session(Session const&) = delete;
@@ -61,17 +61,17 @@ class Session {
 
   // The caller is responsible for ensuring these methods are used in a
   // thread-safe manner (i.e. using external locking).
-  std::chrono::system_clock::time_point last_use_time() const {
+  std::chrono::steady_clock::time_point last_use_time() const {
     return last_use_time_;
   }
   void reset_last_use_time() {
-    last_use_time_ = std::chrono::system_clock::now();
+    last_use_time_ = std::chrono::steady_clock::now();
   }
 
   std::string const session_name_;
   std::shared_ptr<Channel> const channel_;
   std::atomic<bool> is_bad_;
-  std::chrono::system_clock::time_point last_use_time_;
+  std::chrono::steady_clock::time_point last_use_time_;
 };
 
 /**

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -295,7 +295,7 @@ void SessionPool::Release(std::unique_ptr<Session> session) {
     }
     return;
   }
-  session->reset_last_use_time();
+  session->update_last_use_time();
   sessions_.push_back(std::move(session));
   if (num_waiting_for_session_ > 0) {
     lk.unlock();

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -295,6 +295,7 @@ void SessionPool::Release(std::unique_ptr<Session> session) {
     }
     return;
   }
+  session->reset_last_use_time();
   sessions_.push_back(std::move(session));
   if (num_waiting_for_session_ > 0) {
     lk.unlock();


### PR DESCRIPTION
Assume that the session was used (i.e. a RPC was made) just prior to it
being returned to the pool.

I debated doing this in `Stub()` which would be marginally more accurate,
but would require taking a lock we don't otherwise have to take. Since
our notion of "last use time" is already just an approximation of what
the backend considers "last use time" and the timeframes we care about
are measured in minutes, it didn't seem to be worthwhile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1353)
<!-- Reviewable:end -->
