### PR TITLE
fix: let clang-tidy allow bool conversions in conditions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -73,3 +73,5 @@ CheckOptions:
   - { key: readability-identifier-naming.MemberConstantPrefix,     value: k         }
   - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase }
   - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }
+  - { key: readability-implicit-bool-conversion.AllowIntegerConditions,  value: 1   }
+  - { key: readability-implicit-bool-conversion.AllowPointerConditions,  value: 1   }


### PR DESCRIPTION
The readability-implicit-bool-conversion clang-tidy check warns when
objects are implicitly converted to bool. This is a readability check
and attempts to improve readability by making such conversions explicit.
However, in my (and google3's) opinion, this check goes too far by
disallowing bool conversions even in *explicit* boolean contexts such as
if and loop conditions. Doing this hurts readability more than helps,
and for this reason, we should enable this option to allow integer and
pointer conversions in conditionals.

## Rationale for AllowIntegerConditions 

Consider the `std::isprint` and `std::isdigit` family of functions from
`cctype`. These functions all logically return boolean values, but
they're inherited from C when it didn't have a bool type, so naturally
they return `int` instead. These functions are all defined to return
"Non-zero value if the character can be printed, zero otherwise." These
guaranteed return values are like this exactly so these functions can be
used in conditional contexts and the integer conversions will behave
exactly like bools.

Example:

```cc
if (std::isprint(c) != 0) {
  ...
}

if (std::isprint(c)) {
  ...
}
```

I think it's clear that the second case is simpler, clearer, and
perfectly correct. Thus this clang-tidy check is actually *harming*
readability in this case. Thus we should disable this check.

## Rationale for AllowPointerConditions 

C++ is very clear that `nullptr` (and other zero values) convert to bool
in conditionals. This is very standard, common, widely known, and is not a dark corner of the language. For this reason, we use and encourage the following
pattern for many pointer-like types:

```cc
auto x = F();
if (x) {
  x->Foo();
}
```

We use and encourage that pattern for `StatusOr`, `optional`,
`unique_ptr`, `shared_ptr`, and many other smart-pointer like things.
Clearly this should also work for regular pointers, since that's the
pattern all these other cases are modeled after.

NOTE: Conditional contexts are considered *explicit* boolean contexts,
meaning they do not rely on *implicit* conversions, they do *explicit*
convresions. That is, they evaluate the conditional expression as if it
were `bool b(expr)`. This is why all of the above are clearly defined,
safe, and correct. The clang-tidy check is going out of its way to break
these cases, and result in less clear readability.

NOTE: This change only allows these conversions in *conditionals*. That
is, the following will still be disallowed:

```cc
int F();
bool b = F();
```

Links:
https://clang.llvm.org/extra/clang-tidy/checks/readability-implicit-bool-conversion.html
https://en.cppreference.com/w/cpp/string/byte/isprint

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1377)
<!-- Reviewable:end -->
