### PR TITLE
cleanup: make use of the new Client::Commit(Mutations) overload

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -523,9 +523,8 @@ class ExperimentImpl {
       if (!force && current_mutations < 1000) {
         return {};
       }
-      auto m = std::move(mutation).Build();
-      auto result = client.Commit(
-          [&m](spanner::Transaction const&) { return spanner::Mutations{m}; });
+      auto result =
+          client.Commit(spanner::Mutations{std::move(mutation).Build()});
       if (!result) {
         std::lock_guard<std::mutex> lk(mu_);
         std::cout << "# Error in Commit() " << result.status() << "\n";
@@ -1505,13 +1504,10 @@ class MutationExperiment : public Experiment {
 
       int row_count = 0;
       auto commit_result =
-          client.Commit([&](spanner::Transaction const&)
-                            -> google::cloud::StatusOr<spanner::Mutations> {
-            return spanner::Mutations{spanner::MakeInsertOrUpdateMutation(
-                table_name_, column_names, key, values[0], values[1], values[2],
-                values[3], values[4], values[5], values[6], values[7],
-                values[8], values[9])};
-          });
+          client.Commit(spanner::Mutations{spanner::MakeInsertOrUpdateMutation(
+              table_name_, column_names, key, values[0], values[1], values[2],
+              values[3], values[4], values[5], values[6], values[7], values[8],
+              values[9])});
       timer.Stop();
       samples.push_back(RowCpuSample{
           client_count, thread_count, false, row_count, timer.elapsed_time(),

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -185,9 +185,8 @@ void FillTableTask(Config const& config, spanner::Client client, std::mutex& mu,
     if (!force && current_mutations < 1000) {
       return;
     }
-    auto m = std::move(mutation).Build();
-    auto result = client.Commit(
-        [&m](spanner::Transaction const&) { return spanner::Mutations{m}; });
+    auto result =
+        client.Commit(spanner::Mutations{std::move(mutation).Build()});
     if (!result) {
       std::lock_guard<std::mutex> lk(mu);
       std::cerr << "# Error in Commit() " << result.status() << "\n";
@@ -319,10 +318,9 @@ class InsertOrUpdateExperiment : public Experiment {
               deadline = start + config.iteration_duration;
          start < deadline; start = std::chrono::steady_clock::now()) {
       auto key = key_generator();
-      auto m = spanner::MakeInsertOrUpdateMutation("KeyValue", {"Key", "Data"},
-                                                   key, value);
-      auto result = client.Commit(
-          [&m](spanner::Transaction const&) { return spanner::Mutations{m}; });
+      auto result =
+          client.Commit(spanner::Mutations{spanner::MakeInsertOrUpdateMutation(
+              "KeyValue", {"Key", "Data"}, key, value)});
       if (!result) {
         errors.push_back(std::move(result).status());
       }

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -85,13 +85,11 @@ TEST(ClientSqlStressTest, UpsertAndSelect) {
       auto action = static_cast<Action>(random_action(generator));
 
       if (action == kInsert) {
-        auto commit = client.Commit(
-            [key](Transaction const&) -> StatusOr<spanner::Mutations> {
-              auto s = std::to_string(key);
-              return Mutations{spanner::MakeInsertOrUpdateMutation(
-                  "Singers", {"SingerId", "FirstName", "LastName"}, key,
-                  "fname-" + s, "lname-" + s)};
-            });
+        auto s = std::to_string(key);
+        auto commit =
+            client.Commit(Mutations{spanner::MakeInsertOrUpdateMutation(
+                "Singers", {"SingerId", "FirstName", "LastName"}, key,
+                "fname-" + s, "lname-" + s)});
         result.Update(commit.status());
       } else {
         auto size = random_limit(generator);
@@ -152,13 +150,11 @@ TEST(ClientStressTest, UpsertAndRead) {
       auto action = static_cast<Action>(random_action(generator));
 
       if (action == kInsert) {
-        auto commit = client.Commit(
-            [key](Transaction const&) -> StatusOr<spanner::Mutations> {
-              auto s = std::to_string(key);
-              return Mutations{spanner::MakeInsertOrUpdateMutation(
-                  "Singers", {"SingerId", "FirstName", "LastName"}, key,
-                  "fname-" + s, "lname-" + s)};
-            });
+        auto s = std::to_string(key);
+        auto commit =
+            client.Commit(Mutations{spanner::MakeInsertOrUpdateMutation(
+                "Singers", {"SingerId", "FirstName", "LastName"}, key,
+                "fname-" + s, "lname-" + s)});
         result.Update(commit.status());
       } else {
         auto size = random_limit(generator);

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -751,10 +751,8 @@ void InsertData(google::cloud::spanner::Client client) {
                            .EmplaceRow(2, 3, "Terrified")
                            .Build();
 
-  auto commit_result = client.Commit(
-      [&insert_singers, &insert_albums](spanner::Transaction const&) {
-        return spanner::Mutations{insert_singers, insert_albums};
-      });
+  auto commit_result =
+      client.Commit(spanner::Mutations{insert_singers, insert_albums});
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());
   }
@@ -765,14 +763,12 @@ void InsertData(google::cloud::spanner::Client client) {
 //! [update-mutation-builder] [START spanner_update_data]
 void UpdateData(google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
-  auto commit_result = client.Commit([](spanner::Transaction const&) {
-    return spanner::Mutations{
-        spanner::UpdateMutationBuilder(
-            "Albums", {"SingerId", "AlbumId", "MarketingBudget"})
-            .EmplaceRow(1, 1, 100000)
-            .EmplaceRow(2, 2, 500000)
-            .Build()};
-  });
+  auto commit_result = client.Commit(spanner::Mutations{
+      spanner::UpdateMutationBuilder("Albums",
+                                     {"SingerId", "AlbumId", "MarketingBudget"})
+          .EmplaceRow(1, 1, 100000)
+          .EmplaceRow(2, 2, 500000)
+          .Build()});
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());
   }
@@ -800,10 +796,8 @@ void DeleteData(google::cloud::spanner::Client client) {
                                                 spanner::MakeKeyBoundClosed(5)))
           .Build();
 
-  auto commit_result = client.Commit(
-      [&delete_albums, &delete_singers](spanner::Transaction const&) {
-        return spanner::Mutations{delete_albums, delete_singers};
-      });
+  auto commit_result =
+      client.Commit(spanner::Mutations{delete_albums, delete_singers});
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());
   }
@@ -814,19 +808,17 @@ void DeleteData(google::cloud::spanner::Client client) {
 // [START spanner_insert_data_with_timestamp_column]
 void InsertDataWithTimestamp(google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
-  auto commit_result = client.Commit([](spanner::Transaction const&) {
-    return spanner::Mutations{
-        spanner::InsertOrUpdateMutationBuilder(
-            "Performances",
-            {"SingerId", "VenueId", "EventDate", "Revenue", "LastUpdateTime"})
-            .EmplaceRow(1, 4, spanner::Date(2017, 10, 5), 11000,
-                        spanner::CommitTimestamp{})
-            .EmplaceRow(1, 19, spanner::Date(2017, 11, 2), 15000,
-                        spanner::CommitTimestamp{})
-            .EmplaceRow(2, 42, spanner::Date(2017, 12, 23), 7000,
-                        spanner::CommitTimestamp{})
-            .Build()};
-  });
+  auto commit_result = client.Commit(spanner::Mutations{
+      spanner::InsertOrUpdateMutationBuilder(
+          "Performances",
+          {"SingerId", "VenueId", "EventDate", "Revenue", "LastUpdateTime"})
+          .EmplaceRow(1, 4, spanner::Date(2017, 10, 5), 11000,
+                      spanner::CommitTimestamp{})
+          .EmplaceRow(1, 19, spanner::Date(2017, 11, 2), 15000,
+                      spanner::CommitTimestamp{})
+          .EmplaceRow(2, 42, spanner::Date(2017, 12, 23), 7000,
+                      spanner::CommitTimestamp{})
+          .Build()});
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());
   }
@@ -838,15 +830,13 @@ void InsertDataWithTimestamp(google::cloud::spanner::Client client) {
 // [START spanner_update_data_with_timestamp_column]
 void UpdateDataWithTimestamp(google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
-  auto commit_result = client.Commit([](spanner::Transaction const&) {
-    return spanner::Mutations{
-        spanner::UpdateMutationBuilder(
-            "Albums",
-            {"SingerId", "AlbumId", "MarketingBudget", "LastUpdateTime"})
-            .EmplaceRow(1, 1, 1000000, spanner::CommitTimestamp{})
-            .EmplaceRow(2, 2, 750000, spanner::CommitTimestamp{})
-            .Build()};
-  });
+  auto commit_result = client.Commit(spanner::Mutations{
+      spanner::UpdateMutationBuilder(
+          "Albums",
+          {"SingerId", "AlbumId", "MarketingBudget", "LastUpdateTime"})
+          .EmplaceRow(1, 1, 1000000, spanner::CommitTimestamp{})
+          .EmplaceRow(2, 2, 750000, spanner::CommitTimestamp{})
+          .Build()});
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());
   }
@@ -1348,16 +1338,14 @@ void DmlStructs(google::cloud::spanner::Client client) {
 //! [START spanner_write_data_for_struct_queries]
 void WriteDataForStructQueries(google::cloud::spanner::Client client) {
   namespace spanner = ::google::cloud::spanner;
-  auto commit_result = client.Commit([](spanner::Transaction const&) {
-    return spanner::Mutations{
-        spanner::InsertMutationBuilder("Singers",
-                                       {"SingerId", "FirstName", "LastName"})
-            .EmplaceRow(6, "Elena", "Campbell")
-            .EmplaceRow(7, "Gabriel", "Wright")
-            .EmplaceRow(8, "Benjamin", "Martinez")
-            .EmplaceRow(9, "Hannah", "Harris")
-            .Build()};
-  });
+  auto commit_result = client.Commit(
+      spanner::Mutations{spanner::InsertMutationBuilder(
+                             "Singers", {"SingerId", "FirstName", "LastName"})
+                             .EmplaceRow(6, "Elena", "Campbell")
+                             .EmplaceRow(7, "Gabriel", "Wright")
+                             .EmplaceRow(8, "Benjamin", "Martinez")
+                             .EmplaceRow(9, "Hannah", "Harris")
+                             .Build()});
   if (!commit_result) {
     throw std::runtime_error(commit_result.status().message());
   }


### PR DESCRIPTION
Use the new `Commit()` helper whenever the mutator ignores the
passed `Transaction` and simply returns a `Mutations` value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1359)
<!-- Reviewable:end -->
