### PR TITLE
test: add test verifying Value op<< output

### DIFF
--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -1056,6 +1056,62 @@ TEST(Value, OutputStream) {
   }
 }
 
+// Ensures that the following expressions produce the same output.
+//
+// `os << t`
+// `os << Value(t)`
+//
+template <typename T>
+void StreamMatchesValueStream(T t) {
+  std::ostringstream ss1;
+  ss1 << t;
+  std::ostringstream ss2;
+  ss2 << Value(std::move(t));
+  EXPECT_EQ(ss1.str(), ss2.str());
+}
+
+TEST(Value, OutputStreamMatchesT) {
+  // bool
+  StreamMatchesValueStream(false);
+  StreamMatchesValueStream(true);
+
+  // std::int64_t
+  StreamMatchesValueStream(-1);
+  StreamMatchesValueStream(0);
+  StreamMatchesValueStream(1);
+
+  // double
+  StreamMatchesValueStream(0.0);
+  StreamMatchesValueStream(3.14);
+  StreamMatchesValueStream(std::nan("NaN"));
+  StreamMatchesValueStream(std::numeric_limits<double>::infinity());
+  StreamMatchesValueStream(-std::numeric_limits<double>::infinity());
+
+  // std::string
+  // Note: `os << std::string{}` != `os << Value(std::string{})`
+  // because the latter includes surrounding double quotes.
+  // StreamMatchesValueStream("foo");
+
+  // Bytes
+  StreamMatchesValueStream(Bytes());
+  StreamMatchesValueStream(Bytes("foo"));
+
+  // Date
+  StreamMatchesValueStream(Date(1, 1, 1));
+  StreamMatchesValueStream(Date());
+  StreamMatchesValueStream(Date(9999, 12, 31));
+
+  // Timestamp
+  StreamMatchesValueStream(Timestamp());
+  StreamMatchesValueStream(MakeTimestamp(MakeTimePoint(1, 1)).value());
+
+  // std::vector<T>
+  // Not included, because a raw vector cannot be streamed.
+
+  // std::tuple<...>
+  // Not included, because a raw tuple cannot be streamed.
+}
+
 }  // namespace
 }  // namespace SPANNER_CLIENT_NS
 }  // namespace spanner


### PR DESCRIPTION
Adds a unit test that ensures that

```cc
os << t;
```

Produces the same output as

```cc
os << Value(t);
```

for all `T` in `bool`, `std::int64_t`, `double`, `Bytes`, `Date`,
`Timestamp`. This list does not include `std::vector<T>` nor
`std::struct<...>`, because those are not directly streamable on their
own, so there's nothing to compare with.

The other notable exception to this list is `std::string`, which does
not produce the same output since `os << Value(std::string{...})`
wraps the output in double quotes.

Related to #1380 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1387)
<!-- Reviewable:end -->
