### PR TITLE
fix: fully qualify spanner names outside namespace-alias scope

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -147,14 +147,14 @@ int main(int argc, char* argv[]) {
     config.database_id =
         google::cloud::spanner_testing::RandomDatabaseName(generator);
   }
-  spanner::Database database(config.project_id, config.instance_id,
-                             config.database_id);
+  google::cloud::spanner::Database database(
+      config.project_id, config.instance_id, config.database_id);
 
   // Once the configuration is fully initialized and the database name set,
   // print everything out.
   std::cout << config << std::flush;
 
-  spanner::DatabaseAdminClient admin_client;
+  google::cloud::spanner::DatabaseAdminClient admin_client;
   std::vector<std::string> additional_statements = [&available, generator] {
     std::vector<std::string> statements;
     for (auto const& kv : available) {

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -90,8 +90,8 @@ int main(int argc, char* argv[]) {
     config.database_id =
         google::cloud::spanner_testing::RandomDatabaseName(generator);
   }
-  spanner::Database database(config.project_id, config.instance_id,
-                             config.database_id);
+  google::cloud::spanner::Database database(
+      config.project_id, config.instance_id, config.database_id);
   auto available = AvailableExperiments();
   auto e = available.find(config.experiment);
   if (e == available.end()) {
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  spanner::DatabaseAdminClient admin_client;
+  google::cloud::spanner::DatabaseAdminClient admin_client;
   auto create_future =
       admin_client.CreateDatabase(database, {R"sql(CREATE TABLE KeyValue (
                                 Key   INT64 NOT NULL,


### PR DESCRIPTION
Do not expect a namespace alias declared within an anonymous namespace
to work outside of the anonymous namespace, as it could be ambiguous in
that context.

Fixes #1461.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1462)
<!-- Reviewable:end -->
