### PR TITLE
ci: use build cache for ci/kokoro/docker builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,28 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
+# If ccache is installed use it for the build. This makes the Travis
+# configuration agnostic as to wether ccache is installed or not.
+option(GOOGLE_CLOUD_CPP_ENABLE_CCACHE "Automatically use ccache if available"
+       ON)
+mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_CCACHE)
+
+if ("${GOOGLE_CLOUD_CPP_ENABLE_CCACHE}")
+    find_program(GOOGLE_CLOUD_CPP_CCACHE_PROGRAM ccache NAMES /usr/bin/ccache)
+    mark_as_advanced(GOOGLE_CLOUD_CPP_CCACHE_PROGRAM)
+    if (GOOGLE_CLOUD_CPP_CCACHE_PROGRAM)
+        message(STATUS "ccache found: ${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE
+                                     "${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK
+                                     "${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}")
+
+        set(GOOGLE_CLOUD_CPP_EXTERNAL_PROJECT_CCACHE
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}"
+            "-DCMAKE_CC_COMPILER_LAUNCHER=${GOOGLE_CLOUD_CPP_CCACHE_PROGRAM}")
+    endif ()
+endif ()
+
 # If possible, enable a code coverage build type.
 include(EnableCoverage)
 include(SelectMSVCRuntime)

--- a/ci/kokoro/Dockerfile.centos
+++ b/ci/kokoro/Dockerfile.centos
@@ -21,6 +21,6 @@ RUN yum install -y centos-release-scl
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 
 RUN yum makecache && \
-    yum install -y automake cmake3 curl-devel gcc gcc-c++ git libtool \
+    yum install -y automake ccache cmake3 curl-devel gcc gcc-c++ git libtool \
         make openssl-devel pkgconfig tar wget which zlib-devel
 RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake && ln -sf /usr/bin/ctest3 /usr/bin/ctest

--- a/ci/kokoro/Dockerfile.ubuntu
+++ b/ci/kokoro/Dockerfile.ubuntu
@@ -22,6 +22,7 @@ RUN apt-get update && \
         automake \
         build-essential \
         ca-certificates \
+	ccache \
         clang \
         cmake \
         curl \

--- a/ci/kokoro/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/Dockerfile.ubuntu-xenial
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DISTRO_VERSION=18.04
+ARG DISTRO_VERSION=16.04
 FROM ubuntu:${DISTRO_VERSION}
 
 RUN apt-get update && \
@@ -22,7 +22,6 @@ RUN apt-get update && \
         automake \
         build-essential \
         ca-certificates \
-        ccache \
         clang \
         cmake \
         curl \

