### PR TITLE
testing: improvements for Backup related tests

### DIFF
--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -84,8 +84,8 @@ elif [[ "${BUILD_NAME}" = "coverage" ]]; then
   export DISTRO_VERSION=31
   : "${RUN_INTEGRATION_TESTS:=$DEFAULT_RUN_INTEGRATION_TESTS}"
   if [[ -z "${RUN_SLOW_INTEGRATION_TESTS:-}" ]]; then
-    # Defaults to "instance" for the coverage test.
-    export RUN_SLOW_INTEGRATION_TESTS=instance
+    # Defaults to run all the slow tests for the coverage test.
+    export RUN_SLOW_INTEGRATION_TESTS=instance,backup
   fi
   in_docker_script="ci/kokoro/docker/build-in-docker-cmake.sh"
 elif [[ "${BUILD_NAME}" = "publish-refdocs" ]]; then

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -273,6 +273,8 @@ function (spanner_client_define_tests)
 
     add_library(
         spanner_client_testing
+        testing/cleanup_stale_instances.cc
+        testing/cleanup_stale_instances.h
         testing/compiler_supports_regexp.h
         testing/database_environment.cc
         testing/database_environment.h

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -273,6 +273,7 @@ function (spanner_client_define_tests)
 
     add_library(
         spanner_client_testing
+        testing/compiler_supports_regexp.h
         testing/database_environment.cc
         testing/database_environment.h
         testing/matchers.h
@@ -284,6 +285,7 @@ function (spanner_client_define_tests)
         testing/pick_instance_config.h
         testing/pick_random_instance.cc
         testing/pick_random_instance.h
+        testing/policies.h
         testing/random_backup_name.cc
         testing/random_backup_name.h
         testing/random_database_name.cc

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -68,9 +68,6 @@ function (spanner_client_define_integration_tests)
         add_dependencies(spanner-client-integration-tests ${target})
     endforeach ()
 
-    # backup_integration_test sometimes takes long time
-    set_tests_properties("backup_integration_test" PROPERTIES TIMEOUT 2400)
-
     if (MSVC)
         # MSVC warns about using localtime(), this is a valuable warning, so we
         # do not want to disable for everything. But for these files the usage

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -35,9 +35,40 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace {
 
+// For this tests, use 15 minutes as the maximum polling and retry periods. The
+// default is longer, but we need to timeout earlier in the CI builds.
+auto constexpr kMaximumWaitTimeMinutes = 15;
+auto constexpr kBackoffScaling = 2.0;
+
+std::unique_ptr<RetryPolicy> TestRetryPolicy() {
+  return LimitedTimeRetryPolicy(std::chrono::minutes(kMaximumWaitTimeMinutes))
+      .clone();
+}
+
+std::unique_ptr<BackoffPolicy> TestBackoffPolicy() {
+  return ExponentialBackoffPolicy(std::chrono::seconds(1),
+                                  std::chrono::minutes(1), kBackoffScaling)
+      .clone();
+}
+
+std::unique_ptr<PollingPolicy> TestPollingPolicy() {
+  return GenericPollingPolicy<>(
+             LimitedTimeRetryPolicy(
+                 std::chrono::minutes(kMaximumWaitTimeMinutes)),
+             ExponentialBackoffPolicy(std::chrono::seconds(1),
+                                      std::chrono::minutes(1), kBackoffScaling))
+      .clone();
+}
+
 class BackupTest : public testing::Test {
  public:
-  BackupTest() : instance_admin_client_(MakeInstanceAdminConnection()) {}
+  BackupTest()
+      : instance_admin_client_(MakeInstanceAdminConnection(
+            ConnectionOptions{}, TestRetryPolicy(), TestBackoffPolicy(),
+            TestPollingPolicy())),
+        database_admin_client_(MakeDatabaseAdminConnection(
+            ConnectionOptions{}, TestRetryPolicy(), TestBackoffPolicy(),
+            TestPollingPolicy())) {}
 
  protected:
   void SetUp() override {
@@ -45,9 +76,6 @@ class BackupTest : public testing::Test {
         google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST").has_value();
     project_id_ =
         google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-    test_iam_service_account_ =
-        google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_IAM_TEST_SA")
-            .value_or("");
     auto const run_slow_integration_tests =
         google::cloud::internal::GetEnv("RUN_SLOW_INTEGRATION_TESTS")
             .value_or("");
@@ -56,10 +84,9 @@ class BackupTest : public testing::Test {
   }
   InstanceAdminClient instance_admin_client_;
   DatabaseAdminClient database_admin_client_;
-  bool emulator_;
+  bool emulator_ = false;
   std::string project_id_;
-  std::string test_iam_service_account_;
-  bool run_slow_backup_tests_;
+  bool run_slow_backup_tests_ = false;
 };
 
 class BackupTestWithCleanup : public BackupTest {
@@ -109,17 +136,27 @@ class BackupTestWithCleanup : public BackupTest {
   std::regex instance_config_regex_;
 };
 
+bool CompilerSupportsRegexp() {
+#if !defined(__clang__) && defined(__GNUC__) && \
+    (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9))
+  // gcc-4.8 ships with a broken regexp library, it compiles, but does not match
+  // correctly:
+  //    https://stackoverflow.com/questions/12530406/is-gcc-4-8-or-earlier-buggy-about-regular-expressions
+  return false;
+#else
+  return true;
+#endif
+}
+
 /// @test Backup related integration tests.
 TEST_F(BackupTestWithCleanup, BackupTestSuite) {
   if (!run_slow_backup_tests_ || emulator_) {
     GTEST_SKIP();
   }
-#if !defined(__clang__) && defined(__GNUC__) && \
-    (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9))
-  // This test (not the code) depends on regexp and this is not
-  // implemented in gcc 4.8 or lower.
-  GTEST_SKIP();
-#endif
+  if (!CompilerSupportsRegexp()) {
+    // This test (not the code) depends on regexp.
+    GTEST_SKIP();
+  }
   auto generator = google::cloud::internal::MakeDefaultPRNG();
   std::string instance_id =
       google::cloud::spanner_testing::RandomInstanceName(generator);
@@ -225,9 +262,9 @@ TEST_F(BackupTestWithCleanup, BackupTestSuite) {
   EXPECT_STATUS_OK(drop_restored_db_status);
   filter = std::string("expire_time < \"3000-01-01T00:00:00Z\"");
   std::vector<std::string> backup_names;
-  for (auto const& backup : database_admin_client_.ListBackups(in, filter)) {
+  for (auto const& b : database_admin_client_.ListBackups(in, filter)) {
     if (!backup) break;
-    backup_names.push_back(backup->name());
+    backup_names.push_back(b->name());
   }
   EXPECT_LE(
       1, std::count(backup_names.begin(), backup_names.end(), backup->name()))

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/create_instance_request_builder.h"
 #include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/spanner/testing/cleanup_stale_instances.h"
 #include "google/cloud/spanner/testing/compiler_supports_regexp.h"
 #include "google/cloud/spanner/testing/pick_instance_config.h"
 #include "google/cloud/spanner/testing/random_instance_name.h"
@@ -76,36 +77,9 @@ class InstanceAdminClientTestWithCleanup : public InstanceAdminClientTest {
     if (!run_slow_instance_tests_) {
       return;
     }
-    // Deletes leaked temporary instances.
-    std::vector<std::string> instance_ids = [this]() mutable {
-      std::vector<std::string> instance_ids;
-      for (auto const& instance : client_.ListInstances(project_id_, "")) {
-        EXPECT_STATUS_OK(instance);
-        if (!instance) break;
-        auto name = instance->name();
-        std::smatch m;
-        if (std::regex_match(name, m, instance_name_regex_)) {
-          auto instance_id = m[1];
-          auto date_str = m[2];
-          std::string cut_off_date = "1973-03-01";
-          auto cut_off_time_t = std::chrono::system_clock::to_time_t(
-              std::chrono::system_clock::now() - std::chrono::hours(48));
-          std::strftime(&cut_off_date[0], cut_off_date.size() + 1, "%Y-%m-%d",
-                        std::localtime(&cut_off_time_t));
-          // Compare the strings
-          if (date_str < cut_off_date) {
-            instance_ids.push_back(instance_id);
-          }
-        }
-      }
-      return instance_ids;
-    }();
-    // Let it fail if we have too many leaks.
-    EXPECT_GT(20, instance_ids.size());
-    for (auto const& id_to_delete : instance_ids) {
-      // Probably better to ignore failures.
-      client_.DeleteInstance(Instance(project_id_, id_to_delete));
-    }
+    auto s = spanner_testing::CleanupStaleInstances(project_id_,
+                                                    instance_name_regex_);
+    EXPECT_STATUS_OK(s) << s.message();
   }
   std::regex instance_config_regex_;
   std::regex instance_name_regex_;

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/create_instance_request_builder.h"
 #include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/spanner/testing/compiler_supports_regexp.h"
 #include "google/cloud/spanner/testing/pick_instance_config.h"
 #include "google/cloud/spanner/testing/random_instance_name.h"
 #include "google/cloud/spanner/update_instance_request_builder.h"
@@ -140,6 +141,10 @@ TEST_F(InstanceAdminClientTest, InstanceReadOperations) {
 /// @test Verify the basic CRUD operations for instances work.
 TEST_F(InstanceAdminClientTestWithCleanup, InstanceCRUDOperations) {
   if (!run_slow_instance_tests_) {
+    GTEST_SKIP();
+  }
+  if (!spanner_testing::CompilerSupportsRegexp()) {
+    // This test (not the code) depends on regexp.
     GTEST_SKIP();
   }
   auto generator = google::cloud::internal::MakeDefaultPRNG();

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -50,8 +50,6 @@ function (spanner_client_define_samples)
         google_cloud_cpp_test_name_to_target(target "${fname}")
         set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
     endforeach ()
-    # samples sometimes takes long time
-    set_tests_properties("samples" PROPERTIES TIMEOUT 2400)
 endfunction ()
 
 if (BUILD_TESTING)

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -16,12 +16,14 @@
 #include "google/cloud/spanner/client.h"
 //! [END spanner_quickstart]
 #include "google/cloud/spanner/backup.h"
+#include "google/cloud/spanner/connection_options.h"
 #include "google/cloud/spanner/create_instance_request_builder.h"
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/instance_admin_client.h"
 #include "google/cloud/spanner/internal/time_utils.h"
 #include "google/cloud/spanner/row.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
+#include "google/cloud/spanner/testing/policies.h"
 #include "google/cloud/spanner/testing/random_backup_name.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/spanner/testing/random_instance_name.h"
@@ -2617,7 +2619,11 @@ void RunAll(bool emulator) {
   std::cout << "Running instance admin samples on " << instance_id << std::endl;
 
   google::cloud::spanner::InstanceAdminClient instance_admin_client(
-      google::cloud::spanner::MakeInstanceAdminConnection());
+      google::cloud::spanner::MakeInstanceAdminConnection(
+          google::cloud::spanner::ConnectionOptions{},
+          google::cloud::spanner_testing::TestRetryPolicy(),
+          google::cloud::spanner_testing::TestBackoffPolicy(),
+          google::cloud::spanner_testing::TestPollingPolicy()));
 
   std::cout << "\nRunning get-instance sample" << std::endl;
   GetInstance(instance_admin_client, project_id, instance_id);
@@ -2640,7 +2646,12 @@ void RunAll(bool emulator) {
   std::string database_id =
       google::cloud::spanner_testing::RandomDatabaseName(generator);
 
-  google::cloud::spanner::DatabaseAdminClient database_admin_client;
+  google::cloud::spanner::DatabaseAdminClient database_admin_client(
+      MakeDatabaseAdminConnection(
+          google::cloud::spanner::ConnectionOptions{},
+          google::cloud::spanner_testing::TestRetryPolicy(),
+          google::cloud::spanner_testing::TestBackoffPolicy(),
+          google::cloud::spanner_testing::TestPollingPolicy()));
 
   if (run_slow_instance_tests) {
     std::string crud_instance_id =

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for spanner_client_testing - DO NOT EDIT."""
 
 spanner_client_testing_hdrs = [
+    "testing/cleanup_stale_instances.h",
     "testing/compiler_supports_regexp.h",
     "testing/database_environment.h",
     "testing/matchers.h",
@@ -34,6 +35,7 @@ spanner_client_testing_hdrs = [
 ]
 
 spanner_client_testing_srcs = [
+    "testing/cleanup_stale_instances.cc",
     "testing/database_environment.cc",
     "testing/pick_instance_config.cc",
     "testing/pick_random_instance.cc",

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -17,6 +17,7 @@
 """Automatically generated source lists for spanner_client_testing - DO NOT EDIT."""
 
 spanner_client_testing_hdrs = [
+    "testing/compiler_supports_regexp.h",
     "testing/database_environment.h",
     "testing/matchers.h",
     "testing/mock_database_admin_stub.h",
@@ -25,6 +26,7 @@ spanner_client_testing_hdrs = [
     "testing/mock_spanner_stub.h",
     "testing/pick_instance_config.h",
     "testing/pick_random_instance.h",
+    "testing/policies.h",
     "testing/random_backup_name.h",
     "testing/random_database_name.h",
     "testing/random_instance_name.h",

--- a/google/cloud/spanner/testing/cleanup_stale_instances.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_instances.cc
@@ -30,9 +30,7 @@ Status CleanupStaleInstances(std::string const& project_id,
       spanner::MakeDatabaseAdminConnection());
   spanner::InstanceAdminClient instance_admin_client(
       spanner::MakeInstanceAdminConnection());
-  std::vector<std::string> instance_ids =
-      [&instance_admin_client, &project_id,
-       &instance_name_regex]() -> std::vector<std::string> {
+  std::vector<std::string> instance_ids = [&]() -> std::vector<std::string> {
     std::vector<std::string> instance_ids;
     for (auto const& instance :
          instance_admin_client.ListInstances(project_id, {})) {

--- a/google/cloud/spanner/testing/cleanup_stale_instances.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_instances.cc
@@ -1,0 +1,75 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/testing/cleanup_stale_instances.h"
+#include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/internal/format_time_point.h"
+#include <chrono>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+Status CleanupStaleInstances(std::string const& project_id,
+                             std::regex const& instance_name_regex) {
+  spanner::DatabaseAdminClient database_admin_client(
+      spanner::MakeDatabaseAdminConnection());
+  spanner::InstanceAdminClient instance_admin_client(
+      spanner::MakeInstanceAdminConnection());
+  std::vector<std::string> instance_ids =
+      [&instance_admin_client, &project_id,
+       &instance_name_regex]() -> std::vector<std::string> {
+    std::vector<std::string> instance_ids;
+    for (auto const& instance :
+         instance_admin_client.ListInstances(project_id, {})) {
+      if (!instance) break;
+      auto name = instance->name();
+      std::smatch m;
+      if (std::regex_match(name, m, instance_name_regex)) {
+        auto instance_id = m[1];
+        auto date_str = m[2];
+        auto cutoff_date =
+            google::cloud::internal::FormatRfc3339(
+                std::chrono::system_clock::now() - std::chrono::hours(24))
+                .substr(0, 10);
+        // Compare the strings
+        if (date_str < cutoff_date) {
+          instance_ids.push_back(instance_id);
+        }
+      }
+    }
+    return instance_ids;
+  }();
+  // Let it fail if we have too many leaks.
+  if (instance_ids.size() > 20) {
+    return Status(StatusCode::kInternal, "too many stale instances");
+  }
+  // We ignore failures here.
+  for (auto const& id_to_delete : instance_ids) {
+    google::cloud::spanner::Instance in(project_id, id_to_delete);
+    for (auto const& b : database_admin_client.ListBackups(in, {})) {
+      database_admin_client.DeleteBackup(b.value());
+    }
+    instance_admin_client.DeleteInstance(in);
+  }
+  return Status();
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/testing/cleanup_stale_instances.h
+++ b/google/cloud/spanner/testing/cleanup_stale_instances.h
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_INSTANCES_H
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_INSTANCES_H
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/status.h"
+#include <regex>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+Status CleanupStaleInstances(std::string const& project_id,
+                             std::regex const& instance_name_regex);
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_INSTANCES_H

--- a/google/cloud/spanner/testing/compiler_supports_regexp.h
+++ b/google/cloud/spanner/testing/compiler_supports_regexp.h
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_COMPILER_SUPPORTS_REGEXP_H
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_COMPILER_SUPPORTS_REGEXP_H
+
+#include "google/cloud/spanner/version.h"
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+inline bool CompilerSupportsRegexp() {
+#if !defined(__clang__) && defined(__GNUC__) && \
+    (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9))
+  // gcc-4.8 ships with a broken regexp library, it compiles, but does not match
+  // correctly:
+  //    https://stackoverflow.com/questions/12530406/is-gcc-4-8-or-earlier-buggy-about-regular-expressions
+  return false;
+#else
+  return true;
+#endif
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_COMPILER_SUPPORTS_REGEXP_H

--- a/google/cloud/spanner/testing/policies.h
+++ b/google/cloud/spanner/testing/policies.h
@@ -36,7 +36,7 @@ inline std::unique_ptr<spanner::RetryPolicy> TestRetryPolicy() {
 }
 
 inline std::unique_ptr<spanner::BackoffPolicy> TestBackoffPolicy() {
-  return internal::ExponentialBackoffPolicy(
+  return spanner::ExponentialBackoffPolicy(
              std::chrono::seconds(1), std::chrono::minutes(1), kBackoffScaling)
       .clone();
 }
@@ -45,9 +45,9 @@ inline std::unique_ptr<spanner::PollingPolicy> TestPollingPolicy() {
   return spanner::GenericPollingPolicy<>(
              spanner::LimitedTimeRetryPolicy(
                  std::chrono::minutes(kMaximumWaitTimeMinutes)),
-             internal::ExponentialBackoffPolicy(std::chrono::seconds(1),
-                                                std::chrono::minutes(1),
-                                                kBackoffScaling))
+             spanner::ExponentialBackoffPolicy(std::chrono::seconds(1),
+                                               std::chrono::minutes(1),
+                                               kBackoffScaling))
       .clone();
 }
 

--- a/google/cloud/spanner/testing/policies.h
+++ b/google/cloud/spanner/testing/policies.h
@@ -1,0 +1,59 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_POLICIES_H
+#define GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_POLICIES_H
+
+#include "google/cloud/spanner/backoff_policy.h"
+#include "google/cloud/spanner/polling_policy.h"
+#include "google/cloud/spanner/retry_policy.h"
+#include "google/cloud/spanner/version.h"
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+inline namespace SPANNER_CLIENT_NS {
+// For some tests, use 15 minutes as the maximum polling and retry periods. The
+// default is longer, but we need to timeout earlier in the CI builds.
+auto constexpr kMaximumWaitTimeMinutes = 15;
+auto constexpr kBackoffScaling = 2.0;
+
+inline std::unique_ptr<spanner::RetryPolicy> TestRetryPolicy() {
+  return spanner::LimitedTimeRetryPolicy(
+             std::chrono::minutes(kMaximumWaitTimeMinutes))
+      .clone();
+}
+
+inline std::unique_ptr<spanner::BackoffPolicy> TestBackoffPolicy() {
+  return internal::ExponentialBackoffPolicy(
+             std::chrono::seconds(1), std::chrono::minutes(1), kBackoffScaling)
+      .clone();
+}
+
+inline std::unique_ptr<spanner::PollingPolicy> TestPollingPolicy() {
+  return spanner::GenericPollingPolicy<>(
+             spanner::LimitedTimeRetryPolicy(
+                 std::chrono::minutes(kMaximumWaitTimeMinutes)),
+             internal::ExponentialBackoffPolicy(std::chrono::seconds(1),
+                                                std::chrono::minutes(1),
+                                                kBackoffScaling))
+      .clone();
+}
+
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_SPANNER_GOOGLE_CLOUD_SPANNER_TESTING_POLICIES_H


### PR DESCRIPTION
* enable backup related test for the coverage build
* use shorter timeout for admin clients for backup tests
* correctly cleanup stale instances by deleting backups first

Fixes #1432 and fixes #1429

We may still want to disable backup related tests for the coverage build. If so, we can run the backup related tests in nightly build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1438)
<!-- Reviewable:end -->
