### PR TITLE
feat: Value streaming respects io manipulators

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -96,21 +96,20 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
 
   switch (t.code()) {
     case google::spanner::v1::BOOL:
-      return os << (v.bool_value() ? "TRUE" : "FALSE");
+      return os << v.bool_value();
 
-    case google::spanner::v1::TIMESTAMP:
-    case google::spanner::v1::DATE:
     case google::spanner::v1::INT64:
-      return os << v.string_value();
+      return os << internal::FromProto(t, v).get<std::int64_t>().value();
 
     case google::spanner::v1::FLOAT64:
-      if (v.kind_case() == google::protobuf::Value::kStringValue) {
-        return os << v.string_value();
-      }
-      return os << v.number_value();
+      return os << internal::FromProto(t, v).get<double>().value();
 
     case google::spanner::v1::STRING:
       return os << "\"" << v.string_value() << "\"";
+
+    case google::spanner::v1::TIMESTAMP:
+    case google::spanner::v1::DATE:
+      return os << v.string_value();
 
     case google::spanner::v1::BYTES:
       return os
@@ -144,10 +143,8 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
       return os << ')';
     }
 
-    case google::spanner::v1::TYPE_CODE_UNSPECIFIED:
-    case google::spanner::v1::TypeCode_INT_MIN_SENTINEL_DO_NOT_USE_:
-    case google::spanner::v1::TypeCode_INT_MAX_SENTINEL_DO_NOT_USE_:
-      break;
+    default:
+      return os << "Error: unknown value type code " << t.code();
   }
   return os;
 }

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -302,7 +302,8 @@ class Value {
       if (IsOptional<T>::value) return T{};
       return Status(StatusCode::kUnknown, "null value");
     }
-    return GetValue(T{}, std::move(value_), type_);
+    auto tag = T{};  // Works around an odd msvc issue
+    return GetValue(std::move(tag), std::move(value_), type_);
   }
 
   /**

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -994,6 +994,7 @@ TEST(Value, OutputStream) {
       {Value(std::vector<std::int64_t>{10, 11}), "[10, 11]", normal},
       {Value(std::vector<std::int64_t>{10, 11}), "[a, b]", hex},
       {Value(std::vector<double>{1.0, 2.0}), "[1, 2]", normal},
+      {Value(std::vector<double>{1.0, 2.0}), "[1.000, 2.000]", float4},
       {Value(std::vector<std::string>{"a", "b"}), R"(["a", "b"])", normal},
       {Value(std::vector<Bytes>{2}), R"([B"", B""])", normal},
       {Value(std::vector<Date>{2}), "[1970-01-01, 1970-01-01]", normal},


### PR DESCRIPTION
This PR changes the `Value` `op<<` operator for the types `bool`,
`int64_t`, and `double` so that they print by default as they would as
normal C++ types. This also enables them to work with C++ IO stream
manipulators. For example, this change makes the following work:

```cc
std::cout << std::hex << Value(42);  // Output: 2a
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1362)
<!-- Reviewable:end -->
