### PR TITLE
feat: taught Date how to stream itself

### DIFF
--- a/google/cloud/spanner/date.cc
+++ b/google/cloud/spanner/date.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/date.h"
+#include "google/cloud/spanner/internal/date.h"
 #include <array>
 
 namespace google {
@@ -57,6 +58,10 @@ Date::Date(std::int64_t year, int month, int day)
       month_ = 1;
     }
   }
+}
+
+std::ostream& operator<<(std::ostream& os, Date const& date) {
+  return os << internal::DateToString(date);
 }
 
 }  // namespace SPANNER_CLIENT_NS

--- a/google/cloud/spanner/date.h
+++ b/google/cloud/spanner/date.h
@@ -40,6 +40,9 @@ class Date {
   int month() const { return month_; }
   int day() const { return day_; }
 
+  /// @name Output streaming
+  friend std::ostream& operator<<(std::ostream& os, Date const& date);
+
  private:
   std::int64_t year_;
   int month_;

--- a/google/cloud/spanner/date.h
+++ b/google/cloud/spanner/date.h
@@ -41,14 +41,13 @@ class Date {
   int month() const { return month_; }
   int day() const { return day_; }
 
-  /// @name Output streaming
-  friend std::ostream& operator<<(std::ostream& os, Date const& date);
-
  private:
   std::int64_t year_;
   int month_;
   int day_;
 };
+
+std::ostream& operator<<(std::ostream& os, Date const& date);
 
 inline bool operator==(Date const& a, Date const& b) {
   return std::make_tuple(a.year(), a.month(), a.day()) ==

--- a/google/cloud/spanner/date.h
+++ b/google/cloud/spanner/date.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/version.h"
 #include <cstdint>
+#include <ostream>
 #include <tuple>
 
 namespace google {

--- a/google/cloud/spanner/date_test.cc
+++ b/google/cloud/spanner/date_test.cc
@@ -14,6 +14,8 @@
 
 #include "google/cloud/spanner/date.h"
 #include <gmock/gmock.h>
+#include <sstream>
+#include <vector>
 
 namespace google {
 namespace cloud {
@@ -76,6 +78,26 @@ TEST(Date, Normalization) {
 
   // Mixed.
   EXPECT_EQ(Date(2012, 9, 30), Date(2016, -42, 122));
+}
+
+TEST(Date, OutputStream) {
+  struct TestCase {
+    Date date;
+    std::string expected;
+  };
+
+  std::vector<TestCase> test_cases = {
+      {Date(1, 1, 1), "0001-01-01"},
+      {Date(1970, 1, 1), "1970-01-01"},
+      {Date(2020, 3, 14), "2020-03-14"},
+      {Date(9999, 12, 31), "9999-12-31"},
+  };
+
+  for (auto const& tc : test_cases) {
+    std::ostringstream ss;
+    ss << tc.date;
+    EXPECT_EQ(ss.str(), tc.expected);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Date was the only non-aggregate "Value" type that didn't already know
how to print itself. Everything else, (bool, int64_t, double,
std::string, Bytes, and Timestamp) were all streamable directly.
`internal/date.h` already had this support, so it just took a little
plumbing to make the user-facing `Date` class to itself also be
streamable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1385)
<!-- Reviewable:end -->
