### PR TITLE
feat: add async call support classes

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -128,6 +128,8 @@ add_library(
     instance_admin_connection.h
     internal/api_client_header.cc
     internal/api_client_header.h
+    internal/async_retry_op.h
+    internal/async_retry_unary_rpc.h
     internal/build_info.h
     internal/channel.h
     internal/compiler_info.cc
@@ -275,9 +277,11 @@ function (spanner_client_define_tests)
         testing/database_environment.cc
         testing/database_environment.h
         testing/matchers.h
+        testing/mock_completion_queue.h
         testing/mock_database_admin_stub.h
         testing/mock_instance_admin_stub.h
         testing/mock_partial_result_set_reader.h
+        testing/mock_response_reader.h
         testing/mock_spanner_stub.h
         testing/pick_random_instance.cc
         testing/pick_random_instance.h
@@ -320,6 +324,7 @@ function (spanner_client_define_tests)
         instance_admin_connection_test.cc
         instance_test.cc
         internal/api_client_header_test.cc
+        internal/async_retry_unary_rpc_test.cc
         internal/build_info_test.cc
         internal/compiler_info_test.cc
         internal/connection_impl_test.cc

--- a/google/cloud/spanner/internal/async_retry_op.h
+++ b/google/cloud/spanner/internal/async_retry_op.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/spanner/internal/async_retry_op.h
+++ b/google/cloud/spanner/internal/async_retry_op.h
@@ -1,0 +1,56 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_ASYNC_RETRY_OP_H
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_ASYNC_RETRY_OP_H
+
+#include "google/cloud/spanner/backoff_policy.h"
+#include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/internal/make_unique.h"
+#include "google/cloud/internal/throw_delegate.h"
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+
+/**
+ * An idempotent policy for `AsyncRetryOp` based on a pre-computed value.
+ *
+ * In most APIs the idempotency of the API is either known at compile-time or
+ * the value is unchanged during the retry loop. This class can be used in
+ * those cases as the `IdempotentPolicy` template parameter for
+ * `AsyncRetryOp`.
+ */
+class ConstantIdempotencyPolicy {
+ public:
+  explicit ConstantIdempotencyPolicy(bool is_idempotent)
+      : is_idempotent_(is_idempotent) {}
+
+  bool is_idempotent() const { return is_idempotent_; }
+
+ private:
+  bool is_idempotent_;
+};
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_ASYNC_RETRY_OP_H

--- a/google/cloud/spanner/internal/async_retry_unary_rpc.h
+++ b/google/cloud/spanner/internal/async_retry_unary_rpc.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/spanner/internal/async_retry_unary_rpc.h
+++ b/google/cloud/spanner/internal/async_retry_unary_rpc.h
@@ -1,0 +1,230 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_ASYNC_RETRY_UNARY_RPC_H
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_ASYNC_RETRY_UNARY_RPC_H
+
+#include "google/cloud/spanner/backoff_policy.h"
+#include "google/cloud/spanner/internal/async_retry_op.h"
+#include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/internal/make_unique.h"
+#include <google/protobuf/empty.pb.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+
+/**
+ * Make an asynchronous unary RPC with retries.
+ *
+ * This class creates a future<> that becomes satisfied when an asynchronous
+ * operation either:
+ *
+ * - Succeeds.
+ * - Fails with a non-retryable error.
+ * - The retry policy expires.
+ *
+ * The class retries the operation, using a backoff policy to wait between
+ * retries. The class does not block, it uses the completion queue to wait.
+ *
+ * @tparam AsyncCallType the type of the callable used to start the asynchronous
+ *     operation. This is typically a lambda that wraps both the `Client` object
+ *     and the member function to invoke.
+ * @tparam RequestType the type of the request object.
+ * @tparam IdempotencyPolicy the type of the idempotency policy.
+ * @tparam Sig discover the signature and return type of `AsyncCallType`.
+ * @tparam ResponseType the discovered response type for `AsyncCallType`.
+ */
+template <typename AsyncCallType, typename RequestType,
+          typename IdempotencyPolicy,
+          typename Sig = google::cloud::internal::AsyncCallResponseType<
+              AsyncCallType, RequestType>,
+          typename ResponseType = typename Sig::type,
+          typename std::enable_if<Sig::value, int>::type = 0>
+class RetryAsyncUnaryRpcFuture {
+ public:
+  //@{
+  /// @name Convenience aliases for the RPC request response and callback types.
+  using Request = RequestType;
+  using Response = ResponseType;
+  //@}
+
+  /**
+   * Start the asynchronous retry loop.
+   *
+   * @param location typically the name of the function that created this
+   *     asynchronous retry loop.
+   * @param retry_policy controls the number of retries, and what errors are
+   *     considered retryable.
+   * @param backoff_policy determines the wait time between retries.
+   * @param idempotent_policy determines if a request is retryable.
+   * @param async_call the callable to start a new asynchronous operation.
+   * @param request the parameters of the request.
+   * @param cq the completion queue where the retry loop is executed.
+   * @return a future that becomes satisfied when (a) one of the retry attempts
+   *     is successful, or (b) one of the retry attempts fails with a
+   *     non-retryable error, or (c) one of the retry attempts fails with a
+   *     retryable error, but the request is non-idempotent, or (d) the
+   *     retry policy is expired.
+   */
+  static future<StatusOr<Response>> Start(
+      char const* location, std::unique_ptr<RetryPolicy> retry_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy,
+      IdempotencyPolicy idempotent_policy, AsyncCallType async_call,
+      Request request, CompletionQueue cq) {
+    std::shared_ptr<RetryAsyncUnaryRpcFuture> self(new RetryAsyncUnaryRpcFuture(
+        location, std::move(retry_policy), std::move(backoff_policy),
+        std::move(idempotent_policy), async_call, std::move(request)));
+    auto future = self->final_result_.get_future();
+    self->StartIteration(self, cq);
+    return future;
+  }
+
+ private:
+  // The constructor is private because we always want to wrap the object in
+  // a shared pointer. The lifetime is controlled by any pending operations in
+  // the CompletionQueue.
+  RetryAsyncUnaryRpcFuture(char const* location,
+                           std::unique_ptr<RetryPolicy> retry_policy,
+                           std::unique_ptr<BackoffPolicy> backoff_policy,
+                           IdempotencyPolicy idempotent_policy,
+                           AsyncCallType async_call, Request request)
+      : location_(location),
+        retry_policy_(std::move(retry_policy)),
+        backoff_policy_(std::move(backoff_policy)),
+        idempotent_policy_(std::move(idempotent_policy)),
+        async_call_(std::move(async_call)),
+        request_(std::move(request)) {}
+
+  /// The callback for a completed request, successful or not.
+  static void OnCompletion(std::shared_ptr<RetryAsyncUnaryRpcFuture> self,
+                           CompletionQueue cq, StatusOr<Response> result) {
+    if (result) {
+      self->final_result_.set_value(std::move(result));
+      return;
+    }
+    if (!self->idempotent_policy_.is_idempotent()) {
+      self->final_result_.set_value(self->DetailedStatus(
+          "non-idempotent operation failed", result.status()));
+      return;
+    }
+    if (!self->retry_policy_->OnFailure(result.status())) {
+      // TODO(#1388) `RetryPolicy` should implement an `IsPermanentFailure`
+      // method directly; this works because all existing policies use
+      // `SafeGrpcRetry`.
+      char const* context =
+          internal::SafeGrpcRetry::IsPermanentFailure(result.status())
+              ? "permanent error"
+              : "too many transient errors";
+      self->final_result_.set_value(
+          self->DetailedStatus(context, result.status()));
+      return;
+    }
+    cq.MakeRelativeTimer(self->backoff_policy_->OnCompletion())
+        .then([self, cq](future<StatusOr<std::chrono::system_clock::time_point>>
+                             result) {
+          if (auto tp = result.get()) {
+            self->StartIteration(self, cq);
+          } else {
+            self->final_result_.set_value(
+                self->DetailedStatus("timer error", tp.status()));
+          }
+        });
+  }
+
+  /// The callback to start another iteration of the retry loop.
+  static void StartIteration(std::shared_ptr<RetryAsyncUnaryRpcFuture> self,
+                             CompletionQueue cq) {
+    auto context =
+        ::google::cloud::internal::make_unique<grpc::ClientContext>();
+
+    cq.MakeUnaryRpc(self->async_call_, self->request_, std::move(context))
+        .then([self, cq](future<StatusOr<Response>> fut) {
+          self->OnCompletion(self, cq, fut.get());
+        });
+  }
+
+  /// Generate an error message
+  Status DetailedStatus(char const* context, Status const& status) {
+    std::string full_message = location_;
+    full_message += context;
+    full_message += ", last error=";
+    full_message += status.message();
+    return Status(status.code(), std::move(full_message));
+  }
+
+  char const* location_;
+  std::unique_ptr<RetryPolicy> retry_policy_;
+  std::unique_ptr<BackoffPolicy> backoff_policy_;
+  IdempotencyPolicy idempotent_policy_;
+
+  AsyncCallType async_call_;
+  Request request_;
+  Response response_;
+
+  promise<StatusOr<Response>> final_result_;
+};
+
+/**
+ * Automatically deduce the type for `RetryAsyncUnaryRpc` and start the
+ * asynchronous retry loop.
+ *
+ * @param location typically the name of the function that created this
+ *     asynchronous retry loop.
+ * @param retry_policy controls the number of retries, and what errors are
+ *     considered retryable.
+ * @param backoff_policy determines the wait time between retries.
+ * @param idempotent_policy determines if a request is retryable.
+ * @param async_call the callable to start a new asynchronous operation.
+ * @param request the parameters of the request.
+ * @param cq the completion queue where the retry loop is executed.
+ *
+ * @return a future that becomes satisfied when (a) one of the retry attempts
+ *     is successful, or (b) one of the retry attempts fails with a
+ *     non-retryable error, or (c) one of the retry attempts fails with a
+ *     retryable error, but the request is non-idempotent, or (d) the
+ *     retry policy is expired.
+ */
+template <typename AsyncCallType, typename RequestType,
+          typename IdempotencyPolicy,
+          typename Sig = google::cloud::internal::AsyncCallResponseType<
+              AsyncCallType, RequestType>,
+          typename ResponseType = typename Sig::type,
+          typename std::enable_if<Sig::value, int>::type = 0>
+future<StatusOr<ResponseType>> StartRetryAsyncUnaryRpc(
+    char const* location, std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy,
+    IdempotencyPolicy idempotent_policy, AsyncCallType async_call,
+    RequestType request,
+    CompletionQueue cq) {  // NOLINT(performance-unnecessary-value-param)
+  return RetryAsyncUnaryRpcFuture<
+      AsyncCallType, RequestType,
+      IdempotencyPolicy>::Start(location, std::move(retry_policy),
+                                std::move(backoff_policy),
+                                std::move(idempotent_policy),
+                                std::move(async_call), std::move(request),
+                                std::move(cq));
+}
+
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_INTERNAL_ASYNC_RETRY_UNARY_RPC_H

--- a/google/cloud/spanner/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/spanner/internal/async_retry_unary_rpc_test.cc
@@ -1,0 +1,247 @@
+// Copyright 2018 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/internal/async_retry_unary_rpc.h"
+#include "google/cloud/spanner/testing/mock_completion_queue.h"
+#include "google/cloud/spanner/testing/mock_response_reader.h"
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/chrono_literals.h"
+#include <google/spanner/v1/spanner.grpc.pb.h>
+#include <gmock/gmock.h>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+namespace {
+
+namespace spanner_proto = ::google::spanner::v1;
+using ::testing::_;
+using ::testing::Invoke;
+
+// This allows us to use constants like `10_s`, `40_us`, etc.
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace google::cloud::testing_util::chrono_literals;
+
+class MockClient {
+ public:
+  MOCK_METHOD3(
+      AsyncGetSession,
+      std::unique_ptr<
+          grpc::ClientAsyncResponseReaderInterface<spanner_proto::Session>>(
+          grpc::ClientContext* client_context,
+          spanner_proto::GetSessionRequest const& request,
+          grpc::CompletionQueue* cq));
+};
+
+TEST(AsyncRetryUnaryRpcTest, ImmediatelySucceeds) {
+  MockClient client;
+
+  using ReaderType = ::google::cloud::spanner::testing::MockAsyncResponseReader<
+      spanner_proto::Session>;
+  auto reader = google::cloud::internal::make_unique<ReaderType>();
+  EXPECT_CALL(*reader, Finish(_, _, _))
+      .WillOnce(Invoke(
+          [](spanner_proto::Session* session, grpc::Status* status, void*) {
+            // Initialize a value to make sure it is carried all the way back to
+            // the caller.
+            session->set_name("fake/session/name/response");
+            *status = grpc::Status::OK;
+          }));
+
+  EXPECT_CALL(client, AsyncGetSession(_, _, _))
+      .WillOnce(
+          Invoke([&reader](grpc::ClientContext*,
+                           spanner_proto::GetSessionRequest const& request,
+                           grpc::CompletionQueue*) {
+            EXPECT_EQ("fake/session/name/request", request.name());
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                // This is safe, see comments in MockAsyncResponseReader.
+                spanner_proto::Session>>(reader.get());
+          }));
+
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  CompletionQueue cq(impl);
+
+  // Do some basic initialization of the request to verify the values get
+  // carried to the mock.
+  spanner_proto::GetSessionRequest request;
+  request.set_name("fake/session/name/request");
+
+  auto fut = StartRetryAsyncUnaryRpc(
+      __func__, LimitedErrorCountRetryPolicy(3).clone(),
+      ExponentialBackoffPolicy(10_us, 40_us, /*scaling=*/2).clone(),
+      ConstantIdempotencyPolicy(true),
+      [&client](grpc::ClientContext* context,
+                spanner_proto::GetSessionRequest const& request,
+                grpc::CompletionQueue* cq) {
+        return client.AsyncGetSession(context, request, cq);
+      },
+      request, cq);
+
+  EXPECT_EQ(1, impl->size());
+  impl->SimulateCompletion(true);
+
+  EXPECT_TRUE(impl->empty());
+  EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+  auto result = fut.get();
+  ASSERT_STATUS_OK(result);
+  EXPECT_EQ("fake/session/name/response", result->name());
+}
+
+TEST(AsyncRetryUnaryRpcTest, PermanentFailure) {
+  MockClient client;
+
+  using ReaderType = ::google::cloud::spanner::testing::MockAsyncResponseReader<
+      spanner_proto::Session>;
+  auto reader = google::cloud::internal::make_unique<ReaderType>();
+  EXPECT_CALL(*reader, Finish(_, _, _))
+      .WillOnce(Invoke([](spanner_proto::Session*, grpc::Status* status,
+                          void*) {
+        *status = grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh-oh");
+      }));
+
+  EXPECT_CALL(client, AsyncGetSession(_, _, _))
+      .WillOnce(
+          Invoke([&reader](grpc::ClientContext*,
+                           spanner_proto::GetSessionRequest const& request,
+                           grpc::CompletionQueue*) {
+            EXPECT_EQ("fake/session/name/request", request.name());
+            return std::unique_ptr<grpc::ClientAsyncResponseReaderInterface<
+                // This is safe, see comments in MockAsyncResponseReader.
+                spanner_proto::Session>>(reader.get());
+          }));
+
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  CompletionQueue cq(impl);
+
+  // Do some basic initialization of the request to verify the values get
+  // carried to the mock.
+  spanner_proto::GetSessionRequest request;
+  request.set_name("fake/session/name/request");
+
+  auto fut = StartRetryAsyncUnaryRpc(
+      __func__, LimitedErrorCountRetryPolicy(3).clone(),
+      ExponentialBackoffPolicy(10_us, 40_us, /*scaling=*/2).clone(),
+      ConstantIdempotencyPolicy(true),
+      [&client](grpc::ClientContext* context,
+                spanner_proto::GetSessionRequest const& request,
+                grpc::CompletionQueue* cq) {
+        return client.AsyncGetSession(context, request, cq);
+      },
+      request, cq);
+
+  EXPECT_EQ(1, impl->size());
+  impl->SimulateCompletion(true);
+
+  EXPECT_TRUE(impl->empty());
+  EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+  auto result = fut.get();
+  EXPECT_FALSE(result);
+  EXPECT_EQ(StatusCode::kPermissionDenied, result.status().code());
+}
+
+TEST(AsyncRetryUnaryRpcTest, TooManyTransientFailures) {
+  MockClient client;
+
+  using ReaderType = ::google::cloud::spanner::testing::MockAsyncResponseReader<
+      spanner_proto::Session>;
+
+  auto finish_failure = [](spanner_proto::Session*, grpc::Status* status,
+                           void*) {
+    *status = grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again");
+  };
+
+  auto r1 = google::cloud::internal::make_unique<ReaderType>();
+  EXPECT_CALL(*r1, Finish(_, _, _)).WillOnce(Invoke(finish_failure));
+  auto r2 = google::cloud::internal::make_unique<ReaderType>();
+  EXPECT_CALL(*r2, Finish(_, _, _)).WillOnce(Invoke(finish_failure));
+  auto r3 = google::cloud::internal::make_unique<ReaderType>();
+  EXPECT_CALL(*r3, Finish(_, _, _)).WillOnce(Invoke(finish_failure));
+
+  EXPECT_CALL(client, AsyncGetSession(_, _, _))
+      .WillOnce(Invoke([&r1](grpc::ClientContext*,
+                             spanner_proto::GetSessionRequest const& request,
+                             grpc::CompletionQueue*) {
+        EXPECT_EQ("fake/session/name/request", request.name());
+        return std::unique_ptr<
+            grpc::ClientAsyncResponseReaderInterface<spanner_proto::Session>>(
+            r1.get());
+      }))
+      .WillOnce(Invoke([&r2](grpc::ClientContext*,
+                             spanner_proto::GetSessionRequest const& request,
+                             grpc::CompletionQueue*) {
+        EXPECT_EQ("fake/session/name/request", request.name());
+        return std::unique_ptr<
+            grpc::ClientAsyncResponseReaderInterface<spanner_proto::Session>>(
+            r2.get());
+      }))
+      .WillOnce(Invoke([&r3](grpc::ClientContext*,
+                             spanner_proto::GetSessionRequest const& request,
+                             grpc::CompletionQueue*) {
+        EXPECT_EQ("fake/session/name/request", request.name());
+        return std::unique_ptr<
+            grpc::ClientAsyncResponseReaderInterface<spanner_proto::Session>>(
+            r3.get());
+      }));
+
+  auto impl = std::make_shared<testing::MockCompletionQueue>();
+  CompletionQueue cq(impl);
+
+  // Do some basic initialization of the request to verify the values get
+  // carried to the mock.
+  spanner_proto::GetSessionRequest request;
+  request.set_name("fake/session/name/request");
+
+  auto fut = StartRetryAsyncUnaryRpc(
+      __func__, LimitedErrorCountRetryPolicy(2).clone(),
+      ExponentialBackoffPolicy(10_us, 40_us, /*scaling=*/2).clone(),
+      ConstantIdempotencyPolicy(true),
+      [&client](grpc::ClientContext* context,
+                spanner_proto::GetSessionRequest const& request,
+                grpc::CompletionQueue* cq) {
+        return client.AsyncGetSession(context, request, cq);
+      },
+      request, cq);
+
+  // Because the maximum number of failures is 2 we expect 3 calls (the 3rd
+  // failure is the "too many" case). In between the calls there are timers
+  // executed, but there is no timer after the 3rd failure.
+  EXPECT_EQ(1, impl->size());  // simulate the call completing
+  impl->SimulateCompletion(true);
+  EXPECT_EQ(1, impl->size());  // simulate the timer completing
+  impl->SimulateCompletion(true);
+  EXPECT_EQ(1, impl->size());  // simulate the call completing
+  impl->SimulateCompletion(true);
+  EXPECT_EQ(1, impl->size());  // simulate the timer completing
+  impl->SimulateCompletion(true);
+  EXPECT_EQ(1, impl->size());  // simulate the call completing
+  impl->SimulateCompletion(true);
+  EXPECT_TRUE(impl->empty());
+
+  EXPECT_EQ(std::future_status::ready, fut.wait_for(0_us));
+  auto result = fut.get();
+  EXPECT_FALSE(result);
+  EXPECT_EQ(StatusCode::kUnavailable, result.status().code());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/spanner/internal/async_retry_unary_rpc_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC.
+// Copyright 2020 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/spanner/spanner_client.bzl
+++ b/google/cloud/spanner/spanner_client.bzl
@@ -36,6 +36,8 @@ spanner_client_hdrs = [
     "instance_admin_client.h",
     "instance_admin_connection.h",
     "internal/api_client_header.h",
+    "internal/async_retry_op.h",
+    "internal/async_retry_unary_rpc.h",
     "internal/build_info.h",
     "internal/channel.h",
     "internal/compiler_info.h",

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -19,9 +19,11 @@
 spanner_client_testing_hdrs = [
     "testing/database_environment.h",
     "testing/matchers.h",
+    "testing/mock_completion_queue.h",
     "testing/mock_database_admin_stub.h",
     "testing/mock_instance_admin_stub.h",
     "testing/mock_partial_result_set_reader.h",
+    "testing/mock_response_reader.h",
     "testing/mock_spanner_stub.h",
     "testing/pick_random_instance.h",
     "testing/random_backup_name.h",

--- a/google/cloud/spanner/spanner_client_unit_tests.bzl
+++ b/google/cloud/spanner/spanner_client_unit_tests.bzl
@@ -31,6 +31,7 @@ spanner_client_unit_tests = [
     "instance_admin_connection_test.cc",
     "instance_test.cc",
     "internal/api_client_header_test.cc",
+    "internal/async_retry_unary_rpc_test.cc",
     "internal/build_info_test.cc",
     "internal/compiler_info_test.cc",
     "internal/connection_impl_test.cc",

--- a/google/cloud/spanner/testing/mock_completion_queue.h
+++ b/google/cloud/spanner/testing/mock_completion_queue.h
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/google/cloud/spanner/testing/mock_completion_queue.h
+++ b/google/cloud/spanner/testing/mock_completion_queue.h
@@ -1,0 +1,46 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_COMPLETION_QUEUE_H
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_COMPLETION_QUEUE_H
+
+#include "google/cloud/completion_queue.h"
+
+namespace google {
+namespace cloud {
+namespace spanner {
+namespace testing {
+// Tests typically create an instance of this class, then create a
+// `google::cloud::CompletionQueue` to wrap it, keeping a reference to
+// the instance to manipulate its state directly.
+class MockCompletionQueue
+    : public google::cloud::internal::CompletionQueueImpl {
+ public:
+  std::unique_ptr<grpc::Alarm> CreateAlarm() const override {
+    // grpc::Alarm objects are really hard to cleanup when mocking their
+    // behavior, so we do not create an alarm, instead we return nullptr, which
+    // the classes that care (AsyncTimerFunctor) know what to do with.
+    return std::unique_ptr<grpc::Alarm>();
+  }
+
+  using CompletionQueueImpl::empty;
+  using CompletionQueueImpl::SimulateCompletion;
+  using CompletionQueueImpl::size;
+};
+}  // namespace testing
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_COMPLETION_QUEUE_H

--- a/google/cloud/spanner/testing/mock_response_reader.h
+++ b/google/cloud/spanner/testing/mock_response_reader.h
@@ -1,0 +1,134 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_RESPONSE_READER_H
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_RESPONSE_READER_H
+
+#include "google/cloud/spanner/internal/api_client_header.h"
+#include "google/cloud/spanner/testing/validate_metadata.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include <gmock/gmock.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/impl/codegen/async_stream.h>
+#include <grpcpp/impl/codegen/sync_stream.h>
+#include <grpcpp/support/async_unary_call.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+namespace testing {
+/**
+ * Refactor code common to several mock objects.
+ *
+ * Mocking a grpc::ClientReaderInterface<> was getting tedious. This refactors
+ * most (but unfortunately cannnot refactor all) the code for such objects.
+ *
+ * @tparam Response the response type.
+ */
+template <typename Response, typename Request>
+class MockResponseReader : public grpc::ClientReaderInterface<Response> {
+ public:
+  explicit MockResponseReader(std::string method)
+      : method_(std::move(method)) {}
+  MOCK_METHOD0(WaitForInitialMetadata, void());
+  MOCK_METHOD0(Finish, grpc::Status());
+  MOCK_METHOD1(NextMessageSize, bool(std::uint32_t*));
+  MOCK_METHOD1_T(Read, bool(Response*));
+
+  using UniquePtr = std::unique_ptr<grpc::ClientReaderInterface<Response>>;
+
+  /// Return a `std::unique_ptr< mocked-class >`
+  UniquePtr AsUniqueMocked() { return UniquePtr(this); }
+
+  /**
+   * Create a lambda that returns a `std::unique_ptr< mocked-class >`.
+   *
+   * Often the test code has to create a lambda that returns one of these mocks
+   * wrapped in the correct (the base class) `std::unique_ptr<>`.
+   *
+   * We cannot use just `::testing::Return()` because that binds to the static
+   * type of the returned object, and we need to return a `std::unique_ptr<Foo>`
+   * where we have a `MockFoo*`.  And we cannot create a `std::unique_ptr<>`
+   * and pass it because `::testing::Return()` assumes copy constructions and
+   * `std::unique_ptr<>` only supports move constructors.
+   */
+  std::function<UniquePtr(grpc::ClientContext*, Request const&)>
+  MakeMockReturner() {
+    return [this](grpc::ClientContext* context, Request const&) {
+      EXPECT_STATUS_OK(google::cloud::spanner_testing::IsContextMDValid(
+          *context, method_,
+          google::cloud::spanner::internal::ApiClientHeader()));
+      return UniquePtr(this);
+    };
+  }
+
+ private:
+  std::string method_;
+};
+
+/**
+ * Define the interface to mock the result of starting a unary async RPC.
+ *
+ * Note that using this mock often requires special memory management. The
+ * google mock library requires all mocks to be destroyed. In contrast, grpc
+ * specializes `std::unique_ptr<>` to *not* delete objects of type
+ * `grpc::ClientAsyncResponseReaderInterface<T>`:
+ *
+ *
+ *     https://github.com/grpc/grpc/blob/608188c680961b8506847c135b5170b41a9081e8/include/grpcpp/impl/codegen/async_unary_call.h#L305
+ *
+ * No delete, no destructor, nothing. The gRPC library expects all
+ * `grpc::ClientAsyncResponseReader<R>` objects to be allocated from a
+ * per-call arena, and deleted in bulk with other objects when the call
+ * completes and the full arena is released. Unfortunately, our mocks are
+ * allocated from the global heap, as they do not have an associated call or
+ * arena. The override in the gRPC library results in a leak, unless we manage
+ * the memory explicitly.
+ *
+ * As a result, the unit tests need to manually delete the objects. The idiom we
+ * use is a terrible, horrible, no good, very bad hack:
+ *
+ * We create a unique pointer to `MockAsyncResponseReader<T>`, then we pass that
+ * pointer to gRPC using `reader.get()`, and gRPC promptly puts it into a
+ * `std::unique_ptr<ClientAsyncResponseReaderInterface<T>>`. That looks like a
+ * double delete waiting to happen, but it is not, because gRPC has done the
+ * weird specialization of `std::unique_ptr`.
+ *
+ * @tparam Response the type of the RPC response
+ */
+template <typename Response>
+class MockAsyncResponseReader
+    : public grpc::ClientAsyncResponseReaderInterface<Response> {
+ public:
+  MOCK_METHOD0(StartCall, void());
+  MOCK_METHOD1(ReadInitialMetadata, void(void*));
+  MOCK_METHOD3_T(Finish, void(Response*, grpc::Status*, void*));
+};
+
+template <typename Response>
+class MockClientAsyncReaderInterface
+    : public grpc::ClientAsyncReaderInterface<Response> {
+ public:
+  MOCK_METHOD1(StartCall, void(void*));
+  MOCK_METHOD1(ReadInitialMetadata, void(void*));
+  MOCK_METHOD2(Finish, void(grpc::Status*, void*));
+  MOCK_METHOD2_T(Read, void(Response*, void*));
+};
+
+}  // namespace testing
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_MOCK_RESPONSE_READER_H


### PR DESCRIPTION
These are mostly copied from `bigtable` in the `google-cloud-cpp` repo.
We should eventually factor these out to `-common`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1389)
<!-- Reviewable:end -->
