### PR TITLE
ci: run benchmarks in CMake-based builds

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -424,6 +424,7 @@ function (spanner_client_define_benchmarks)
         string(REPLACE "/" "_" target ${fname})
         string(REPLACE ".cc" "" target ${target})
         add_executable(${target} ${fname})
+        add_test(NAME ${target} COMMAND ${target})
         target_link_libraries(${target} PRIVATE googleapis-c++::spanner_client
                                                 benchmark::benchmark_main)
         google_cloud_cpp_add_clang_tidy(${target})


### PR DESCRIPTION
The benchmarks were not declared "tests" so they would not run as
part as the regular CMake builds. We may not have strict testing
criteria for them, but at least we should run them to avoid code rot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1400)
<!-- Reviewable:end -->
