### PR TITLE
feat: escape non-printable bytes in Value::op<<

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -126,7 +126,7 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
           // formatting on `os` for other streaming operations.
           std::array<char, sizeof(R"(\000)")> buf;
           auto n = std::snprintf(&buf[0], buf.size(), R"(\%03o)", byte);
-          if (n == buf.size() - 1) os << buf.data();
+          if (n == static_cast<int>(buf.size() - 1)) os << buf.data();
         }
       }
       return os << R"(")";

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -125,7 +125,7 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
           // This uses snprintf rather than iomanip so we don't mess up the
           // formatting on `os` for other streaming operations.
           std::array<char, sizeof(R"(\000)")> buf;
-          auto n = std::snprintf(&buf[0], buf.size(), R"(\%03o)", byte);
+          auto n = std::snprintf(buf.data(), buf.size(), R"(\%03o)", byte);
           if (n == static_cast<int>(buf.size() - 1)) os << buf.data();
         }
       }

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -119,7 +119,7 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
                              ->get<std::vector<unsigned char>>();
       os << R"(B")";
       for (auto const byte : bytes) {
-        if (std::isprint(byte) != 0) {
+        if (std::isprint(byte)) {
           os << byte;
         } else {
           // This uses snprintf rather than iomanip so we don't mess up the

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -119,14 +119,20 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
                              ->get<std::vector<unsigned char>>();
       os << R"(B")";
       for (auto const byte : bytes) {
-        if (std::isprint(byte)) {
+        if (byte == '"') {
+          os << R"(\")";
+        } else if (std::isprint(byte)) {
           os << byte;
         } else {
           // This uses snprintf rather than iomanip so we don't mess up the
           // formatting on `os` for other streaming operations.
           std::array<char, sizeof(R"(\000)")> buf;
           auto n = std::snprintf(buf.data(), buf.size(), R"(\%03o)", byte);
-          if (n == static_cast<int>(buf.size() - 1)) os << buf.data();
+          if (n == static_cast<int>(buf.size() - 1)) {
+            os << buf.data();
+          } else {
+            os << R"(\?)";
+          }
         }
       }
       return os << R"(")";

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -988,6 +988,18 @@ TEST(Value, OutputStream) {
       {MakeNullValue<Date>(), "NULL", normal},
       {MakeNullValue<Timestamp>(), "NULL", normal},
 
+      // Tests escaping of bytes
+      {Value(Bytes(std::string("ab\tZ"))), R"(B"ab\011Z")", normal},
+      {Value(Bytes(std::string("ab\tZ"))), R"(B"ab\011Z")", hex},
+      {Value(Bytes(std::string("ab\001Z\0211"))), R"(B"ab\001Z\0211")", normal},
+      {Value(Bytes(std::string("ab\001Z\0211"))), R"(B"ab\001Z\0211")", hex},
+      {Value(Bytes(std::string(3, '\0'))), R"(B"\000\000\000")", normal},
+      {Value(Bytes(std::string(3, '\0'))), R"(B"\000\000\000")", hex},
+      {Value(Bytes(std::string("!@#$%^&*()-."))), R"(B"!@#$%^&*()-.")", normal},
+      {Value(Bytes(std::string("!@#$%^&*()-."))), R"(B"!@#$%^&*()-.")", hex},
+      {Value(Bytes("foo")), R"(B"foo\000")", normal},
+      {Value(Bytes("foo")), R"(B"foo\000")", hex},
+
       // Tests arrays
       {Value(std::vector<bool>{false, true}), "[0, 1]", normal},
       {Value(std::vector<bool>{false, true}), "[false, true]", boolalpha},

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -989,8 +989,8 @@ TEST(Value, OutputStream) {
       {MakeNullValue<Timestamp>(), "NULL", normal},
 
       // Tests escaping of bytes
-      {Value(Bytes(std::string("ab\tZ"))), R"(B"ab\011Z")", normal},
-      {Value(Bytes(std::string("ab\tZ"))), R"(B"ab\011Z")", hex},
+      {Value(Bytes(std::string("ab\011Z"))), R"(B"ab\011Z")", normal},
+      {Value(Bytes(std::string("ab\011Z"))), R"(B"ab\011Z")", hex},
       {Value(Bytes(std::string("ab\001Z\0211"))), R"(B"ab\001Z\0211")", normal},
       {Value(Bytes(std::string("ab\001Z\0211"))), R"(B"ab\001Z\0211")", hex},
       {Value(Bytes(std::string(3, '\0'))), R"(B"\000\000\000")", normal},

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -997,6 +997,8 @@ TEST(Value, OutputStream) {
       {Value(Bytes(std::string(3, '\0'))), R"(B"\000\000\000")", hex},
       {Value(Bytes(std::string("!@#$%^&*()-."))), R"(B"!@#$%^&*()-.")", normal},
       {Value(Bytes(std::string("!@#$%^&*()-."))), R"(B"!@#$%^&*()-.")", hex},
+      {Value(Bytes(std::string(R"("foo")"))), R"(B"\"foo\"")", normal},
+      {Value(Bytes(std::string(R"("foo")"))), R"(B"\"foo\"")", hex},
       {Value(Bytes("foo")), R"(B"foo\000")", normal},
       {Value(Bytes("foo")), R"(B"foo\000")", hex},
 
@@ -1065,6 +1067,16 @@ TEST(Value, OutputStream) {
     std::stringstream ss;
     tc.manip(ss) << tc.value;
     EXPECT_EQ(ss.str(), tc.expected);
+  }
+}
+
+TEST(Value, ByteEscapingCannotFail) {
+  using ByteType = unsigned char;
+  for (int i = 0; i < std::numeric_limits<ByteType>::max() + 1; ++i) {
+    auto const b = static_cast<ByteType>(i);
+    std::ostringstream ss;
+    ss << Value(Bytes(std::array<ByteType, 1>{b}));
+    EXPECT_NE(ss.str(), R"(B"\?")") << "i=" << i;
   }
 }
 


### PR DESCRIPTION
Non-printable `Byte` values are now printed using their octal escape sequence. We don't use hex escape sequences because in C++ `"\x41B"` is a 3-digit hex number, not 2-digits.

We might consider escaping non-printable string characters too. I didn't do that here because it's not clear that we want that feature since normal `std::string` objects don't do that.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1371)
<!-- Reviewable:end -->
