### PR TITLE
ci: actually use Bazel 2.0 in the build

### DIFF
--- a/ci/kokoro/windows/build-new.bat
+++ b/ci/kokoro/windows/build-new.bat
@@ -15,6 +15,10 @@
 REM Install Bazel using Chocolatey.
 choco install -y bazel --version 2.0.0
 
+REM Change PATH to use chocolatey's version of Bazel
+set PATH=C:\ProgramData\chocolatey\bin;%PATH%
+bazel version
+
 REM Configure the environment to use MSVC 2019 and then switch to PowerShell.
 call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 


### PR DESCRIPTION
Part of the work for googleapis/google-cloud-cpp-common#231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1369)
<!-- Reviewable:end -->