--- a/ci/kokoro/docker/build-in-docker-cmake.sh
+++ b/ci/kokoro/docker/build-in-docker-cmake.sh
@@ -54,10 +54,6 @@ cmake_flags=(
     # Configure the build type (Debug, Release, etc)
     "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
 
-    # Always disable ccache in the CI builds because they can flake if the
-    # ccache.conf file is not created properly
-    "-DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF"
-
     # To test installs without root privileges we cannot install in the default
     # directory (typically /usr/local)
     "-DCMAKE_INSTALL_PREFIX=$HOME/staging"

--- a/ci/kokoro/docker/build.sh
+++ b/ci/kokoro/docker/build.sh
@@ -161,7 +161,7 @@ elif [[ "${BUILD_NAME}" = "clang-3.8" ]]; then
   # particularly interesting about that version. It is simply the version
   # included with Ubuntu:16.04, and the oldest version tested by
   # google-cloud-cpp.
-  export DISTRO=ubuntu
+  export DISTRO=ubuntu-xenial
   export DISTRO_VERSION=16.04
   export CC=clang
   export CXX=clang++

--- a/ci/kokoro/docker/common.cfg
+++ b/ci/kokoro/docker/common.cfg
@@ -20,3 +20,4 @@ gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-service-account.js
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/gcr-configuration.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-integration-tests-config.sh"
 gfile_resources: "/bigstore/cloud-cpp-integration-secrets/spanner-credentials.json"
+gfile_resources: "/bigstore/cloud-cpp-integration-secrets/build-results-service-account.json"

--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -45,6 +45,6 @@ gsutil -q cp "gs://${CACHE_FOLDER}/${CACHE_NAME}.tar.gz" "${HOME_DIR}"
 gcloud --quiet auth revoke --all || echo "Ignore revoke failure"
 # Ignore timestamp warnings, Bazel has files with timestamps 10 years
 # into the future :shrug:
-tar -zxf "${HOME_DIR}/${CACHE_NAME}.tar.gz" 2>&1 | egrep -v 'tar:.*in the future'
+tar -zxf "${HOME_DIR}/${CACHE_NAME}.tar.gz" 2>&1 | grep -E -v 'tar:.*in the future'
 
 exit 0

--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ $# != 3 ]]; then
+  echo "Usage: $(basename "$0") <cache-folder> <cache-name> <home-directory>"
+  exit 1
+fi
+
+readonly CACHE_FOLDER="$1"
+readonly CACHE_NAME="$2"
+readonly HOME_DIR="$3"
+
+mkdir -p "${HOME_DIR}/.cache"
+mkdir -p "${HOME_DIR}/.ccache"
+echo "max_size = 4.0G" >"${HOME_DIR}/.ccache/ccache.conf"
+
+readonly KEYFILE="${KOKORO_GFILE_DIR:-/dev/shm}/build-results-service-account.json"
+if [[ ! -f "${KEYFILE}" ]]; then
+  echo "================================================================"
+  echo "Service account for cache access is not configured."
+  echo "No attempt will be made to download the cache, exit with success."
+  exit 0
+fi
+
+echo "================================================================"
+echo "$(date -u): Downloading build cache ${CACHE_NAME} from ${CACHE_FOLDER}"
+
+set -v
+gcloud --quiet auth activate-service-account --key-file "${KEYFILE}"
+gsutil -q cp "gs://${CACHE_FOLDER}/${CACHE_NAME}.tar.gz" "${HOME_DIR}"
+gcloud --quiet auth revoke --all || echo "Ignore revoke failure"
+# Ignore timestamp warnings, Bazel has files with timestamps 10 years
+# into the future :shrug:
+tar -zxf "${HOME_DIR}/${CACHE_NAME}.tar.gz" 2>&1 | egrep -v 'tar:.*in the future'
+
+exit 0

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ $# != 3 ]]; then
+  echo "Usage: $(basename "$0") <cache-folder> <cache-name> <home-directory>"
+  exit 1
+fi
+
+readonly CACHE_FOLDER="$1"
+readonly CACHE_NAME="$2"
+readonly HOME_DIR="$3"
+
+readonly KEYFILE="${KOKORO_GFILE_DIR:-/dev/shm}/build-results-service-account.json"
+if [[ ! -f "${KEYFILE}" ]]; then
+  echo "================================================================"
+  echo "Service account for cache access is not configured."
+  echo "No attempt will be made to download the cache, exit with success."
+  exit 0
+fi
+
+if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] || \
+   [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
+  echo "================================================================"
+  echo "This is a presubmit build, cache will not be updated, exist with success."
+  exit 0
+fi
+
+echo "================================================================"
+echo "$(date -u): Uploading build cache ${CACHE_NAME} to ${CACHE_FOLDER}"
+
+set -v
+tar -zcf "${HOME_DIR}/${CACHE_NAME}.tar.gz" \
+    "${HOME_DIR}/.cache" "${HOME_DIR}/.ccache"
+gcloud --quiet auth activate-service-account --key-file "${KEYFILE}"
+gsutil -q cp "${HOME_DIR}/${CACHE_NAME}.tar.gz" "gs://${CACHE_FOLDER}/"
+gcloud --quiet auth revoke --all >/dev/null 2>&1 || echo "Ignore revoke failure"
+
+exit 0

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -36,7 +36,7 @@ if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] || \
    [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"
   echo "This is a presubmit build, cache will not be updated, exist with success."
-  exit 0
+# TODO(coryan)  exit 0
 fi
 
 echo "================================================================"

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -36,7 +36,7 @@ if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] || \
    [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"
   echo "This is a presubmit build, cache will not be updated, exit with success."
-# TODO(coryan) - uncomment before merge  exit 0
+  exit 0
 fi
 
 echo "================================================================"

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -36,7 +36,7 @@ if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] || \
    [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"
   echo "This is a presubmit build, cache will not be updated, exit with success."
-  exit 0
+# TODO(coryan) - uncomment before merge  exit 0
 fi
 
 echo "================================================================"

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -35,8 +35,8 @@ fi
 if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] || \
    [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"
-  echo "This is a presubmit build, cache will not be updated, exist with success."
-# TODO(coryan)  exit 0
+  echo "This is a presubmit build, cache will not be updated, exit with success."
+  exit 0
 fi
 
 echo "================================================================"


### PR DESCRIPTION
Part of the work for googleapis/google-cloud-cpp-common#263

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1446)
<!-- Reviewable:end -->
