### PR TITLE
ci: update googleapis for Windows+CMake builds

### DIFF
--- a/ci/kokoro/windows/build-dependencies.ps1
+++ b/ci/kokoro/windows/build-dependencies.ps1
@@ -17,6 +17,8 @@
 # Stop on errors. This is similar to `set -e` on Unix shells.
 $ErrorActionPreference = "Stop"
 
+$project_root = (Get-Item -Path ".\" -Verbose).FullName
+
 # First check the required environment variables.
 if (-not (Test-Path env:CONFIG)) {
     throw "Aborting build because the CONFIG environment variable is not set."
@@ -38,18 +40,18 @@ if (-not (Test-Path env:BUILD_CACHE)) {
 # build.
 Write-Host "Obtaining vcpkg repository."
 Get-Date -Format o
-cd ..
+Set-Location ..
 if (Test-Path vcpkg\.git) {
-    cd vcpkg
+    Set-Location vcpkg
     git pull
 } elseif (Test-Path vcpkg\installed) {
-    move vcpkg vcpkg-tmp
+    Move-Item vcpkg vcpkg-tmp
     git clone https://github.com/Microsoft/vcpkg
-    move vcpkg-tmp\installed vcpkg
-    cd vcpkg
+    Move-Item vcpkg-tmp\installed vcpkg
+    Set-Location vcpkg
 } else {
     git clone https://github.com/Microsoft/vcpkg
-    cd vcpkg
+    Set-Location vcpkg
 }
 if ($LastExitCode) {
     throw "vcpkg git setup failed with exit code $LastExitCode"
@@ -90,21 +92,24 @@ if ($LastExitCode) {
     throw "vcpkg integrate failed with exit code $LastExitCode"
 }
 
+$vcpkg_flags=@(
+    "--triplet", "x64-windows-static",
+    "--overlay-ports=${project_root}/ci/kokoro/windows/vcpkg-ports")
+
 # Remove old versions of the packages.
 Write-Host "Cleanup old vcpkg package versions."
 Get-Date -Format o
-.\vcpkg.exe remove --outdated --recurse
+.\vcpkg.exe remove ${vcpkg_flags} --outdated --recurse
 if ($LastExitCode) {
     throw "vcpkg remove --outdated failed with exit code $LastExitCode"
 }
 
 Write-Host "Building vcpkg package versions."
 Get-Date -Format o
-$packages = @("gtest:x64-windows-static", "benchmark:x64-windows-static",
-              "googleapis:x64-windows-static",
-              "google-cloud-cpp-common[test]:x64-windows-static")
+$packages = @("gtest", "benchmark", "googleapis",
+              "google-cloud-cpp-common[test]")
 foreach ($pkg in $packages) {
-    .\vcpkg.exe install $pkg
+    .\vcpkg.exe install ${vcpkg_flags} ${pkg}
     if ($LastExitCode) {
         throw "vcpkg install $pkg failed with exit code $LastExitCode"
     }

--- a/ci/kokoro/windows/vcpkg-ports/googleapis/CONTROL
+++ b/ci/kokoro/windows/vcpkg-ports/googleapis/CONTROL
@@ -1,0 +1,6 @@
+Source: googleapis
+Version: 0.6.0
+Build-Depends: grpc, protobuf
+Description: C++ Proto Libraries for Google APIs.
+Homepage: https://github.com/googleapis/cpp-cmakefiles
+Supports: !uwp

--- a/ci/kokoro/windows/vcpkg-ports/googleapis/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-ports/googleapis/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_fail_port_install(ON_TARGET "uwp")
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO googleapis/cpp-cmakefiles
+    REF v0.6.0
+    SHA512 93f3b061ad9e20b31d597f48b476c1fdef09e822e556e9253318f0d387b2d6c143920658844690c7ea710be7b157e7a1473e1e2f0fdd3bf0e3e6fcb6b69a9e9d
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+)
+
+vcpkg_install_cmake(ADD_BIN_TO_PATH)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_copy_pdbs()
+
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ci/kokoro/windows/vcpkg-ports/googleapis/portfile.cmake
+++ b/ci/kokoro/windows/vcpkg-ports/googleapis/portfile.cmake
@@ -3,17 +3,18 @@ vcpkg_fail_port_install(ON_TARGET "uwp")
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO googleapis/cpp-cmakefiles
-    REF v0.6.0
-    SHA512 93f3b061ad9e20b31d597f48b476c1fdef09e822e556e9253318f0d387b2d6c143920658844690c7ea710be7b157e7a1473e1e2f0fdd3bf0e3e6fcb6b69a9e9d
-    HEAD_REF master
-)
+    OUT_SOURCE_PATH
+    SOURCE_PATH
+    REPO
+    googleapis/cpp-cmakefiles
+    REF
+    v0.6.0
+    SHA512
+    93f3b061ad9e20b31d597f48b476c1fdef09e822e556e9253318f0d387b2d6c143920658844690c7ea710be7b157e7a1473e1e2f0fdd3bf0e3e6fcb6b69a9e9d
+    HEAD_REF
+    master)
 
-vcpkg_configure_cmake(
-    SOURCE_PATH ${SOURCE_PATH}
-    PREFER_NINJA
-)
+vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH} PREFER_NINJA)
 
 vcpkg_install_cmake(ADD_BIN_TO_PATH)
 
@@ -21,8 +22,12 @@ file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
 vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
 
 file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
-file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(
+    INSTALL ${SOURCE_PATH}/LICENSE
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+    RENAME copyright)
 
 vcpkg_copy_pdbs()
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/usage
+     DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})

--- a/ci/kokoro/windows/vcpkg-ports/googleapis/usage
+++ b/ci/kokoro/windows/vcpkg-ports/googleapis/usage
@@ -1,0 +1,6 @@
+The package googleapis is compatible with built-in CMake targets:
+
+    find_package(googleapis CONFIG REQUIRED)
+
+    # Then link against the proto libraries that you want to use, for example:
+    target_link_libraries(main PRIVATE googleapis-c++::bigtable_protos gRPC::grpc gRPC::grpc++)


### PR DESCRIPTION
Use vcpkg overlays to get the latest release of googleapis. A separate
PR will update the release on the vcpkg repository, but we want to
unblock ourselves to make progress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1354)
<!-- Reviewable:end -->
