### PR TITLE
feat: streaming Value STRING only quotes in aggregates

### DIFF
--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -85,12 +85,12 @@ TEST(SqlStatementTest, OStreamOperatorWithParams) {
   SqlStatement stmt("select * from foo", params);
   std::string expected1(
       "select * from foo\n"
-      "[param]: {first=\"Elwood\"}\n"
-      "[param]: {last=\"Blues\"}");
+      "[param]: {first=Elwood}\n"
+      "[param]: {last=Blues}");
   std::string expected2(
       "select * from foo\n"
-      "[param]: {last=\"Blues\"}\n"
-      "[param]: {first=\"Elwood\"}");
+      "[param]: {last=Blues}\n"
+      "[param]: {first=Elwood}");
   std::stringstream ss;
   ss << stmt;
   EXPECT_THAT(ss.str(), AnyOf(Eq(expected1), Eq(expected2)));

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -90,8 +90,25 @@ bool Equal(google::spanner::v1::Type const& pt1,
   }
 }
 
+// A helper to escape all double quotes in the given string `s`. For example,
+// if given `"foo"`, outputs `\"foo\"`. This is useful when a caller needs to
+// wrap `s` itself in double quotes.
+std::ostream& EscapeQuotes(std::ostream& os, std::string const& s) {
+  for (auto const& c : s) {
+    if (c == '"') os << "\\";
+    os << c;
+  }
+  return os;
+}
+
+// An enum to tell StreamHelper() whether a value is being printed as a scalar
+// or as part of an aggregate type (i.e., a vector or tuple). Some types may
+// format themselves differently in each case.
+enum class StreamMode { kScalar, kAggregate };
+
 std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
-                           google::spanner::v1::Type const& t) {
+                           google::spanner::v1::Type const& t,
+                           StreamMode mode) {
   if (v.kind_case() == google::protobuf::Value::kNullValue) {
     return os << "NULL";
   }
@@ -107,21 +124,28 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
       return os << internal::FromProto(t, v).get<double>().value();
 
     case google::spanner::v1::STRING:
-      return os << "\"" << v.string_value() << "\"";
+      switch (mode) {
+        case StreamMode::kScalar:
+          return os << v.string_value();
+        case StreamMode::kAggregate:
+          os << '"';
+          EscapeQuotes(os, v.string_value());
+          return os << '"';
+      }
+
+    case google::spanner::v1::BYTES:
+      return os << internal::BytesFromBase64(v.string_value()).value();
 
     case google::spanner::v1::TIMESTAMP:
     case google::spanner::v1::DATE:
       return os << v.string_value();
-
-    case google::spanner::v1::BYTES:
-      return os << internal::BytesFromBase64(v.string_value()).value();
 
     case google::spanner::v1::ARRAY: {
       const char* delimiter = "";
       os << '[';
       for (auto const& e : v.list_value().values()) {
         os << delimiter;
-        StreamHelper(os, e, t.array_element_type());
+        StreamHelper(os, e, t.array_element_type(), StreamMode::kAggregate);
         delimiter = ", ";
       }
       return os << ']';
@@ -133,10 +157,12 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
       for (int i = 0; i < v.list_value().values_size(); ++i) {
         os << delimiter;
         if (!t.struct_type().fields(i).name().empty()) {
-          os << t.struct_type().fields(i).name() << ": ";
+          os << '"';
+          EscapeQuotes(os, t.struct_type().fields(i).name());
+          os << '"' << ": ";
         }
         StreamHelper(os, v.list_value().values(i),
-                     t.struct_type().fields(i).type());
+                     t.struct_type().fields(i).type(), StreamMode::kAggregate);
         delimiter = ", ";
       }
       return os << ')';
@@ -167,7 +193,7 @@ bool operator==(Value const& a, Value const& b) {
 }
 
 std::ostream& operator<<(std::ostream& os, Value const& v) {
-  return StreamHelper(os, v.value_, v.type_);
+  return StreamHelper(os, v.value_, v.type_, StreamMode::kScalar);
 }
 
 //

--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -132,6 +132,7 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
           EscapeQuotes(os, v.string_value());
           return os << '"';
       }
+      return os;  // Unreachable, but quiets warning.
 
     case google::spanner::v1::BYTES:
       return os << internal::BytesFromBase64(v.string_value()).value();


### PR DESCRIPTION
Fixes: #1391

This PR changes the way `Value(string)` streams its values.
Specifically, double quotes are no longer included when streaming scalar
`Value(string)` values. For example: `std::cout << Value("foo")` would
output `foo` (no quotes). This behavior matches that of `std::cout <<
std::string("foo")`.

However, when streaming strings as part of an aggregate type
(std::vector or std::tuple), strings *will be* wrapped in double quotes
so that the contents of the string does not break the
structure/formatting of the printed array/struct itself. Any double
quotes in the string itself will be backslash escaped.

This PR also adds double-quoting to field names in tuples, which are
strings and should therefore also be quoted like other string fields in
aggregates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1401)
<!-- Reviewable:end -->
