### PR TITLE
test: write integration test for SessionPool

### DIFF
--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -35,7 +35,8 @@ function (spanner_client_define_integration_tests)
         data_types_integration_test.cc
         database_admin_integration_test.cc
         instance_admin_integration_test.cc
-        rpc_failure_threshold_integration_test.cc)
+        rpc_failure_threshold_integration_test.cc
+        session_pool_integration_test.cc)
 
     # Export the list of unit tests to a .bzl file so we do not need to maintain
     # the list in two places.

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -1,0 +1,98 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/internal/session_pool.h"
+#include "google/cloud/spanner/testing/database_environment.h"
+#include "google/cloud/testing_util/assert_ok.h"
+#include "google/cloud/testing_util/init_google_mock.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace spanner {
+inline namespace SPANNER_CLIENT_NS {
+namespace internal {
+namespace {
+
+TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
+  google::cloud::CompletionQueue cq;
+  std::thread t([&cq] { cq.Run(); });
+  auto const db = spanner_testing::DatabaseEnvironment::GetDatabase();
+  auto stub = CreateDefaultSpannerStub(ConnectionOptions{}, /*channel_id=*/0);
+  auto session_pool =
+      MakeSessionPool(db, {stub}, SessionPoolOptions{}, cq,
+                      LimitedTimeRetryPolicy(std::chrono::minutes(5)).clone(),
+                      ExponentialBackoffPolicy(std::chrono::seconds(10),
+                                               std::chrono::minutes(1), 2.0)
+                          .clone());
+
+  // Make an asynchronous request, but immediately block until the response
+  // arrives
+  auto constexpr kNumTestSession = 4;
+  auto create_response =
+      session_pool->AsyncBatchCreateSessions(cq, stub, {}, kNumTestSession)
+          .get();
+  ASSERT_STATUS_OK(create_response);
+  EXPECT_EQ(kNumTestSession, create_response->session_size());
+
+  using ::google::spanner::v1::Session;
+  std::vector<future<bool>> async_get;
+  for (auto const& s : create_response->session()) {
+    auto const& session_name = s.name();
+    async_get.push_back(session_pool->AsyncGetSession(cq, stub, session_name)
+                            .then([session_name](future<StatusOr<Session>> f) {
+                              auto session = f.get();
+                              EXPECT_STATUS_OK(session);
+                              if (!session) return false;
+                              EXPECT_EQ(session->name(), session_name);
+                              return session->name() == session_name;
+                            }));
+  }
+  for (auto& ag : async_get) {
+    auto matched = ag.get();
+    EXPECT_TRUE(matched);
+  }
+
+  std::vector<future<Status>> async_delete;
+  for (auto const& s : create_response->session()) {
+    auto const& session_name = s.name();
+    async_delete.push_back(
+        session_pool->AsyncDeleteSession(cq, stub, session_name)
+            .then([](future<StatusOr<google::protobuf::Empty>> f) {
+              return f.get().status();
+            }));
+  }
+  for (auto& ad : async_delete) {
+    auto status = ad.get();
+    EXPECT_STATUS_OK(status);
+  }
+
+  cq.Shutdown();
+  t.join();
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace SPANNER_CLIENT_NS
+}  // namespace spanner
+}  // namespace cloud
+}  // namespace google
+
+int main(int argc, char* argv[]) {
+  ::google::cloud::testing_util::InitGoogleMock(argc, argv);
+  (void)::testing::AddGlobalTestEnvironment(
+      new google::cloud::spanner_testing::DatabaseEnvironment());
+
+  return RUN_ALL_TESTS();
+}

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -23,6 +23,31 @@ namespace cloud {
 namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
+struct SessionPoolFriendForTest {
+  future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
+  AsyncBatchCreateSessions(std::shared_ptr<SessionPool> const& session_pool,
+                           CompletionQueue& cq,
+                           std::shared_ptr<SpannerStub> stub,
+                           std::map<std::string, std::string> const& labels,
+                           int num_sessions) {
+    return session_pool->AsyncBatchCreateSessions(cq, std::move(stub), labels,
+                                                  num_sessions);
+  }
+
+  future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
+      std::shared_ptr<SessionPool> const& session_pool, CompletionQueue& cq,
+      std::shared_ptr<SpannerStub> stub, std::string session_name) {
+    return session_pool->AsyncDeleteSession(cq, std::move(stub),
+                                            std::move(session_name));
+  }
+
+  future<StatusOr<google::spanner::v1::Session>> AsyncGetSession(
+      std::shared_ptr<SessionPool> const& session_pool, CompletionQueue& cq,
+      std::shared_ptr<SpannerStub> stub, std::string session_name) {
+    return session_pool->AsyncGetSession(cq, std::move(stub),
+                                         std::move(session_name));
+  }
+};
 namespace {
 
 TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
@@ -41,7 +66,8 @@ TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   // arrives
   auto constexpr kNumTestSession = 4;
   auto create_response =
-      session_pool->AsyncBatchCreateSessions(cq, stub, {}, kNumTestSession)
+      SessionPoolFriendForTest{}
+          .AsyncBatchCreateSessions(session_pool, cq, stub, {}, kNumTestSession)
           .get();
   ASSERT_STATUS_OK(create_response);
   EXPECT_EQ(kNumTestSession, create_response->session_size());
@@ -50,14 +76,16 @@ TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   std::vector<future<bool>> async_get;
   for (auto const& s : create_response->session()) {
     auto const& session_name = s.name();
-    async_get.push_back(session_pool->AsyncGetSession(cq, stub, session_name)
-                            .then([session_name](future<StatusOr<Session>> f) {
-                              auto session = f.get();
-                              EXPECT_STATUS_OK(session);
-                              if (!session) return false;
-                              EXPECT_EQ(session->name(), session_name);
-                              return session->name() == session_name;
-                            }));
+    async_get.push_back(
+        SessionPoolFriendForTest{}
+            .AsyncGetSession(session_pool, cq, stub, session_name)
+            .then([session_name](future<StatusOr<Session>> f) {
+              auto session = f.get();
+              EXPECT_STATUS_OK(session);
+              if (!session) return false;
+              EXPECT_EQ(session->name(), session_name);
+              return session->name() == session_name;
+            }));
   }
   for (auto& ag : async_get) {
     auto matched = ag.get();
@@ -68,7 +96,8 @@ TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   for (auto const& s : create_response->session()) {
     auto const& session_name = s.name();
     async_delete.push_back(
-        session_pool->AsyncDeleteSession(cq, stub, session_name)
+        SessionPoolFriendForTest{}
+            .AsyncDeleteSession(session_pool, cq, stub, session_name)
             .then([](future<StatusOr<google::protobuf::Empty>> f) {
               return f.get().status();
             }));

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -24,7 +24,7 @@ namespace spanner {
 inline namespace SPANNER_CLIENT_NS {
 namespace internal {
 struct SessionPoolFriendForTest {
-  future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
+  static future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
   AsyncBatchCreateSessions(std::shared_ptr<SessionPool> const& session_pool,
                            CompletionQueue& cq,
                            std::shared_ptr<SpannerStub> stub,
@@ -34,14 +34,14 @@ struct SessionPoolFriendForTest {
                                                   num_sessions);
   }
 
-  future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
+  static future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
       std::shared_ptr<SessionPool> const& session_pool, CompletionQueue& cq,
       std::shared_ptr<SpannerStub> stub, std::string session_name) {
     return session_pool->AsyncDeleteSession(cq, std::move(stub),
                                             std::move(session_name));
   }
 
-  future<StatusOr<google::spanner::v1::Session>> AsyncGetSession(
+  static future<StatusOr<google::spanner::v1::Session>> AsyncGetSession(
       std::shared_ptr<SessionPool> const& session_pool, CompletionQueue& cq,
       std::shared_ptr<SpannerStub> stub, std::string session_name) {
     return session_pool->AsyncGetSession(cq, std::move(stub),
@@ -65,10 +65,9 @@ TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   // Make an asynchronous request, but immediately block until the response
   // arrives
   auto constexpr kNumTestSession = 4;
-  auto create_response =
-      SessionPoolFriendForTest{}
-          .AsyncBatchCreateSessions(session_pool, cq, stub, {}, kNumTestSession)
-          .get();
+  auto create_response = SessionPoolFriendForTest::AsyncBatchCreateSessions(
+                             session_pool, cq, stub, {}, kNumTestSession)
+                             .get();
   ASSERT_STATUS_OK(create_response);
   EXPECT_EQ(kNumTestSession, create_response->session_size());
 
@@ -76,16 +75,15 @@ TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   std::vector<future<bool>> async_get;
   for (auto const& s : create_response->session()) {
     auto const& session_name = s.name();
-    async_get.push_back(
-        SessionPoolFriendForTest{}
-            .AsyncGetSession(session_pool, cq, stub, session_name)
-            .then([session_name](future<StatusOr<Session>> f) {
-              auto session = f.get();
-              EXPECT_STATUS_OK(session);
-              if (!session) return false;
-              EXPECT_EQ(session->name(), session_name);
-              return session->name() == session_name;
-            }));
+    async_get.push_back(SessionPoolFriendForTest::AsyncGetSession(
+                            session_pool, cq, stub, session_name)
+                            .then([session_name](future<StatusOr<Session>> f) {
+                              auto session = f.get();
+                              EXPECT_STATUS_OK(session);
+                              if (!session) return false;
+                              EXPECT_EQ(session->name(), session_name);
+                              return session->name() == session_name;
+                            }));
   }
   for (auto& ag : async_get) {
     auto matched = ag.get();
@@ -96,8 +94,8 @@ TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   for (auto const& s : create_response->session()) {
     auto const& session_name = s.name();
     async_delete.push_back(
-        SessionPoolFriendForTest{}
-            .AsyncDeleteSession(session_pool, cq, stub, session_name)
+        SessionPoolFriendForTest::AsyncDeleteSession(session_pool, cq, stub,
+                                                     session_name)
             .then([](future<StatusOr<google::protobuf::Empty>> f) {
               return f.get().status();
             }));

--- a/google/cloud/spanner/integration_tests/spanner_client_integration_tests.bzl
+++ b/google/cloud/spanner/integration_tests/spanner_client_integration_tests.bzl
@@ -24,4 +24,5 @@ spanner_client_integration_tests = [
     "database_admin_integration_test.cc",
     "instance_admin_integration_test.cc",
     "rpc_failure_threshold_integration_test.cc",
+    "session_pool_integration_test.cc",
 ]

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -97,6 +97,19 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
    */
   std::shared_ptr<SpannerStub> GetStub(Session const& session);
 
+  // Asynchronous calls used to maintain the pool.
+  future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
+  AsyncBatchCreateSessions(CompletionQueue& cq,
+                           std::shared_ptr<SpannerStub> stub,
+                           std::map<std::string, std::string> const& labels,
+                           int num_sessions);
+  future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
+      CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+      std::string session_name);
+  future<StatusOr<google::spanner::v1::Session>> AsyncGetSession(
+      CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+      std::string session_name);
+
  private:
   // Represents a request to create `session_count` sessions on `channel`
   // See `ComputeCreateCounts` and `CreateSessions`.
@@ -133,19 +146,6 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
 
   SessionHolder MakeSessionHolder(std::unique_ptr<Session> session,
                                   bool dissociate_from_pool);
-
-  // Asynchronous calls used to maintain the pool.
-  future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
-  AsyncBatchCreateSessions(CompletionQueue& cq,
-                           std::shared_ptr<SpannerStub> stub,
-                           std::map<std::string, std::string> const& labels,
-                           int num_sessions);
-  future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
-      CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
-      std::string session_name);
-  future<StatusOr<google::spanner::v1::Session>> AsyncGetSession(
-      CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
-      std::string session_name);
 
   Status HandleBatchCreateSessionsDone(
       std::shared_ptr<Channel> const& channel,


### PR DESCRIPTION
Make sure the low-level functions to make async calls actually work,
the value of unit tests for these is limited (we would be re-testing
the retry loop, but we have tests for that). An integration test
verifies we are filling the protos with the right data. Note that
some of these functions are not exercised in the other integration
tests because they run too infrequently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1442)
<!-- Reviewable:end -->
