### PR TITLE
fix: remove `includes = ["."]`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -22,8 +22,6 @@ exports_files([
 
 cc_library(
     name = "spanner_client",
-    includes = ["."],
-    tags = ["manual"],
     deps = [
         "//google/cloud/spanner:spanner_client",
     ],


### PR DESCRIPTION
Using `includes = ["."]` in a top-level BUILD file causes too many odd
behaviors and breakages. For example, it makes `bazel build ...` fail.

The goal was to allow users to include our headers using angle-bracket
includes, which this does. However, there may be a better way to do
this. Until we figure that out, we should remove the odd line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1423)
<!-- Reviewable:end -->
