### PR TITLE
testing: use a temporary instance for Backup tests

### DIFF
--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -74,8 +74,7 @@ function (spanner_client_define_integration_tests)
         # is "safe". This is a relatively obscure feature to add compile flags
         # to just one source:
         set_property(
-            SOURCE backup_integration_test.cc
-                   instance_admin_integration_test.cc
+            SOURCE backup_integration_test.cc instance_admin_integration_test.cc
             APPEND_STRING
             PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
     endif ()

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -29,6 +29,7 @@ function (spanner_client_define_integration_tests)
 
     set(spanner_client_integration_tests
         # cmake-format: sortable
+        backup_integration_test.cc
         client_integration_test.cc
         client_stress_test.cc
         data_types_integration_test.cc

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -74,7 +74,8 @@ function (spanner_client_define_integration_tests)
         # is "safe". This is a relatively obscure feature to add compile flags
         # to just one source:
         set_property(
-            SOURCE instance_admin_integration_test.cc
+            SOURCE backup_integration_test.cc
+                   instance_admin_integration_test.cc
             APPEND_STRING
             PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
     endif ()

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -74,7 +74,7 @@ function (spanner_client_define_integration_tests)
         # is "safe". This is a relatively obscure feature to add compile flags
         # to just one source:
         set_property(
-            SOURCE backup_integration_test.cc instance_admin_integration_test.cc
+            SOURCE instance_admin_integration_test.cc
             APPEND_STRING
             PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
     endif ()

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -1,0 +1,258 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/create_instance_request_builder.h"
+#include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/spanner/internal/time_utils.h"
+#include "google/cloud/spanner/testing/random_backup_name.h"
+#include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/spanner/testing/random_instance_name.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include <gmock/gmock.h>
+#include <chrono>
+#include <ctime>
+#include <regex>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace {
+
+class BackupTest : public testing::Test {
+ public:
+  BackupTest() : instance_admin_client_(MakeInstanceAdminConnection()) {}
+
+ protected:
+  void SetUp() override {
+    emulator_ =
+        google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST").has_value();
+    project_id_ =
+        google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+    run_slow_integration_tests_ =
+        google::cloud::internal::GetEnv("RUN_SLOW_INTEGRATION_TESTS")
+            .value_or("");
+    test_iam_service_account_ =
+        google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA")
+            .value_or("");
+  }
+  InstanceAdminClient instance_admin_client_;
+  DatabaseAdminClient database_admin_client_;
+  bool emulator_;
+  std::string project_id_;
+  std::string run_slow_integration_tests_;
+  std::string test_iam_service_account_;
+};
+
+class BackupTestWithCleanup : public BackupTest {
+ protected:
+  void SetUp() override {
+    BackupTest::SetUp();
+    instance_name_regex_ = std::regex(
+        R"(projects/.+/instances/(temporary-instance-(\d{4}-\d{2}-\d{2})-.+))");
+    if (run_slow_integration_tests_ != "yes") {
+      return;
+    }
+    // Deletes leaked temporary instances.
+    std::vector<std::string> instance_ids = [this]() mutable {
+      std::vector<std::string> instance_ids;
+      for (auto const& instance :
+           instance_admin_client_.ListInstances(project_id_, "")) {
+        EXPECT_STATUS_OK(instance);
+        if (!instance) break;
+        auto name = instance->name();
+        std::smatch m;
+        if (std::regex_match(name, m, instance_name_regex_)) {
+          auto instance_id = m[1];
+          auto date_str = m[2];
+          std::string cut_off_date = "1973-03-01";
+          auto cut_off_time_t = std::chrono::system_clock::to_time_t(
+              std::chrono::system_clock::now() - std::chrono::hours(48));
+          std::strftime(&cut_off_date[0], cut_off_date.size() + 1, "%Y-%m-%d",
+                        std::localtime(&cut_off_time_t));
+          // Compare the strings
+          if (date_str < cut_off_date) {
+            instance_ids.push_back(instance_id);
+          }
+        }
+      }
+      return instance_ids;
+    }();
+    // Let it fail if we have too many leaks.
+    EXPECT_GT(20, instance_ids.size());
+    for (auto const& id_to_delete : instance_ids) {
+      // Probably better to ignore failures.
+      instance_admin_client_.DeleteInstance(
+          Instance(project_id_, id_to_delete));
+    }
+  }
+  std::regex instance_name_regex_;
+};
+
+/// @test Backup related integration tests.
+TEST_F(BackupTestWithCleanup, BackupTestSuite) {
+  if (run_slow_integration_tests_ != "yes" || emulator_) {
+    GTEST_SKIP();
+  }
+  auto generator = google::cloud::internal::MakeDefaultPRNG();
+  std::string instance_id =
+      google::cloud::spanner_testing::RandomInstanceName(generator);
+  std::string database_id =
+      google::cloud::spanner_testing::RandomDatabaseName(generator);
+  std::string restore_database_id =
+      google::cloud::spanner_testing::RandomDatabaseName(generator);
+  ASSERT_FALSE(project_id_.empty());
+  ASSERT_FALSE(instance_id.empty());
+  Instance in(project_id_, instance_id);
+
+  // Make sure we're using correct regex.
+  std::smatch m;
+  auto full_name = in.FullName();
+  EXPECT_TRUE(std::regex_match(full_name, m, instance_name_regex_));
+  std::vector<std::string> instance_config_names = [this]() mutable {
+    std::vector<std::string> names;
+    for (auto const& instance_config :
+         instance_admin_client_.ListInstanceConfigs(project_id_)) {
+      EXPECT_STATUS_OK(instance_config);
+      if (!instance_config) break;
+      names.push_back(instance_config->name());
+    }
+    return names;
+  }();
+  ASSERT_FALSE(instance_config_names.empty());
+  // Use the name of the first element from the list of instance configs.
+  auto instance_config = instance_config_names[0];
+
+  future<StatusOr<google::spanner::admin::instance::v1::Instance>> f =
+      instance_admin_client_.CreateInstance(
+          CreateInstanceRequestBuilder(in, instance_config)
+              .SetDisplayName("test-display-name")
+              .SetNodeCount(1)
+              .Build());
+  StatusOr<google::spanner::admin::instance::v1::Instance> instance = f.get();
+
+  EXPECT_STATUS_OK(instance);
+
+  Database db(project_id_, instance_id, database_id);
+
+  auto database_future = database_admin_client_.CreateDatabase(db);
+  auto database = database_future.get();
+  ASSERT_STATUS_OK(database);
+
+  auto backup_future = database_admin_client_.CreateBackup(
+      db, database_id,
+      std::chrono::system_clock::now() + std::chrono::hours(7));
+
+  // Cancel the CreateBackup operation.
+  backup_future.cancel();
+  auto cancelled_backup = backup_future.get();
+  if (cancelled_backup) {
+    auto delete_result =
+        database_admin_client_.DeleteBackup(cancelled_backup.value());
+    EXPECT_STATUS_OK(delete_result);
+  }
+
+  // Then create a Backup without cancelling
+  backup_future = database_admin_client_.CreateBackup(
+      db, database_id,
+      std::chrono::system_clock::now() + std::chrono::hours(7));
+
+  // List the backup operations
+  auto filter = std::string("(metadata.database:") + database_id + ") AND " +
+                "(metadata.@type:type.googleapis.com/" +
+                "google.spanner.admin.database.v1.CreateBackupMetadata)";
+
+  std::vector<std::string> db_names;
+  for (auto const& operation :
+       database_admin_client_.ListBackupOperations(in, filter)) {
+    if (!operation) break;
+    google::spanner::admin::database::v1::CreateBackupMetadata metadata;
+    operation->metadata().UnpackTo(&metadata);
+    db_names.push_back(metadata.database());
+  }
+  EXPECT_LE(1, std::count(db_names.begin(), db_names.end(), db.FullName()))
+      << "Database " << database_id
+      << " not found in the backup operation list.";
+
+  auto backup = backup_future.get();
+  EXPECT_STATUS_OK(backup);
+
+  google::cloud::spanner::Backup backup_name = google::cloud::spanner::Backup(
+      google::cloud::spanner::Instance(project_id_, instance_id), database_id);
+  auto backup_get = database_admin_client_.GetBackup(backup_name);
+  EXPECT_STATUS_OK(backup_get);
+  EXPECT_EQ(backup_get->name(), backup->name());
+  // RestoreDatabase
+  Database restore_db(project_id_, instance_id, restore_database_id);
+  auto r_future =
+      database_admin_client_.RestoreDatabase(restore_db, backup_name);
+  auto restored_database = r_future.get();
+  EXPECT_STATUS_OK(restored_database);
+
+  // List the database operations
+  filter = std::string(
+      "(metadata.@type:type.googleapis.com/"
+      "google.spanner.admin.database.v1.OptimizeRestoredDatabaseMetadata)");
+  std::vector<std::string> restored_db_names;
+  for (auto const& operation :
+       database_admin_client_.ListDatabaseOperations(in, filter)) {
+    if (!operation) break;
+    google::spanner::admin::database::v1::OptimizeRestoredDatabaseMetadata md;
+    operation->metadata().UnpackTo(&md);
+    restored_db_names.push_back(md.name());
+  }
+  EXPECT_LE(1, std::count(restored_db_names.begin(), restored_db_names.end(),
+                          restored_database->name()))
+      << "Backup " << restored_database->name()
+      << " not found in the OptimizeRestoredDatabase operation list.";
+  auto drop_restored_db_status =
+      database_admin_client_.DropDatabase(restore_db);
+  EXPECT_STATUS_OK(drop_restored_db_status);
+  filter = std::string("expire_time < \"3000-01-01T00:00:00Z\"");
+  std::vector<std::string> backup_names;
+  for (auto const& backup : database_admin_client_.ListBackups(in, filter)) {
+    if (!backup) break;
+    backup_names.push_back(backup->name());
+  }
+  EXPECT_LE(
+      1, std::count(backup_names.begin(), backup_names.end(), backup->name()))
+      << "Backup " << backup->name() << " not found in the backup list.";
+  auto new_expire_time =
+      std::chrono::system_clock::now() + std::chrono::hours(7);
+  auto updated_backup = database_admin_client_.UpdateBackupExpireTime(
+      backup.value(), new_expire_time);
+  EXPECT_STATUS_OK(updated_backup);
+  auto expected_timestamp =
+      google::cloud::spanner::internal::ConvertTimePointToProtoTimestamp(
+          new_expire_time);
+  EXPECT_STATUS_OK(expected_timestamp);
+  EXPECT_EQ(expected_timestamp->seconds(),
+            updated_backup->expire_time().seconds());
+  // The server only preserves micros.
+  EXPECT_EQ(expected_timestamp->nanos() / 1000,
+            updated_backup->expire_time().nanos() / 1000);
+  auto delete_result = database_admin_client_.DeleteBackup(backup.value());
+  EXPECT_STATUS_OK(delete_result);
+  auto status = instance_admin_client_.DeleteInstance(in);
+  EXPECT_STATUS_OK(status);
+}
+
+}  // namespace
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_client.h"
-#include "google/cloud/spanner/internal/time_utils.h"
 #include "google/cloud/spanner/testing/matchers.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
@@ -168,103 +167,6 @@ TEST(DatabaseAdminClient, DatabaseBasicCRUD) {
 
   db_list = get_current_databases();
   ASSERT_EQ(1, std::count(db_list.begin(), db_list.end(), db.FullName()));
-
-  // Tests for Backup are taking long time. To run them, set
-  // RUN_SLOW_INTEGRATION_TESTS environment variable to yes.
-  if (run_slow_integration_tests == "yes" && !emulator) {
-    auto backup_future = client.CreateBackup(
-        db, database_id,
-        std::chrono::system_clock::now() + std::chrono::hours(7));
-
-    // Cancel the CreateBackup operation.
-    backup_future.cancel();
-    auto cancelled_backup = backup_future.get();
-    if (cancelled_backup) {
-      auto delete_result = client.DeleteBackup(cancelled_backup.value());
-      EXPECT_STATUS_OK(delete_result);
-    }
-
-    // Then create a Backup without cancelling
-    backup_future = client.CreateBackup(
-        db, database_id,
-        std::chrono::system_clock::now() + std::chrono::hours(7));
-
-    // List the backup operations
-    auto filter = std::string("(metadata.database:") + database_id + ") AND " +
-                  "(metadata.@type:type.googleapis.com/" +
-                  "google.spanner.admin.database.v1.CreateBackupMetadata)";
-
-    std::vector<std::string> db_names;
-    for (auto const& operation : client.ListBackupOperations(in, filter)) {
-      if (!operation) break;
-      google::spanner::admin::database::v1::CreateBackupMetadata metadata;
-      operation->metadata().UnpackTo(&metadata);
-      db_names.push_back(metadata.database());
-    }
-    EXPECT_LE(1, std::count(db_names.begin(), db_names.end(), db.FullName()))
-        << "Database " << database_id
-        << " not found in the backup operation list.";
-
-    auto backup = backup_future.get();
-    EXPECT_STATUS_OK(backup);
-
-    google::cloud::spanner::Backup backup_name = google::cloud::spanner::Backup(
-        google::cloud::spanner::Instance(project_id, *instance_id),
-        database_id);
-    auto backup_get = client.GetBackup(backup_name);
-    EXPECT_STATUS_OK(backup_get);
-    EXPECT_EQ(backup_get->name(), backup->name());
-    // RestoreDatabase
-    std::string restore_database_id =
-        spanner_testing::RandomDatabaseName(generator);
-    Database restore_db(project_id, *instance_id, restore_database_id);
-    auto r_future = client.RestoreDatabase(restore_db, backup_name);
-    auto restored_database = r_future.get();
-    EXPECT_STATUS_OK(restored_database);
-
-    // List the database operations
-    filter = std::string(
-        "(metadata.@type:type.googleapis.com/"
-        "google.spanner.admin.database.v1.OptimizeRestoredDatabaseMetadata)");
-    std::vector<std::string> restored_db_names;
-    for (auto const& operation : client.ListDatabaseOperations(in, filter)) {
-      if (!operation) break;
-      google::spanner::admin::database::v1::OptimizeRestoredDatabaseMetadata md;
-      operation->metadata().UnpackTo(&md);
-      restored_db_names.push_back(md.name());
-    }
-    EXPECT_LE(1, std::count(restored_db_names.begin(), restored_db_names.end(),
-                            restored_database->name()))
-        << "Backup " << restored_database->name()
-        << " not found in the OptimizeRestoredDatabase operation list.";
-    auto drop_restored_db_status = client.DropDatabase(restore_db);
-    EXPECT_STATUS_OK(drop_restored_db_status);
-    filter = std::string("expire_time < \"3000-01-01T00:00:00Z\"");
-    std::vector<std::string> backup_names;
-    for (auto const& backup : client.ListBackups(in, filter)) {
-      if (!backup) break;
-      backup_names.push_back(backup->name());
-    }
-    EXPECT_LE(
-        1, std::count(backup_names.begin(), backup_names.end(), backup->name()))
-        << "Backup " << backup->name() << " not found in the backup list.";
-    auto new_expire_time =
-        std::chrono::system_clock::now() + std::chrono::hours(7);
-    auto updated_backup =
-        client.UpdateBackupExpireTime(backup.value(), new_expire_time);
-    EXPECT_STATUS_OK(updated_backup);
-    auto expected_timestamp =
-        google::cloud::spanner::internal::ConvertTimePointToProtoTimestamp(
-            new_expire_time);
-    EXPECT_STATUS_OK(expected_timestamp);
-    EXPECT_EQ(expected_timestamp->seconds(),
-              updated_backup->expire_time().seconds());
-    // The server only preserves micros.
-    EXPECT_EQ(expected_timestamp->nanos() / 1000,
-              updated_backup->expire_time().nanos() / 1000);
-    auto delete_result = client.DeleteBackup(backup.value());
-    EXPECT_STATUS_OK(delete_result);
-  }
 
   auto drop_status = client.DropDatabase(db);
   EXPECT_STATUS_OK(drop_status);

--- a/google/cloud/spanner/integration_tests/spanner_client_integration_tests.bzl
+++ b/google/cloud/spanner/integration_tests/spanner_client_integration_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 spanner_client_integration_tests = [
+    "backup_integration_test.cc",
     "client_integration_test.cc",
     "client_stress_test.cc",
     "data_types_integration_test.cc",

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -50,6 +50,8 @@ function (spanner_client_define_samples)
         google_cloud_cpp_test_name_to_target(target "${fname}")
         set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
     endforeach ()
+    # samples sometimes takes long time
+    set_tests_properties("samples" PROPERTIES TIMEOUT 2400)
 endfunction ()
 
 if (BUILD_TESTING)

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -2403,6 +2403,11 @@ void RunAll(bool emulator) {
     InstanceGetIamPolicy(instance_admin_client, project_id, instance_id);
   }
 
+  std::string database_id =
+      google::cloud::spanner_testing::RandomDatabaseName(generator);
+
+  google::cloud::spanner::DatabaseAdminClient database_admin_client;
+
   if (run_slow_integration_tests == "yes") {
     std::string crud_instance_id =
         google::cloud::spanner_testing::RandomInstanceName(generator);
@@ -2419,7 +2424,55 @@ void RunAll(bool emulator) {
       std::cout << "\nRunning (instance) remove-database-reader sample\n";
       RemoveDatabaseReader(instance_admin_client, project_id, crud_instance_id,
                            "serviceAccount:" + test_iam_service_account);
+      std::string backup_id =
+          google::cloud::spanner_testing::RandomBackupName(generator);
+
+      std::cout << "\nRunning spanner_create_database sample\n";
+      CreateDatabase(database_admin_client, project_id, crud_instance_id,
+                     database_id);
+
+      std::cout << "\nRunning spanner_create_backup sample\n";
+      CreateBackup(database_admin_client, project_id, crud_instance_id,
+                   database_id, backup_id);
+
+      std::cout << "\nRunning spanner_get_backup sample\n";
+      GetBackup(database_admin_client, project_id, crud_instance_id, backup_id);
+
+      std::cout << "\nRunning spanner_update_backup sample\n";
+      UpdateBackup(database_admin_client, project_id, crud_instance_id,
+                   backup_id);
+
+      std::string restore_database_id =
+          google::cloud::spanner_testing::RandomDatabaseName(generator);
+
+      std::cout << "\nRunning spanner_restore_database sample\n";
+      RestoreDatabase(database_admin_client, project_id, crud_instance_id,
+                      restore_database_id, backup_id);
+
+      std::cout << "\nRunning spanner_drop_database sample\n";
+      DropDatabase(database_admin_client, project_id, crud_instance_id,
+                   restore_database_id);
+
+      std::cout << "\nRunning spanner_delete_backup sample\n";
+      DeleteBackup(database_admin_client, project_id, crud_instance_id,
+                   backup_id);
+
+      std::cout << "\nRunning spanner_cancel_backup_create sample\n";
+      CreateBackupAndCancel(database_admin_client, project_id, crud_instance_id,
+                            database_id, backup_id);
+
+      std::cout << "\nRunning spanner_list_backup_operations sample\n";
+      ListBackupOperations(database_admin_client, project_id, crud_instance_id,
+                           database_id);
+
+      std::cout << "\nRunning spanner_list_backups sample\n";
+      ListBackups(database_admin_client, project_id, crud_instance_id);
+
+      std::cout << "\nRunning spanner_list_database_operations sample\n";
+      ListDatabaseOperations(database_admin_client, project_id,
+                             crud_instance_id);
     }
+
     std::cout << "\nRunning delete-instance sample\n";
     DeleteInstance(instance_admin_client, project_id, crud_instance_id);
   }
@@ -2429,12 +2482,8 @@ void RunAll(bool emulator) {
     InstanceTestIamPermissions(instance_admin_client, project_id, instance_id);
   }
 
-  std::string database_id =
-      google::cloud::spanner_testing::RandomDatabaseName(generator);
-
   std::cout << "Running samples in database " << database_id << "\n";
 
-  google::cloud::spanner::DatabaseAdminClient database_admin_client;
   std::cout << "\nRunning spanner_create_database sample\n";
   CreateDatabase(database_admin_client, project_id, instance_id, database_id);
 
@@ -2626,49 +2675,6 @@ void RunAll(bool emulator) {
 
   std::cout << "\nRunning spanner_delete_data sample\n";
   DeleteData(client);
-
-  if (run_slow_integration_tests == "yes" && (!emulator)) {
-    std::string backup_id =
-        google::cloud::spanner_testing::RandomBackupName(generator);
-
-    std::cout << "\nRunning spanner_create_backup sample\n";
-    CreateBackup(database_admin_client, project_id, instance_id, database_id,
-                 backup_id);
-
-    std::cout << "\nRunning spanner_get_backup sample\n";
-    GetBackup(database_admin_client, project_id, instance_id, backup_id);
-
-    std::cout << "\nRunning spanner_update_backup sample\n";
-    UpdateBackup(database_admin_client, project_id, instance_id, backup_id);
-
-    std::string restore_database_id =
-        google::cloud::spanner_testing::RandomDatabaseName(generator);
-
-    std::cout << "\nRunning spanner_restore_database sample\n";
-    RestoreDatabase(database_admin_client, project_id, instance_id,
-                    restore_database_id, backup_id);
-
-    std::cout << "\nRunning spanner_drop_database sample\n";
-    DropDatabase(database_admin_client, project_id, instance_id,
-                 restore_database_id);
-
-    std::cout << "\nRunning spanner_delete_backup sample\n";
-    DeleteBackup(database_admin_client, project_id, instance_id, backup_id);
-
-    std::cout << "\nRunning spanner_cancel_backup_create sample\n";
-    CreateBackupAndCancel(database_admin_client, project_id, instance_id,
-                          database_id, backup_id);
-
-    std::cout << "\nRunning spanner_list_backup_operations sample\n";
-    ListBackupOperations(database_admin_client, project_id, instance_id,
-                         database_id);
-
-    std::cout << "\nRunning spanner_list_backups sample\n";
-    ListBackups(database_admin_client, project_id, instance_id);
-
-    std::cout << "\nRunning spanner_list_database_operations sample\n";
-    ListDatabaseOperations(database_admin_client, project_id, instance_id);
-  }
 
   std::cout << "\nRunning spanner_drop_database sample\n";
   DropDatabase(database_admin_client, project_id, instance_id, database_id);


### PR DESCRIPTION
fixes #1376

In `samples.cc`, I put all the Backup related test in the block for instance CRUD test. I also created a new integration test for the Backup feature. The new test also creates a new instance with a random name so the restore operation won't conflict with another test run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1379)
<!-- Reviewable:end -->
