### PR TITLE
cleanup: fix clang-tidy-9 warnings

### DIFF
--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -295,7 +295,7 @@ class InsertOrUpdateExperiment : public Experiment {
     auto start = std::chrono::steady_clock::now();
     for (auto& t : tasks) {
       t = std::async(std::launch::async, &InsertOrUpdateExperiment::RunTask,
-                     this, config, client, locked_random_key, error_sink);
+                     config, client, locked_random_key, error_sink);
     }
     int insert_count = 0;
     for (auto& t : tasks) {
@@ -308,9 +308,9 @@ class InsertOrUpdateExperiment : public Experiment {
         std::chrono::duration_cast<std::chrono::microseconds>(elapsed)}});
   }
 
-  int RunTask(Config const& config, spanner::Client client,
-              RandomKeyGenerator const& key_generator,
-              ErrorSink const& error_sink) {
+  static int RunTask(Config const& config, spanner::Client client,
+                     RandomKeyGenerator const& key_generator,
+                     ErrorSink const& error_sink) {
     int count = 0;
     std::string value(1024, 'A');
     std::vector<google::cloud::Status> errors;
@@ -387,7 +387,7 @@ class ReadExperiment : public Experiment {
     std::vector<std::future<int>> tasks(thread_count);
     auto start = std::chrono::steady_clock::now();
     for (auto& t : tasks) {
-      t = std::async(std::launch::async, &ReadExperiment::RunTask, this, config,
+      t = std::async(std::launch::async, &ReadExperiment::RunTask, config,
                      client, locked_random_key, error_sink);
     }
     int total_count = 0;
@@ -401,9 +401,9 @@ class ReadExperiment : public Experiment {
         std::chrono::duration_cast<std::chrono::microseconds>(elapsed)}});
   }
 
-  int RunTask(Config const& config, spanner::Client client,
-              RandomKeyGenerator const& key_generator,
-              ErrorSink const& error_sink) {
+  static int RunTask(Config const& config, spanner::Client client,
+                     RandomKeyGenerator const& key_generator,
+                     ErrorSink const& error_sink) {
     int count = 0;
     std::string value(1024, 'A');
     std::vector<google::cloud::Status> errors;
@@ -484,8 +484,8 @@ class UpdateDmlExperiment : public Experiment {
     std::vector<std::future<int>> tasks(thread_count);
     auto start = std::chrono::steady_clock::now();
     for (auto& t : tasks) {
-      t = std::async(std::launch::async, &UpdateDmlExperiment::RunTask, this,
-                     config, client, locked_random_key, error_sink);
+      t = std::async(std::launch::async, &UpdateDmlExperiment::RunTask, config,
+                     client, locked_random_key, error_sink);
     }
     int insert_count = 0;
     for (auto& t : tasks) {
@@ -498,9 +498,9 @@ class UpdateDmlExperiment : public Experiment {
         std::chrono::duration_cast<std::chrono::microseconds>(elapsed)}});
   }
 
-  int RunTask(Config const& config, spanner::Client client,
-              RandomKeyGenerator const& key_generator,
-              ErrorSink const& error_sink) {
+  static int RunTask(Config const& config, spanner::Client client,
+                     RandomKeyGenerator const& key_generator,
+                     ErrorSink const& error_sink) {
     int count = 0;
     std::string value(1024, 'A');
     std::vector<google::cloud::Status> errors;
@@ -585,8 +585,8 @@ class SelectExperiment : public Experiment {
     std::vector<std::future<int>> tasks(thread_count);
     auto start = std::chrono::steady_clock::now();
     for (auto& t : tasks) {
-      t = std::async(std::launch::async, &SelectExperiment::RunTask, this,
-                     config, client, locked_random_key, error_sink);
+      t = std::async(std::launch::async, &SelectExperiment::RunTask, config,
+                     client, locked_random_key, error_sink);
     }
     int total_count = 0;
     for (auto& t : tasks) {
@@ -599,9 +599,9 @@ class SelectExperiment : public Experiment {
         std::chrono::duration_cast<std::chrono::microseconds>(elapsed)}});
   }
 
-  int RunTask(Config const& config, spanner::Client client,
-              RandomKeyGenerator const& key_generator,
-              ErrorSink const& error_sink) {
+  static int RunTask(Config const& config, spanner::Client client,
+                     RandomKeyGenerator const& key_generator,
+                     ErrorSink const& error_sink) {
     int count = 0;
     std::string value(1024, 'A');
     std::vector<google::cloud::Status> errors;

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -49,7 +49,7 @@ class ClientIntegrationTest : public ::testing::Test {
     EXPECT_STATUS_OK(commit_result);
   }
 
-  void InsertTwoSingers() {
+  static void InsertTwoSingers() {
     auto commit_result = client_->Commit(Mutations{
         InsertMutationBuilder("Singers", {"SingerId", "FirstName", "LastName"})
             .EmplaceRow(1, "test-fname-1", "test-lname-1")
@@ -428,7 +428,7 @@ void CheckReadWithOptions(
 }
 
 /// @test Test Read() with bounded staleness set by a timestamp.
-TEST_F(ClientIntegrationTest, Read_BoundedStaleness_Timestamp) {
+TEST_F(ClientIntegrationTest, ReadBoundedStalenessTimestamp) {
   CheckReadWithOptions(*client_, [](CommitResult const& result) {
     return Transaction::SingleUseOptions(
         /*min_read_timestamp=*/result.commit_timestamp);
@@ -436,7 +436,7 @@ TEST_F(ClientIntegrationTest, Read_BoundedStaleness_Timestamp) {
 }
 
 /// @test Test Read() with bounded staleness set by duration.
-TEST_F(ClientIntegrationTest, Read_BoundedStaleness_Duration) {
+TEST_F(ClientIntegrationTest, ReadBoundedStalenessDuration) {
   CheckReadWithOptions(*client_, [](CommitResult const&) {
     // We want a duration sufficiently recent to include the latest commit.
     return Transaction::SingleUseOptions(
@@ -445,14 +445,14 @@ TEST_F(ClientIntegrationTest, Read_BoundedStaleness_Duration) {
 }
 
 /// @test Test Read() with exact staleness set to "all previous transactions".
-TEST_F(ClientIntegrationTest, Read_ExactStaleness_Latest) {
+TEST_F(ClientIntegrationTest, ReadExactStalenessLatest) {
   CheckReadWithOptions(*client_, [](CommitResult const&) {
     return Transaction::SingleUseOptions(Transaction::ReadOnlyOptions());
   });
 }
 
 /// @test Test Read() with exact staleness set by a timestamp.
-TEST_F(ClientIntegrationTest, Read_ExactStaleness_Timestamp) {
+TEST_F(ClientIntegrationTest, ReadExactStalenessTimestamp) {
   CheckReadWithOptions(*client_, [](CommitResult const& result) {
     return Transaction::SingleUseOptions(Transaction::ReadOnlyOptions(
         /*read_timestamp=*/result.commit_timestamp));
@@ -460,7 +460,7 @@ TEST_F(ClientIntegrationTest, Read_ExactStaleness_Timestamp) {
 }
 
 /// @test Test Read() with exact staleness set by duration.
-TEST_F(ClientIntegrationTest, Read_ExactStaleness_Duration) {
+TEST_F(ClientIntegrationTest, ReadExactStalenessDuration) {
   CheckReadWithOptions(*client_, [](CommitResult const&) {
     return Transaction::SingleUseOptions(Transaction::ReadOnlyOptions(
         /*exact_staleness=*/std::chrono::nanoseconds(0)));
@@ -511,7 +511,7 @@ void CheckExecuteQueryWithSingleUseOptions(
 }
 
 /// @test Test ExecuteQuery() with bounded staleness set by a timestamp.
-TEST_F(ClientIntegrationTest, ExecuteQuery_BoundedStaleness_Timestamp) {
+TEST_F(ClientIntegrationTest, ExecuteQueryBoundedStalenessTimestamp) {
   CheckExecuteQueryWithSingleUseOptions(
       *client_, [](CommitResult const& result) {
         return Transaction::SingleUseOptions(
@@ -520,7 +520,7 @@ TEST_F(ClientIntegrationTest, ExecuteQuery_BoundedStaleness_Timestamp) {
 }
 
 /// @test Test ExecuteQuery() with bounded staleness set by duration.
-TEST_F(ClientIntegrationTest, ExecuteQuery_BoundedStaleness_Duration) {
+TEST_F(ClientIntegrationTest, ExecuteQueryBoundedStalenessDuration) {
   CheckExecuteQueryWithSingleUseOptions(*client_, [](CommitResult const&) {
     // We want a duration sufficiently recent to include the latest commit.
     return Transaction::SingleUseOptions(
@@ -530,14 +530,14 @@ TEST_F(ClientIntegrationTest, ExecuteQuery_BoundedStaleness_Duration) {
 
 /// @test Test ExecuteQuery() with exact staleness set to "all previous
 /// transactions".
-TEST_F(ClientIntegrationTest, ExecuteQuery_ExactStaleness_Latest) {
+TEST_F(ClientIntegrationTest, ExecuteQueryExactStalenessLatest) {
   CheckExecuteQueryWithSingleUseOptions(*client_, [](CommitResult const&) {
     return Transaction::SingleUseOptions(Transaction::ReadOnlyOptions());
   });
 }
 
 /// @test Test ExecuteQuery() with exact staleness set by a timestamp.
-TEST_F(ClientIntegrationTest, ExecuteQuery_ExactStaleness_Timestamp) {
+TEST_F(ClientIntegrationTest, ExecuteQueryExactStalenessTimestamp) {
   CheckExecuteQueryWithSingleUseOptions(
       *client_, [](CommitResult const& result) {
         return Transaction::SingleUseOptions(Transaction::ReadOnlyOptions(
@@ -546,7 +546,7 @@ TEST_F(ClientIntegrationTest, ExecuteQuery_ExactStaleness_Timestamp) {
 }
 
 /// @test Test ExecuteQuery() with exact staleness set by duration.
-TEST_F(ClientIntegrationTest, ExecuteQuery_ExactStaleness_Duration) {
+TEST_F(ClientIntegrationTest, ExecuteQueryExactStalenessDuration) {
   CheckExecuteQueryWithSingleUseOptions(*client_, [](CommitResult const&) {
     return Transaction::SingleUseOptions(Transaction::ReadOnlyOptions(
         /*exact_staleness=*/std::chrono::nanoseconds(0)));

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -1266,7 +1266,7 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteTooManyTransientFailures) {
 }
 
 TEST(ConnectionImplTest,
-     ExecutePartitionedDmlDelete_BeginTransactionPermanentFailure) {
+     ExecutePartitionedDmlDeleteBeginTransactionPermanentFailure) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeConnection(db, {mock});
@@ -1287,7 +1287,7 @@ TEST(ConnectionImplTest,
 }
 
 TEST(ConnectionImplTest,
-     ExecutePartitionedDmlDelete_BeginTransactionTooManyTransientFailures) {
+     ExecutePartitionedDmlDeleteBeginTransactionTooManyTransientFailures) {
   auto mock = std::make_shared<spanner_testing::MockSpannerStub>();
   auto db = Database("dummy_project", "dummy_instance", "dummy_database_id");
   auto conn = MakeLimitedRetryConnection(db, mock);

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -45,7 +45,7 @@ class DatabaseAdminLoggingTest : public ::testing::Test {
     logger_id_ = 0;
   }
 
-  Status TransientError() {
+  static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -39,7 +39,7 @@ class DatabaseAdminMetadataTest : public ::testing::Test {
 
   void TearDown() override {}
 
-  Status TransientError() {
+  static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -45,7 +45,7 @@ class InstanceAdminLoggingTest : public ::testing::Test {
     logger_id_ = 0;
   }
 
-  Status TransientError() {
+  static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -39,7 +39,7 @@ class InstanceAdminMetadataTest : public ::testing::Test {
 
   void TearDown() override {}
 
-  Status TransientError() {
+  static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -45,7 +45,7 @@ class LoggingSpannerStubTest : public ::testing::Test {
     logger_id_ = 0;
   }
 
-  Status TransientError() {
+  static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -44,16 +44,16 @@ class MetadataSpannerStubTest : public ::testing::Test {
 
   void TearDown() override {}
 
-  Status TransientError() {
+  static Status TransientError() {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
   template <typename T>
-  void ExpectTransientError(StatusOr<T> const& status) {
+  static void ExpectTransientError(StatusOr<T> const& status) {
     EXPECT_EQ(TransientError(), status.status());
   }
 
-  void ExpectTransientError(Status const& status) {
+  static void ExpectTransientError(Status const& status) {
     EXPECT_EQ(TransientError(), status);
   }
 

--- a/google/cloud/spanner/internal/time_utils_test.cc
+++ b/google/cloud/spanner/internal/time_utils_test.cc
@@ -24,7 +24,7 @@ inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 namespace {
 
-TEST(time_utils, ConvertTimePointToProtoTimestamp) {
+TEST(TimeUtils, ConvertTimePointToProtoTimestamp) {
   auto const epoch = std::chrono::system_clock::from_time_t(0);
   auto t = epoch + std::chrono::seconds(123) + std::chrono::nanoseconds(456000);
   auto proto_timestamp = ConvertTimePointToProtoTimestamp(t);

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -81,6 +81,7 @@ class RowStream {
   }
 
   /// Returns a `RowStreamIterator` defining the end of this range.
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   RowStreamIterator end() { return {}; }
 
   /**
@@ -163,6 +164,7 @@ class ProfileQueryResult {
   }
 
   /// Returns a `RowStreamIterator` defining the end of this result set.
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   RowStreamIterator end() { return {}; }
 
   /**

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -47,9 +47,8 @@ RowStreamIterator::Source MakeRowStreamIteratorSource(
 class RowRange {
  public:
   explicit RowRange(RowStreamIterator::Source s) : s_(std::move(s)) {}
-  // NOLINTNEXTLINE(readability-identifier-naming)
   RowStreamIterator begin() { return RowStreamIterator(s_); }
-  // NOLINTNEXTLINE(readability-identifier-naming)
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   RowStreamIterator end() { return RowStreamIterator(); }
 
  private:


### PR DESCRIPTION
The clang-tidy build is still using clang-8.0, we want to use clang-9.0,
this changes fix a few warnings. In most cases I preferred to use the
recommended fix over silencing the warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1409)
<!-- Reviewable:end -->
