### PR TITLE
fix: //:spanner_client tagged manual

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -23,6 +23,7 @@ exports_files([
 cc_library(
     name = "spanner_client",
     includes = ["."],
+    tags = ["manual"],
     deps = [
         "//google/cloud/spanner:spanner_client",
     ],


### PR DESCRIPTION
This makes the following command work again

```
bazel build ...
```

from the top-level dir. And users are still able to directly link against the `//:spanner_client` build target.

This fixes an issue that was added in https://github.com/googleapis/google-cloud-cpp-spanner/pull/1396

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1419)
<!-- Reviewable:end -->
