### PR TITLE
feat: adds BUILD target to top-level BUILD file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,3 +19,11 @@ licenses(["notice"])  # Apache 2.0
 exports_files([
     "LICENSE",
 ])
+
+cc_library(
+    name = "spanner_client",
+    includes = ["."],
+    deps = [
+        "//google/cloud/spanner:spanner_client",
+    ],
+)

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#XXX) Change this visibility to "//:__subpackages__" so that users are
+# TODO(#1415) Change this visibility to "//:__subpackages__" so that users are
 # required to use the top-level BUILD file rather than reaching down into this
 # one.
 package(default_visibility = ["//visibility:public"])

--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(#XXX) Change this visibility to "//:__subpackages__" so that users are
+# required to use the top-level BUILD file rather than reaching down into this
+# one.
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0


### PR DESCRIPTION
Adds user-facing bazel build targets to the project's top-level BUILD
file. This file should list *all* of the BUILD targets that users are
allowed to use. In a future PR, visibility restrictions should prohibit
users from reaching down into `google/cloud/spanner/BUILD`.

This change will make things simpler for users since they'll have a
single, uncomplicated, top-level BUILD file that contains all the build
targets that they're allowed to use. It also gives us a place to put an
`includes = ["."]` directive, which will allow Bazel users to include
our headers using either double quotes or angle brackets.

Related to #1296

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1396)
<!-- Reviewable:end -->
