### PR TITLE
fix: made .clang-format generic for any repo

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,10 +9,11 @@ PointerAlignment: Left
 
 IncludeBlocks: Merge
 IncludeCategories:
-- Regex: '^\"google/cloud/spanner'
-  Priority: 500
-- Regex: '^\"google/cloud/'
+# Matches common headers first, but sorts them after project includes
+- Regex: '^\"google/cloud/(internal/|grpc_utils/|testing_util/|[^/]+\.h)'
   Priority: 1500
+- Regex: '^\"google/cloud/'  # project includes should sort first
+  Priority: 500
 - Regex: '^\"'
   Priority: 1000
 - Regex: '^<grpc/'


### PR DESCRIPTION
As we prepare to move to a monorepo, we want all of our existing repos
to be formatted with the same .clang-format config. This config removes
any per-library specific names (i.e., I removed "spanner"). Instead,
this names the headers and directories of the *common* headers and
ensures that those sort after the other quoted "google/cloud/.+"
includes, which should be the project ones.

This exact same `.clang-format` file should work in all of our repos.

The intent is that library includes sort first, and they sort before the common includes. For example:

```cc
// file: spanner/foo.h
#include "google/cloud/spanner/blah.h"
#include "google/cloud/bar.h"
...
```

Part of https://github.com/googleapis/google-cloud-cpp/issues/3596

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1454)
<!-- Reviewable:end -->
