### PR TITLE
ci: update builds to use g-c-cpp-common v0.23.0

### DIFF
--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -42,11 +42,11 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_googleapis_google_cloud_cpp_common" not in native.existing_rules():
         http_archive(
             name = "com_github_googleapis_google_cloud_cpp_common",
-            strip_prefix = "google-cloud-cpp-common-0.21.0",
+            strip_prefix = "google-cloud-cpp-common-0.23.0",
             urls = [
-                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz",
             ],
-            sha256 = "2e1cd2a97122a02fe3c58a997657a360e19ec9984b857197a9a193a07b4c092b",
+            sha256 = "5079dfa6a1d735a9da52769fc0619030cef3f82a1f30a2a66f7825f9c148b24e",
         )
 
     # Load a version of googletest that we know works.

--- a/ci/etc/kokoro/install/version-config.sh
+++ b/ci/etc/kokoro/install/version-config.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly GOOGLE_CLOUD_CPP_COMMON_VERSION=0.21.0
+readonly GOOGLE_CLOUD_CPP_COMMON_VERSION=0.23.0

--- a/ci/kokoro/Dockerfile.fedora-install
+++ b/ci/kokoro/Dockerfile.fedora-install
@@ -77,9 +77,9 @@ RUN cmake --build cmake-out --target install
 
 # Download and compile google-cloud-cpp from source too:
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz
-RUN tar -xf v0.21.0.tar.gz
-WORKDIR /var/tmp/build/google-cloud-cpp-common-0.21.0
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz
+RUN tar -xf v0.23.0.tar.gz
+WORKDIR /var/tmp/build/google-cloud-cpp-common-0.23.0
 # Compile without the tests because we are testing spanner, not the base
 # libraries
 RUN cmake -H. -Bcmake-out \

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -123,9 +123,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.6.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -102,9 +102,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.6.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.debian-buster
+++ b/ci/kokoro/install/Dockerfile.debian-buster
@@ -65,9 +65,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.6.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -98,9 +98,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.6.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.fedora
+++ b/ci/kokoro/install/Dockerfile.fedora
@@ -71,9 +71,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.6.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -118,9 +118,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.6.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
+++ b/ci/kokoro/install/Dockerfile.opensuse-tumbleweed
@@ -69,9 +69,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.6.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -91,9 +91,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.6.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -106,9 +106,9 @@ RUN wget -q https://github.com/googleapis/cpp-cmakefiles/archive/v0.6.0.tar.gz &
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+RUN wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
     cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/ci/kokoro/windows/google-cloud-cpp-common/CONTROL
+++ b/ci/kokoro/windows/google-cloud-cpp-common/CONTROL
@@ -1,0 +1,9 @@
+Source: google-cloud-cpp-common
+Version: 0.23.0
+Build-Depends: grpc, googleapis
+Description: Base C++ Libraries for Google Cloud Platform APIs
+Homepage: https://github.com/googleapis/google-cloud-cpp-common
+
+Feature: test
+Description: Build test
+Build-Depends: gtest

--- a/ci/kokoro/windows/google-cloud-cpp-common/portfile.cmake
+++ b/ci/kokoro/windows/google-cloud-cpp-common/portfile.cmake
@@ -1,0 +1,39 @@
+include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH
+    SOURCE_PATH
+    REPO
+    googleapis/google-cloud-cpp-common
+    REF
+    v0.23.0
+    SHA512
+    76b610b8d345f49c101b7de885287df6289f5f4349c59b5c38683fc299c5cbdb7b763700cdc3e75460802bf2da36f1b75e8ff5e660a622451d23523f34e5a001
+    HEAD_REF
+    master)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS test BUILD_TESTING)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH
+    ${SOURCE_PATH}
+    PREFER_NINJA
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+    ${FEATURE_OPTIONS}
+    -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF)
+
+vcpkg_install_cmake(ADD_BIN_TO_PATH)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(
+    INSTALL ${SOURCE_PATH}/LICENSE
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/google-cloud-cpp-common
+    RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -127,9 +127,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -244,9 +244,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -334,9 +334,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -439,9 +439,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -503,9 +503,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -600,9 +600,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -701,9 +701,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
@@ -823,9 +823,9 @@ all the Google Cloud C++ client libraries:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz && \
-    tar -xf v0.21.0.tar.gz && \
-    cd google-cloud-cpp-common-0.21.0 && \
+wget -q https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz && \
+    tar -xf v0.23.0.tar.gz && \
+    cd google-cloud-cpp-common-0.23.0 && \
     cmake -H. -Bcmake-out -DBUILD_TESTING=OFF && \
     cmake --build cmake-out -- -j ${NCPU:-4} && \
 sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \

--- a/super/external/google-cloud-cpp-common.cmake
+++ b/super/external/google-cloud-cpp-common.cmake
@@ -23,10 +23,10 @@ if (NOT TARGET google-cloud-cpp-common-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_URL
-        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.21.0.tar.gz"
+        "https://github.com/googleapis/google-cloud-cpp-common/archive/v0.23.0.tar.gz"
     )
     set(GOOGLE_CLOUD_CPP_SHA256
-        "2e1cd2a97122a02fe3c58a997657a360e19ec9984b857197a9a193a07b4c092b")
+        "5079dfa6a1d735a9da52769fc0619030cef3f82a1f30a2a66f7825f9c148b24e")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
Part of the work for googleapis/google-cloud-cpp-common#248

----
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1399)
<!-- Reviewable:end -->
