### PR TITLE
refactor: move Bytes formatting to bytes.{h,cc}

### DIFF
--- a/google/cloud/spanner/bytes.cc
+++ b/google/cloud/spanner/bytes.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/bytes.h"
 #include "google/cloud/status.h"
 #include <array>
+#include <cctype>
 #include <climits>
 #include <cstdio>
 
@@ -78,7 +79,8 @@ std::ostream& operator<<(std::ostream& os, Bytes const& bytes) {
       }
     }
   }
-  return os << R"(")";
+  // Can't use raw string literal here because of a doxygen bug.
+  return os << "\"";
 }
 
 void Bytes::Encoder::Flush() {

--- a/google/cloud/spanner/bytes.cc
+++ b/google/cloud/spanner/bytes.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/status.h"
 #include <array>
 #include <climits>
+#include <cstdio>
 
 namespace google {
 namespace cloud {
@@ -54,6 +55,31 @@ constexpr std::array<unsigned char, UCHAR_MAX + 1> kCharToIndexExcessOne = {{
 static_assert(UCHAR_MAX == 255, "required by base64 encoder");
 
 }  // namespace
+
+// Prints the bytes in the form B"...", where printable bytes are output
+// normally, double quotes are backslash escaped, and non-printable characters
+// are printed as a 3-digit octal escape sequence.
+std::ostream& operator<<(std::ostream& os, Bytes const& bytes) {
+  os << R"(B")";
+  for (auto const byte : Bytes::Decoder(bytes.base64_rep_)) {
+    if (byte == '"') {
+      os << R"(\")";
+    } else if (std::isprint(byte)) {
+      os << byte;
+    } else {
+      // This uses snprintf rather than iomanip so we don't mess up the
+      // formatting on `os` for other streaming operations.
+      std::array<char, sizeof(R"(\000)")> buf;
+      auto n = std::snprintf(buf.data(), buf.size(), R"(\%03o)", byte);
+      if (n == static_cast<int>(buf.size() - 1)) {
+        os << buf.data();
+      } else {
+        os << R"(\?)";
+      }
+    }
+  }
+  return os << R"(")";
+}
 
 void Bytes::Encoder::Flush() {
   unsigned int const v = buf_[0] << 16 | buf_[1] << 8 | buf_[2];

--- a/google/cloud/spanner/bytes.h
+++ b/google/cloud/spanner/bytes.h
@@ -20,6 +20,7 @@
 #include <array>
 #include <cstddef>
 #include <iterator>
+#include <ostream>
 #include <string>
 
 namespace google {
@@ -76,6 +77,14 @@ class Bytes {
   }
   friend bool operator!=(Bytes const& a, Bytes const& b) { return !(a == b); }
   ///@}
+
+  /**
+   * Outputs string representation of the Bytes to the provided stream.
+   *
+   * @warning This is intended for debugging and human consumption only, not
+   *     machine consumption, as the output format may change without notice.
+   */
+  friend std::ostream& operator<<(std::ostream& os, Bytes const& bytes);
 
  private:
   friend StatusOr<Bytes> internal::BytesFromBase64(std::string input);

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -114,29 +114,8 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
     case google::spanner::v1::DATE:
       return os << v.string_value();
 
-    case google::spanner::v1::BYTES: {
-      auto const bytes = internal::BytesFromBase64(v.string_value())
-                             ->get<std::vector<unsigned char>>();
-      os << R"(B")";
-      for (auto const byte : bytes) {
-        if (byte == '"') {
-          os << R"(\")";
-        } else if (std::isprint(byte)) {
-          os << byte;
-        } else {
-          // This uses snprintf rather than iomanip so we don't mess up the
-          // formatting on `os` for other streaming operations.
-          std::array<char, sizeof(R"(\000)")> buf;
-          auto n = std::snprintf(buf.data(), buf.size(), R"(\%03o)", byte);
-          if (n == static_cast<int>(buf.size() - 1)) {
-            os << buf.data();
-          } else {
-            os << R"(\?)";
-          }
-        }
-      }
-      return os << R"(")";
-    }
+    case google::spanner::v1::BYTES:
+      return os << internal::BytesFromBase64(v.string_value()).value();
 
     case google::spanner::v1::ARRAY: {
       const char* delimiter = "";

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -15,11 +15,8 @@
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/spanner/internal/date.h"
 #include "google/cloud/log.h"
-#include <array>
-#include <cctype>
 #include <cerrno>
 #include <cmath>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ios>

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -988,20 +988,6 @@ TEST(Value, OutputStream) {
       {MakeNullValue<Date>(), "NULL", normal},
       {MakeNullValue<Timestamp>(), "NULL", normal},
 
-      // Tests escaping of bytes
-      {Value(Bytes(std::string("ab\011Z"))), R"(B"ab\011Z")", normal},
-      {Value(Bytes(std::string("ab\011Z"))), R"(B"ab\011Z")", hex},
-      {Value(Bytes(std::string("ab\001Z\0211"))), R"(B"ab\001Z\0211")", normal},
-      {Value(Bytes(std::string("ab\001Z\0211"))), R"(B"ab\001Z\0211")", hex},
-      {Value(Bytes(std::string(3, '\0'))), R"(B"\000\000\000")", normal},
-      {Value(Bytes(std::string(3, '\0'))), R"(B"\000\000\000")", hex},
-      {Value(Bytes(std::string("!@#$%^&*()-."))), R"(B"!@#$%^&*()-.")", normal},
-      {Value(Bytes(std::string("!@#$%^&*()-."))), R"(B"!@#$%^&*()-.")", hex},
-      {Value(Bytes(std::string(R"("foo")"))), R"(B"\"foo\"")", normal},
-      {Value(Bytes(std::string(R"("foo")"))), R"(B"\"foo\"")", hex},
-      {Value(Bytes("foo")), R"(B"foo\000")", normal},
-      {Value(Bytes("foo")), R"(B"foo\000")", hex},
-
       // Tests arrays
       {Value(std::vector<bool>{false, true}), "[0, 1]", normal},
       {Value(std::vector<bool>{false, true}), "[false, true]", boolalpha},
@@ -1067,16 +1053,6 @@ TEST(Value, OutputStream) {
     std::stringstream ss;
     tc.manip(ss) << tc.value;
     EXPECT_EQ(ss.str(), tc.expected);
-  }
-}
-
-TEST(Value, ByteEscapingCannotFail) {
-  using ByteType = unsigned char;
-  for (int i = 0; i < std::numeric_limits<ByteType>::max() + 1; ++i) {
-    auto const b = static_cast<ByteType>(i);
-    std::ostringstream ss;
-    ss << Value(Bytes(std::array<ByteType, 1>{b}));
-    EXPECT_NE(ss.str(), R"(B"\?")") << "i=" << i;
   }
 }
 


### PR DESCRIPTION
This makes it so that `Value::op<<` can just stream the `Bytes`
directly, and `Value` is no longer responsible for the
formatting/escaping of bytes.

This makes it so that if a user has a `Bytes` object (not a
`Value`), they can still stream it. It's also more efficient this way because we can
directly iterate using the `Bytes::Decoder` rather than having to first copy the
bytes to an unnecessary `vector<unsigned char>`.

There's no change in formatting logic or behavior in this PR. Just a
refactoring/move of the code from value.cc -> bytes.cc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1384)
<!-- Reviewable:end -->
