### PR TITLE
ci: use new CI scripts for Windows+CMake

### DIFF
--- a/ci/kokoro/windows/cmake-presubmit.cfg
+++ b/ci/kokoro/windows/cmake-presubmit.cfg
@@ -1,0 +1,1 @@
+build_file: "google-cloud-cpp-spanner/ci/kokoro/windows/build.bat"

--- a/ci/kokoro/windows/cmake.cfg
+++ b/ci/kokoro/windows/cmake.cfg
@@ -1,0 +1,1 @@
+build_file: "google-cloud-cpp-spanner/ci/kokoro/windows/build.bat"


### PR DESCRIPTION
Part of the work for googleapis/google-cloud-cpp-common#227

This change points Kokoro to the new scripts for the CMake builds, but leaves the old scripts untouched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1372)
<!-- Reviewable:end -->
