### PR TITLE
ci: copy windows build scripts from -common

### DIFF
--- a/ci/kokoro/windows/bazel-presubmit.cfg
+++ b/ci/kokoro/windows/bazel-presubmit.cfg
@@ -1,0 +1,1 @@
+build_file: "google-cloud-cpp-spanner/ci/kokoro/windows/build-new.bat"

--- a/ci/kokoro/windows/bazel.cfg
+++ b/ci/kokoro/windows/bazel.cfg
@@ -1,0 +1,1 @@
+build_file: "google-cloud-cpp-spanner/ci/kokoro/windows/build-new.bat"

--- a/ci/kokoro/windows/build-bazel-dependencies.ps1
+++ b/ci/kokoro/windows/build-bazel-dependencies.ps1
@@ -1,0 +1,16 @@
+# !/usr/bin/env powershell
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) No dependencies required for Bazel builds."

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -1,0 +1,81 @@
+# !/usr/bin/env powershell
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stop on errors. This is similar to `set -e` on Unix shells.
+$ErrorActionPreference = "Stop"
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Capture Bazel information for troubleshooting"
+bazel version
+
+$common_flags = @()
+# Create output directory for Bazel. Bazel creates really long paths,
+# sometimes exceeding the Windows limits. Using a short name for the
+# root of the Bazel output directory works around this problem.
+$bazel_root="C:\b"
+if (-not (Test-Path $bazel_root)) {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Create bazel user root (${bazel_root})"
+    New-Item -ItemType Directory -Path $bazel_root | Out-Null
+}
+$common_flags += ("--output_user_root=${bazel_root}")
+
+$test_flags = @("--test_output=errors",
+                "--verbose_failures=true",
+                "--keep_going")
+$build_flags = @("--keep_going")
+
+$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
+
+1..3 | % {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Fetch dependencies [$_]"
+    bazel $common_flags fetch -- //google/cloud/...:all
+    if ($LastExitCode -eq 0) {
+        return
+    }
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling and running unit tests"
+bazel $common_flags test $test_flags `
+  --test_tag_filters=-integration-tests `
+  -- //google/cloud/...:all
+if ($LastExitCode) {
+    throw "bazel test failed with exit code $LastExitCode"
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling extra programs"
+bazel $common_flags build $build_flags -- //google/cloud/...:all
+if ($LastExitCode) {
+    throw "bazel test failed with exit code $LastExitCode"
+}
+
+if ((Test-Path env:RUN_INTEGRATION_TESTS) -and ($env:RUN_INTEGRATION_TESTS -eq "true")) {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running integration tests $env:CONFIG"
+    $integration_flags=@(
+        "--test_env", "GOOGLE_CLOUD_PROJECT=${env:GOOGLE_CLOUD_PROJECT}",
+        "--test_env", "GOOGLE_APPLICATION_CREDENTIALS=${env:GOOGLE_APPLICATION_CREDENTIALS}",
+        "--test_env", "RUN_SLOW_INTEGRATION_TESTS=${env:RUN_SLOW_INTEGRATION_TESTS}",
+        "--test_env", "GOOGLE_CLOUD_CPP_SPANNER_INSTANCE=${env:GOOGLE_CLOUD_CPP_SPANNER_INSTANCE}",
+        "--test_env", "GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA=${env:GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA}",
+        "--test_env", "GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=${env:GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}",
+        "--test_env", "GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES=yes"
+    )
+    bazel $common_flags test $test_flags $integration_flags `
+      --test_tag_filters=integration-tests `
+      -- //google/cloud/...:all
+    if ($LastExitCode) {
+        throw "Integration tests failed with exit code $LastExitCode"
+    }
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DONE"

--- a/ci/kokoro/windows/build-cmake-dependencies.ps1
+++ b/ci/kokoro/windows/build-cmake-dependencies.ps1
@@ -1,0 +1,125 @@
+# !/usr/bin/env powershell
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stop on errors. This is similar to `set -e` on Unix shells.
+$ErrorActionPreference = "Stop"
+
+# First check the required environment variables.
+if (-not (Test-Path env:CONFIG)) {
+    throw "Aborting build because the CONFIG environment variable is not set."
+}
+$CONFIG = $env:CONFIG
+
+$project_root = (Get-Item -Path ".\" -Verbose).FullName
+
+# Update or clone the 'vcpkg' package manager, this is a bit overly complicated,
+# but it works well on your workstation where you may want to run this script
+# multiple times while debugging vcpkg installs.  It also works on AppVeyor
+# where we cache the vcpkg installation, but it might be empty on the first
+# build.
+Set-Location ..
+if (Test-Path env:RUNNING_CI) {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cloning vcpkg repository."
+    if (Test-Path "vcpkg") {
+        Remove-Item -LiteralPath "vcpkg" -Force -Recurse
+    }
+    git clone --depth 10 https://github.com/Microsoft/vcpkg.git
+    if ($LastExitCode) {
+      throw "vcpkg git setup failed with exit code $LastExitCode"
+    }
+}
+if (-not (Test-Path "vcpkg")) {
+    throw "Missing vcpkg directory."
+}
+Set-Location vcpkg
+
+# If BUILD_CACHE is set (which typically is on Kokoro builds), try
+# to download and extract the build cache.
+if (Test-Path env:BUILD_CACHE) {
+    gcloud auth activate-service-account --key-file "${env:KOKORO_GFILE_DIR}/build-results-service-account.json"
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Downloading build cache."
+    gsutil cp $env:BUILD_CACHE vcpkg-installed.zip
+    if ($LastExitCode) {
+        # Ignore errors, caching failures should not break the build.
+        Write-Host "gsutil download failed with exit code $LastExitCode"
+    }
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Extracting build cache."
+    7z x vcpkg-installed.zip -aoa
+    if ($LastExitCode) {
+        # Ignore errors, caching failures should not break the build.
+        Write-Host "extracting build cache failed with exit code $LastExitCode"
+    }
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Bootstrap vcpkg."
+powershell -exec bypass scripts\bootstrap.ps1
+if ($LastExitCode) {
+  throw "Error bootstrapping vcpkg: $LastExitCode"
+  Write-Host -ForegroundColor Red "bootstrap[1] failed"
+}
+
+# Only compile the release version of the packages we need, for Debug builds
+# this trick does not work, so we need to compile all versions (yuck).
+if ($CONFIG -eq "Release") {
+#    Add-Content triplets\x64-windows-static.cmake "set(VCPKG_BUILD_TYPE release)"
+}
+
+# Integrate installed packages into the build environment.
+.\vcpkg.exe integrate install
+if ($LastExitCode) {
+    throw "vcpkg integrate failed with exit code $LastExitCode"
+}
+
+$vcpkg_flags=@(
+    "--triplet", "${env:VCPKG_TRIPLET}",
+    "--overlay-ports=${project_root}/ci/kokoro/windows/vcpkg-ports")
+
+# Remove old versions of the packages.
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Cleanup old vcpkg package versions."
+.\vcpkg.exe remove ${vcpkg_flags} --outdated --recurse
+if ($LastExitCode) {
+    throw "vcpkg remove --outdated failed with exit code $LastExitCode"
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Building vcpkg package versions."
+$packages = @("zlib", "openssl",
+              "protobuf", "c-ares", "benchmark",
+              "grpc", "gtest", "crc32c", "curl",
+              "googleapis", "google-cloud-cpp-common[test]")
+foreach ($pkg in $packages) {
+    .\vcpkg.exe install ${vcpkg_flags} "${pkg}"
+    if ($LastExitCode) {
+        throw "vcpkg install $pkg failed with exit code $LastExitCode"
+    }
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) vcpkg list"
+.\vcpkg.exe list
+
+if (Test-Path env:BUILD_CACHE) {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Create cache zip file."
+    7z a vcpkg-installed.zip installed\
+    if ($LastExitCode) {
+        # Ignore errors, caching failures should not break the build.
+        Write-Host "zip build cache failed with exit code $LastExitCode"
+    }
+
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Upload cache zip file."
+    gsutil cp vcpkg-installed.zip $env:BUILD_CACHE
+    if ($LastExitCode) {
+        # Ignore errors, caching failures should not break the build.
+        Write-Host "gsutil upload failed with exit code $LastExitCode"
+    }
+}

--- a/ci/kokoro/windows/build-cmake.ps1
+++ b/ci/kokoro/windows/build-cmake.ps1
@@ -1,0 +1,74 @@
+# !/usr/bin/env powershell
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stop on errors. This is similar to `set -e` on Unix shells.
+$ErrorActionPreference = "Stop"
+
+# First check the required environment variables.
+if (-not (Test-Path env:CONFIG)) {
+    throw "Aborting build because the CONFIG environment variable is not set."
+}
+
+# By default assume "module", use the configuration parameters and build in the `cmake-out` directory.
+$cmake_flags=@("-G$env:GENERATOR", "-DCMAKE_BUILD_TYPE=$env:CONFIG", "-H.", "-Bcmake-out")
+
+# This script expects vcpkg to be installed in ..\vcpkg, discover the full
+# path to that directory:
+$dir = Split-Path (Get-Item -Path ".\" -Verbose).FullName
+
+# Setup the environment for vcpkg:
+$cmake_flags += "-DCMAKE_TOOLCHAIN_FILE=`"$dir\vcpkg\scripts\buildsystems\vcpkg.cmake`""
+$cmake_flags += "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TRIPLET"
+$cmake_flags += "-DCMAKE_C_COMPILER=cl.exe"
+$cmake_flags += "-DCMAKE_CXX_COMPILER=cl.exe"
+
+# Configure CMake and create the build directory.
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Configuring CMake with $cmake_flags"
+cmake $cmake_flags
+if ($LastExitCode) {
+    throw "cmake config failed with exit code $LastExitCode"
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Compiling with CMake $env:CONFIG"
+cmake --build cmake-out --config $env:CONFIG
+if ($LastExitCode) {
+    throw "cmake for 'all' target failed with exit code $LastExitCode"
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running unit tests $env:CONFIG"
+Set-Location cmake-out
+if (Test-Path env:RUNNING_CI) {
+    # On Kokoro we need to define %TEMP% or the tests do not have a valid directory for
+    # temporary files.
+    $env:TEMP="T:\tmp"
+}
+
+# Get the number of processors to parallelize the tests
+$NCPU=(Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
+
+ctest --output-on-failure -LE integration-tests -C $env:CONFIG -j ${NCPU}
+if ($LastExitCode) {
+    throw "ctest failed with exit code $LastExitCode"
+}
+
+if ((Test-Path env:RUN_INTEGRATION_TESTS) -and ($env:RUN_INTEGRATION_TESTS -eq "true")) {
+    Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running integration tests $env:CONFIG"
+    ctest --output-on-failure -L integration-tests -j ${NCPU}
+    if ($LastExitCode) {
+        throw "Integration tests failed with exit code $LastExitCode"
+    }
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) DONE"

--- a/ci/kokoro/windows/build-new.bat
+++ b/ci/kokoro/windows/build-new.bat
@@ -1,0 +1,38 @@
+@REM Copyright 2020 Google LLC
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+
+REM Install Bazel using Chocolatey.
+choco install -y bazel --version 2.0.0
+
+REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
+call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+REM The remaining of the build script is implemented in PowerShell.
+echo %date% %time%
+cd github\google-cloud-cpp-spanner
+powershell -exec bypass ci\kokoro\windows\build.ps1
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+@REM Kokoro rsyncs all the files in the %KOKORO_ARTIFACTS_DIR%, which takes a
+@REM long time. The recommended workaround is to remove all the files that are
+@REM not interesting artifacts.
+if defined KOKORO_ARTIFACTS_DIR (
+  @echo %date% %time% "Cleanup Kokoro artifacts directory"
+  cd "%KOKORO_ARTIFACTS_DIR%"
+  powershell -Command "& {Get-ChildItem -Recurse -File -Exclude test.xml,sponge_log.xml,build.bat | Remove-Item -Recurse -Force}"
+  if %errorlevel% neq 0 exit /b %errorlevel%
+)
+
+@echo DONE "============================================="
+@echo %date% %time%

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -1,0 +1,91 @@
+# !/usr/bin/env powershell
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stop on errors. This is similar to `set -e` on Unix shells.
+$ErrorActionPreference = "Stop"
+
+$BuildName = ""
+if ($args.count -eq 1) {
+    $BuildName = $args[0]
+} elseif (Test-Path env:KOKORO_JOB_NAME) {
+    # Kokoro injects the KOKORO_JOB_NAME environment variable, the value of this
+    # variable is cloud-cpp/common/<config-file-name-without-cfg> (or more
+    # generally <path/to/config-file-without-cfg>). By convention we name these
+    # files `$foo.cfg` for continuous builds and `$foo-presubmit.cfg` for
+    # presubmit builds. Here we extract the value of "foo" and use it as the build
+    # name.
+    $BuildName = Split-Path -Path $env:KOKORO_JOB_NAME -Leaf
+    $BuildName = $BuildName -replace "-presubmit",""
+
+    # This is passed into the environment of the docker build and its scripts to
+    # tell them if they are running as part of a CI build rather than just a
+    # human invocation of "build.sh <build-name>". This allows scripts to be
+    # strict when run in a CI, but a little more friendly when run by a human.
+    $env:RUNNING_CI = "yes"
+} else {
+    throw @"
+Aborting build as the build name is not defined.
+If you are invoking this script via the command line use:
+
+$PSCommandPath <build-name>
+
+If this script is invoked by Kokoro, the CI system is expected to set
+the KOKORO_JOB_NAME environment variable.
+"@
+}
+
+if (Test-Path env:KOKORO_GFILE_DIR) {
+    $config_file = "${env:KOKORO_GFILE_DIR}/spanner-integration-tests-config.ps1"
+    if (Test-Path "${config_file}") {
+        Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Loading integration tests config"
+        . "${config_file}"
+        ${env:GOOGLE_APPLICATION_CREDENTIALS}="${env:KOKORO_GFILE_DIR}/spanner-credentials.json"
+        ${env:GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES}="yes"
+        (New-Object System.Net.WebClient).Downloadfile(
+            'https://raw.githubusercontent.com/grpc/grpc/master/etc/roots.pem',
+             "${env:KOKORO_GFILE_DIR}/roots.pem")
+        ${env:GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}="${env:KOKORO_GFILE_DIR}/roots.pem"
+        ${env:RUN_INTEGRATION_TESTS}="true"
+    }
+}
+
+if (($BuildName -eq "cmake") -or ($BuildName -eq "cmake-new")) {
+    $env:CONFIG = "Release"
+    $env:GENERATOR = "Ninja"
+    $env:VCPKG_TRIPLET = "x64-windows-static"
+    $DependencyScript = "build-cmake-dependencies.ps1"
+    $BuildScript = "build-cmake.ps1"
+} elseif ($BuildName -eq "bazel") {
+    $DependencyScript = "build-bazel-dependencies.ps1"
+    $BuildScript = "build-bazel.ps1"
+}
+
+$ScriptLocation = Split-Path $PSCommandPath -Parent
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Building dependencies for $BuildName build"
+powershell -exec bypass "${ScriptLocation}/${DependencyScript}"
+if ($LastExitCode) {
+    throw "Building dependencies failed with exit code $LastExitCode"
+}
+
+Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Running build script for $BuildName build"
+powershell -exec bypass "${ScriptLocation}/${BuildScript}"
+# Save the build exit code, we want to delete the artifacts
+# even if the build fails.
+$BuildExitCode = $LastExitCode
+
+if ($BuildExitCode) {
+    throw "Build failed with exit code $LastExitCode"
+}

--- a/ci/kokoro/windows/cmake-new-presubmit.cfg
+++ b/ci/kokoro/windows/cmake-new-presubmit.cfg
@@ -1,0 +1,1 @@
+build_file: "google-cloud-cpp-spanner/ci/kokoro/windows/build-new.bat"

--- a/ci/kokoro/windows/cmake-new.cfg
+++ b/ci/kokoro/windows/cmake-new.cfg
@@ -1,0 +1,1 @@
+build_file: "google-cloud-cpp-spanner/ci/kokoro/windows/build-new.bat"


### PR DESCRIPTION
This is part of the work to have uniform build scripts for Windows
across all the repositories. In this step I copied the build scripts
from -common, and tweak them to build this repository. When there was a
confiict with an existing file I named the new file `-new`. We will need
a few more changes, one to configure Kokoro to use the new
scripts, another to delete the old scripts / replace them with the new
ones, then configure Kokoro to stop using the `-new` placeholders, and
then remove the placeholders.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1367)
<!-- Reviewable:end -->
