### PR TITLE
fix: Value::op==() correctly handles Date and Timestamp

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -51,6 +51,8 @@ bool Equal(google::spanner::v1::Type const& pt1,
              pv1.number_value() == pv2.number_value();
     case google::spanner::v1::TypeCode::STRING:
     case google::spanner::v1::TypeCode::BYTES:
+    case google::spanner::v1::TypeCode::DATE:
+    case google::spanner::v1::TypeCode::TIMESTAMP:
       return pv1.string_value() == pv2.string_value();
     case google::spanner::v1::TypeCode::ARRAY: {
       auto const& etype1 = pt1.array_element_type();

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -190,6 +190,32 @@ TEST(Value, BasicSemantics) {
   TestBasicSemantics(v);
 }
 
+TEST(Value, Equality) {
+  std::vector<std::pair<Value, Value>> test_cases = {
+      {Value(false), Value(true)},
+      {Value(0), Value(1)},
+      {Value(3.14), Value(42.0)},
+      {Value("foo"), Value("bar")},
+      {Value(Bytes("foo")), Value(Bytes("bar"))},
+      {Value(Date(1970, 1, 1)), Value(Date(2020, 3, 15))},
+      {Value(std::vector<double>{1.2, 3.4}),
+       Value(std::vector<double>{4.5, 6.7})},
+      {Value(std::make_tuple(false, 123, "foo")),
+       Value(std::make_tuple(true, 456, "bar"))},
+  };
+
+  for (auto const& tc : test_cases) {
+    EXPECT_EQ(tc.first, tc.first);
+    EXPECT_EQ(tc.second, tc.second);
+    EXPECT_NE(tc.first, tc.second);
+    // Compares tc.first to tc2.second, which ensures that different "kinds" of
+    // value are never equal.
+    for (auto const& tc2 : test_cases) {
+      EXPECT_NE(tc.first, tc2.second);
+    }
+  }
+}
+
 // NOTE: This test relies on unspecified behavior about the moved-from state
 // of std::string. Specifically, this test relies on the fact that "large"
 // strings, when moved-from, end up empty. And we use this fact to verify that


### PR DESCRIPTION
Oops. It looks like we forgot to teach Value::op== how to compare Date
and Timestamps. Now it's fixed, and I added a test to make sure basic
Value equality works for all "kinds".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1386)
<!-- Reviewable:end -->
