### PR TITLE
fix: workaround bugs in clang-3.8

### DIFF
--- a/google/cloud/spanner/bytes_test.cc
+++ b/google/cloud/spanner/bytes_test.cc
@@ -282,7 +282,8 @@ TEST(Bytes, OutputStreamEscapingCannotFail) {
   for (int i = 0; i < std::numeric_limits<ByteType>::max() + 1; ++i) {
     auto const b = static_cast<ByteType>(i);
     std::ostringstream ss;
-    ss << Bytes(std::array<ByteType, 1>{b});
+    // Workaround clang-3.8 bug by using double braces
+    ss << Bytes(std::array<ByteType, 1>{{b}});
     EXPECT_NE(ss.str(), R"(B"\?")") << "i=" << i;
   }
 }

--- a/google/cloud/spanner/client_options_test.cc
+++ b/google/cloud/spanner/client_options_test.cc
@@ -24,7 +24,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 TEST(ClientOptionsTest, OptimizerVersion) {
-  ClientOptions const default_constructed;
+  ClientOptions const default_constructed{};
   EXPECT_EQ(QueryOptions{}, default_constructed.query_options());
 
   auto copy = default_constructed;

--- a/google/cloud/spanner/query_options_test.cc
+++ b/google/cloud/spanner/query_options_test.cc
@@ -23,7 +23,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace {
 
 TEST(QueryOptionsTest, OptimizerVersion) {
-  QueryOptions const default_constructed;
+  QueryOptions const default_constructed{};
   EXPECT_FALSE(default_constructed.optimizer_version().has_value());
 
   auto copy = default_constructed;


### PR DESCRIPTION
The build is not actually using Clang-3.8, that fix will come in a
separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1408)
<!-- Reviewable:end -->
