### PR TITLE
chore: remove some unncessary NOLINTs

### DIFF
--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -27,25 +27,23 @@ struct SessionPoolFriendForTest {
   static future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
   AsyncBatchCreateSessions(std::shared_ptr<SessionPool> const& session_pool,
                            CompletionQueue& cq,
-                           std::shared_ptr<SpannerStub> stub,
+                           std::shared_ptr<SpannerStub> const& stub,
                            std::map<std::string, std::string> const& labels,
                            int num_sessions) {
-    return session_pool->AsyncBatchCreateSessions(cq, std::move(stub), labels,
+    return session_pool->AsyncBatchCreateSessions(cq, stub, labels,
                                                   num_sessions);
   }
 
   static future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
       std::shared_ptr<SessionPool> const& session_pool, CompletionQueue& cq,
-      std::shared_ptr<SpannerStub> stub, std::string session_name) {
-    return session_pool->AsyncDeleteSession(cq, std::move(stub),
-                                            std::move(session_name));
+      std::shared_ptr<SpannerStub> const& stub, std::string session_name) {
+    return session_pool->AsyncDeleteSession(cq, stub, std::move(session_name));
   }
 
   static future<StatusOr<google::spanner::v1::Session>> AsyncGetSession(
       std::shared_ptr<SessionPool> const& session_pool, CompletionQueue& cq,
-      std::shared_ptr<SpannerStub> stub, std::string session_name) {
-    return session_pool->AsyncGetSession(cq, std::move(stub),
-                                         std::move(session_name));
+      std::shared_ptr<SpannerStub> const& stub, std::string session_name) {
+    return session_pool->AsyncGetSession(cq, stub, std::move(session_name));
   }
 };
 namespace {

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -191,7 +191,7 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQuery(
       std::move(params.transaction),
       [this, &params](SessionHolder& session,
                       spanner_proto::TransactionSelector& s, std::int64_t) {
-        return PartitionQueryImpl(session, s, std::move(params));
+        return PartitionQueryImpl(session, s, params);
       });
 }
 
@@ -585,8 +585,7 @@ StatusOr<ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
 
 StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
     SessionHolder& session, spanner_proto::TransactionSelector& s,
-    PartitionQueryParams
-        params) {  // NOLINT(performance-unnecessary-value-param)
+    PartitionQueryParams const& params) {
   // Since the session may be sent to other machines, it should not be returned
   // to the pool when the Transaction is destroyed.
   auto prepare_status = PrepareSession(session, /*dissociate_from_pool=*/true);
@@ -628,7 +627,7 @@ StatusOr<std::vector<QueryPartition>> ConnectionImpl::PartitionQueryImpl(
   for (auto& partition : response->partitions()) {
     query_partitions.push_back(internal::MakeQueryPartition(
         response->transaction().id(), session->session_name(),
-        partition.partition_token(), std::move(params.statement)));
+        partition.partition_token(), params.statement));
   }
 
   return query_partitions;

--- a/google/cloud/spanner/internal/connection_impl.h
+++ b/google/cloud/spanner/internal/connection_impl.h
@@ -132,7 +132,7 @@ class ConnectionImpl : public Connection {
 
   StatusOr<std::vector<QueryPartition>> PartitionQueryImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,
-      PartitionQueryParams params);
+      PartitionQueryParams const& params);
 
   StatusOr<BatchDmlResult> ExecuteBatchDmlImpl(
       SessionHolder& session, google::spanner::v1::TransactionSelector& s,

--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -123,7 +123,7 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
               WaitForSessionAllocation wait);  // EXCLUSIVE_LOCKS_REQUIRED(mu_)
   StatusOr<std::vector<CreateCount>> ComputeCreateCounts(
       int sessions_to_create);  // EXCLUSIVE_LOCKS_REQUIRED(mu_)
-  Status CreateSessions(std::vector<CreateCount> create_counts,
+  Status CreateSessions(std::vector<CreateCount> const& create_counts,
                         WaitForSessionAllocation wait);  // LOCKS_EXCLUDED(mu_)
   Status CreateSessionsSync(std::shared_ptr<Channel> const& channel,
                             std::map<std::string, std::string> const& labels,
@@ -139,14 +139,14 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
   // Asynchronous calls used to maintain the pool.
   future<StatusOr<google::spanner::v1::BatchCreateSessionsResponse>>
   AsyncBatchCreateSessions(CompletionQueue& cq,
-                           std::shared_ptr<SpannerStub> stub,
+                           std::shared_ptr<SpannerStub> const& stub,
                            std::map<std::string, std::string> const& labels,
                            int num_sessions);
   future<StatusOr<google::protobuf::Empty>> AsyncDeleteSession(
-      CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+      CompletionQueue& cq, std::shared_ptr<SpannerStub> const& stub,
       std::string session_name);
   future<StatusOr<google::spanner::v1::Session>> AsyncGetSession(
-      CompletionQueue& cq, std::shared_ptr<SpannerStub> stub,
+      CompletionQueue& cq, std::shared_ptr<SpannerStub> const& stub,
       std::string session_name);
 
   Status HandleBatchCreateSessionsDone(


### PR DESCRIPTION
Change some methods to pass by const-ref rather than value, and
eliminate some `performance-unnecessary-value-param` lint suppressions.

In `PartitionQueryImpl`, I removed a `std::move` that had no effect since
 it was already passing via const-ref.

(none of these APIs are public FYI)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1447)
<!-- Reviewable:end -->
