### PR TITLE
testing: use temporary instances in us-west for integration tests and samples

### DIFF
--- a/doc/testing-resources.md
+++ b/doc/testing-resources.md
@@ -1,12 +1,12 @@
 # Some rules around Spanner resources
 
 We're running integration tests and samples on every PR. We've created
-pre-defined Spanner instances for speeding up the tests. Also some test suite
+pre-defined Spanner instances for speeding up the tests. Also some of our tests
 need to create a new Spanner instance. There are certain rules on instance names
 and InstanceConfig for those instances.
 
 Pre-defined Spanner instances have instance ids prefixed with `test-instance-n`
-where n is just index number, and they're in `us-central` or `us-east`.
+where `n` is just an index number, and they're in `us-central` or `us-east`.
 
 Temporary Spanner instances have instance ids prefixed with
-`temporary-instance-YYY-MM-DD` and they're in `us-west`.
+`temporary-instance-YYY-MM-DD` and they're in `us-west*`.

--- a/doc/testing-resources.md
+++ b/doc/testing-resources.md
@@ -1,0 +1,12 @@
+# Some rules around Spanner resources
+
+We're running integration tests and samples on every PR. We've created
+pre-defined Spanner instances for speeding up the tests. Also some test suite
+need to create a new Spanner instance. There are certain rules on instance names
+and InstanceConfig for those instances.
+
+Pre-defined Spanner instances have instance ids prefixed with `test-instance-n`
+where n is just index number, and they're in `us-central` or `us-east`.
+
+Temporary Spanner instances have instance ids prefixed with
+`temporary-instance-YYY-MM-DD` and they're in `us-west`.

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -283,6 +283,8 @@ function (spanner_client_define_tests)
         testing/mock_partial_result_set_reader.h
         testing/mock_response_reader.h
         testing/mock_spanner_stub.h
+        testing/pick_instance_config.cc
+        testing/pick_instance_config.h
         testing/pick_random_instance.cc
         testing/pick_random_instance.h
         testing/random_backup_name.cc

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -68,6 +68,9 @@ function (spanner_client_define_integration_tests)
         add_dependencies(spanner-client-integration-tests ${target})
     endforeach ()
 
+    # backup_integration_test sometimes takes long time
+    set_tests_properties("backup_integration_test" PROPERTIES TIMEOUT 2400)
+
     if (MSVC)
         # MSVC warns about using localtime(), this is a valuable warning, so we
         # do not want to disable for everything. But for these files the usage

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -25,6 +25,7 @@ spanner_client_testing_hdrs = [
     "testing/mock_partial_result_set_reader.h",
     "testing/mock_response_reader.h",
     "testing/mock_spanner_stub.h",
+    "testing/pick_instance_config.h",
     "testing/pick_random_instance.h",
     "testing/random_backup_name.h",
     "testing/random_database_name.h",
@@ -34,6 +35,7 @@ spanner_client_testing_hdrs = [
 
 spanner_client_testing_srcs = [
     "testing/database_environment.cc",
+    "testing/pick_instance_config.cc",
     "testing/pick_random_instance.cc",
     "testing/random_backup_name.cc",
     "testing/random_database_name.cc",

--- a/google/cloud/spanner/testing/pick_instance_config.cc
+++ b/google/cloud/spanner/testing/pick_instance_config.cc
@@ -1,0 +1,56 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/testing/pick_instance_config.h"
+#include "google/cloud/spanner/connection_options.h"
+#include "google/cloud/spanner/instance_admin_client.h"
+#include <regex>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+
+std::string PickInstanceConfig(
+    std::string const& project_id, std::regex const& filter_regex,
+    google::cloud::internal::DefaultPRNG& generator) {
+  spanner::InstanceAdminClient client(spanner::MakeInstanceAdminConnection());
+  std::string instance_config_name{};
+  auto instance_configs =
+      [&client, &instance_config_name, &project_id,
+       &filter_regex]() mutable -> std::vector<std::string> {
+    std::vector<std::string> ret;
+    for (auto const& instance_config : client.ListInstanceConfigs(project_id)) {
+      if (!instance_config) return ret;
+      if (instance_config_name.empty()) {
+        instance_config_name = instance_config->name();
+      }
+      if (std::regex_match(instance_config->name(), filter_regex)) {
+        ret.push_back(instance_config->name());
+      }
+    }
+    return ret;
+  }();
+  if (instance_configs.size() > 0) {
+    auto random_index = std::uniform_int_distribution<std::size_t>(
+        0, instance_configs.size() - 1);
+    instance_config_name = instance_configs[random_index(generator)];
+  }
+  return instance_config_name;
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/testing/pick_instance_config.h
+++ b/google/cloud/spanner/testing/pick_instance_config.h
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_PICK_INSTANCE_CONFIG_H
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_PICK_INSTANCE_CONFIG_H
+
+#include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/internal/random.h"
+#include <regex>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+
+/// Pick one instance_config from a list given a PRNG generator, project_id,
+/// and a regex for filtering, if none matches the filter, it will return the
+/// value for the first element.
+std::string PickInstanceConfig(std::string const& project_id,
+                               std::regex const& filter_regex,
+                               google::cloud::internal::DefaultPRNG& generator);
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_PICK_INSTANCE_CONFIG_H


### PR DESCRIPTION
also increase the timeout for backup_integration_test.
also create a document for Spanner resource rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1403)
<!-- Reviewable:end -->
