### PR TITLE
testing: add RUNS_PER_TEST environment variable

### DIFF
--- a/ci/kokoro/docker/build-in-docker-bazel.sh
+++ b/ci/kokoro/docker/build-in-docker-bazel.sh
@@ -50,6 +50,10 @@ readonly BAZEL_BIN="/usr/local/bin/bazel"
 echo "Using Bazel in ${BAZEL_BIN}"
 
 bazel_args=("--test_output=errors" "--verbose_failures=true" "--keep_going")
+if [[ -n "${RUNS_PER_TEST}" ]]; then
+    bazel_args+=("--runs_per_test=${RUNS_PER_TEST}")
+fi
+
 if [[ -n "${BAZEL_CONFIG}" ]]; then
     bazel_args+=(--config "${BAZEL_CONFIG}")
 fi

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -94,6 +94,11 @@ if [[ "${BUILD_TYPE}" == "Coverage" ]]; then
 fi
 readonly TEST_JOB_COUNT
 
+ctest_args=("--output-on-failure" "-j" "${TEST_JOB_COUNT}")
+if [[ -n "${RUNS_PER_TEST}" ]]; then
+    ctest_args+=("--repeat-until-fail" "${RUNS_PER_TEST}")
+fi
+
 # When user a super-build the tests are hidden in a subdirectory. We can tell
 # that ${BINARY_DIR} does not have the tests by checking for this file:
 if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
@@ -102,7 +107,7 @@ if [[ -r "${BINARY_DIR}/CTestTestfile.cmake" ]]; then
   # automatically runs them.
   echo "Running the unit tests $(date)"
   env -C "${BINARY_DIR}" ctest \
-      -LE integration-tests --output-on-failure -j "${TEST_JOB_COUNT}"
+      -LE integration-tests "${ctest_args[@]}"
   echo "================================================================"
 fi
 
@@ -122,7 +127,7 @@ if [[ "${RUN_INTEGRATION_TESTS}" == "yes" || \
 
   # Run the integration tests too.
   env -C "${BINARY_DIR}" ctest \
-      -L integration-tests --output-on-failure -j "${TEST_JOB_COUNT}"
+      -L integration-tests "${ctest_args[@]}"
   echo "================================================================"
 fi
 

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -372,7 +372,8 @@ docker_flags=(
     # baseline.
     "--env" "UPDATE_API=${UPDATE_API:-}"
 
-    # If set, add a flag --runs_per_test=<value> to bazel
+    # If set, add a flag --runs_per_test=<value> to bazel or --repeat-until-fail
+    # to ctest.
     "--env" "RUNS_PER_TEST=${RUNS_PER_TEST:-}"
 
     # Tells scripts whether they are running as part of a CI or not.

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -372,6 +372,9 @@ docker_flags=(
     # baseline.
     "--env" "UPDATE_API=${UPDATE_API:-}"
 
+    # If set, add a flag --runs_per_test=<value> to bazel
+    "--env" "RUNS_PER_TEST=${RUNS_PER_TEST:-}"
+
     # Tells scripts whether they are running as part of a CI or not.
     "--env" "RUNNING_CI=${RUNNING_CI:-no}"
 


### PR DESCRIPTION
Introducing a new environment variable `RUNS_PER_TEST` for the build script. This is only useful for linux based builds for now, and probably only useful for unit tests.

Example usage:

```bash
RUNS_PER_TEST=10 RUN_INTEGRATION_TESTS=no ci/kokoro/docker/build.sh integration
```

Then bazel or ctest will run each tests 10 times. This is useful when you have flaky unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1360)
<!-- Reviewable:end -->
