### PR TITLE
feat: add async calls to `SessionPool`

### DIFF
--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/session_pool.h"
+#include "google/cloud/spanner/internal/async_retry_unary_rpc.h"
 #include "google/cloud/spanner/internal/connection_impl.h"
 #include "google/cloud/spanner/internal/retry_loop.h"
 #include "google/cloud/spanner/internal/session.h"
@@ -360,6 +361,61 @@ SessionHolder SessionPool::MakeSessionHolder(std::unique_ptr<Session> session,
       shared_pool->Release(std::move(session));
     }
   });
+}
+
+future<StatusOr<spanner_proto::BatchCreateSessionsResponse>>
+SessionPool::AsyncBatchCreateSessions(
+    CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+    std::map<std::string, std::string> const& labels, int num_sessions) {
+  spanner_proto::BatchCreateSessionsRequest request;
+  request.set_database(db_.FullName());
+  request.mutable_session_template()->mutable_labels()->insert(labels.begin(),
+                                                               labels.end());
+  request.set_session_count(std::int32_t{num_sessions});
+  return internal::StartRetryAsyncUnaryRpc(
+      __func__, retry_policy_prototype_->clone(),
+      backoff_policy_prototype_->clone(),
+      internal::ConstantIdempotencyPolicy(true),
+      [&stub](grpc::ClientContext* context,
+              spanner_proto::BatchCreateSessionsRequest const& request,
+              grpc::CompletionQueue* cq) {
+        return stub->AsyncBatchCreateSessions(*context, request, cq);
+      },
+      std::move(request), cq);
+}
+
+future<StatusOr<google::protobuf::Empty>> SessionPool::AsyncDeleteSession(
+    CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+    std::string session_name) {
+  spanner_proto::DeleteSessionRequest request;
+  request.set_name(std::move(session_name));
+  return internal::StartRetryAsyncUnaryRpc(
+      __func__, retry_policy_prototype_->clone(),
+      backoff_policy_prototype_->clone(),
+      internal::ConstantIdempotencyPolicy(true),
+      [&stub](grpc::ClientContext* context,
+              spanner_proto::DeleteSessionRequest const& request,
+              grpc::CompletionQueue* cq) {
+        return stub->AsyncDeleteSession(*context, request, cq);
+      },
+      std::move(request), cq);
+}
+
+future<StatusOr<spanner_proto::Session>> SessionPool::AsyncGetSession(
+    CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+    std::string session_name) {
+  spanner_proto::GetSessionRequest request;
+  request.set_name(std::move(session_name));
+  return internal::StartRetryAsyncUnaryRpc(
+      __func__, retry_policy_prototype_->clone(),
+      backoff_policy_prototype_->clone(),
+      internal::ConstantIdempotencyPolicy(true),
+      [&stub](grpc::ClientContext* context,
+              spanner_proto::GetSessionRequest const& request,
+              grpc::CompletionQueue* cq) {
+        return stub->AsyncGetSession(*context, request, cq);
+      },
+      std::move(request), cq);
 }
 
 }  // namespace internal

--- a/google/cloud/spanner/internal/session_pool.cc
+++ b/google/cloud/spanner/internal/session_pool.cc
@@ -365,7 +365,9 @@ SessionHolder SessionPool::MakeSessionHolder(std::unique_ptr<Session> session,
 
 future<StatusOr<spanner_proto::BatchCreateSessionsResponse>>
 SessionPool::AsyncBatchCreateSessions(
-    CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+    CompletionQueue& cq,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::shared_ptr<SpannerStub> stub,
     std::map<std::string, std::string> const& labels, int num_sessions) {
   spanner_proto::BatchCreateSessionsRequest request;
   request.set_database(db_.FullName());
@@ -376,43 +378,45 @@ SessionPool::AsyncBatchCreateSessions(
       __func__, retry_policy_prototype_->clone(),
       backoff_policy_prototype_->clone(),
       internal::ConstantIdempotencyPolicy(true),
-      [&stub](grpc::ClientContext* context,
-              spanner_proto::BatchCreateSessionsRequest const& request,
-              grpc::CompletionQueue* cq) {
+      [stub](grpc::ClientContext* context,
+             spanner_proto::BatchCreateSessionsRequest const& request,
+             grpc::CompletionQueue* cq) {
         return stub->AsyncBatchCreateSessions(*context, request, cq);
       },
       std::move(request), cq);
 }
 
 future<StatusOr<google::protobuf::Empty>> SessionPool::AsyncDeleteSession(
-    CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
-    std::string session_name) {
+    CompletionQueue& cq,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::shared_ptr<SpannerStub> stub, std::string session_name) {
   spanner_proto::DeleteSessionRequest request;
   request.set_name(std::move(session_name));
   return internal::StartRetryAsyncUnaryRpc(
       __func__, retry_policy_prototype_->clone(),
       backoff_policy_prototype_->clone(),
       internal::ConstantIdempotencyPolicy(true),
-      [&stub](grpc::ClientContext* context,
-              spanner_proto::DeleteSessionRequest const& request,
-              grpc::CompletionQueue* cq) {
+      [stub](grpc::ClientContext* context,
+             spanner_proto::DeleteSessionRequest const& request,
+             grpc::CompletionQueue* cq) {
         return stub->AsyncDeleteSession(*context, request, cq);
       },
       std::move(request), cq);
 }
 
 future<StatusOr<spanner_proto::Session>> SessionPool::AsyncGetSession(
-    CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
-    std::string session_name) {
+    CompletionQueue& cq,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::shared_ptr<SpannerStub> stub, std::string session_name) {
   spanner_proto::GetSessionRequest request;
   request.set_name(std::move(session_name));
   return internal::StartRetryAsyncUnaryRpc(
       __func__, retry_policy_prototype_->clone(),
       backoff_policy_prototype_->clone(),
       internal::ConstantIdempotencyPolicy(true),
-      [&stub](grpc::ClientContext* context,
-              spanner_proto::GetSessionRequest const& request,
-              grpc::CompletionQueue* cq) {
+      [stub](grpc::ClientContext* context,
+             spanner_proto::GetSessionRequest const& request,
+             grpc::CompletionQueue* cq) {
         return stub->AsyncGetSession(*context, request, cq);
       },
       std::move(request), cq);

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -118,6 +118,19 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
   SessionHolder MakeSessionHolder(std::unique_ptr<Session> session,
                                   bool dissociate_from_pool);
 
+  // Asynchronous calls used to maintain the pool.
+  future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
+  AsyncBatchCreateSessions(CompletionQueue& cq,
+                           std::shared_ptr<SpannerStub> stub,
+                           std::map<std::string, std::string> const& labels,
+                           int num_sessions);
+  future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
+      CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+      std::string session_name);
+  future<StatusOr<google::spanner::v1::Session>> AsyncGetSession(
+      CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+      std::string session_name);
+
   void UpdateNextChannelForCreateSessions();  // EXCLUSIVE_LOCKS_REQUIRED(mu_)
 
   void ScheduleBackgroundWork(std::chrono::seconds relative_time);


### PR DESCRIPTION
note #1389 is effectively a DIFFBASE; you only need to review the
changes in `session_pool.{h,cc}` in this PR.

Adds wrappers for Async{BatchCreate,Delete,Get}Session that use the
retry loops from #1389 and returns a future for the result of the call.

These could undoubtably use some tests.

fixes #1365

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1390)
<!-- Reviewable:end -->
