### PR TITLE
feat: allow for the emulator in ClientIntegrationTest.QueryOptionsWork

### DIFF
--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -357,8 +357,13 @@ TEST_F(ClientIntegrationTest, QueryOptionsWork) {
     }
     ++row_count;
   }
-  EXPECT_TRUE(got_error) << "An invalid optimizer version should be an error";
-  EXPECT_EQ(0, row_count);
+  if (!emulator_) {
+    EXPECT_TRUE(got_error) << "An invalid optimizer version should be an error";
+    EXPECT_EQ(0, row_count);
+  } else {
+    EXPECT_FALSE(got_error) << "An invalid optimizer version should be OK";
+    EXPECT_EQ(2, row_count);
+  }
 }
 
 /// @test Test ExecutePartitionedDml


### PR DESCRIPTION
`set_optimizer_version("some-invalid-version")` doesn't faze the
Spanner emulator, so expect the normal result for the query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1453)
<!-- Reviewable:end -->
