### PR TITLE
cleanup: treat enum TypeCode elements consistently

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -114,16 +114,16 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
   }
 
   switch (t.code()) {
-    case google::spanner::v1::BOOL:
+    case google::spanner::v1::TypeCode::BOOL:
       return os << v.bool_value();
 
-    case google::spanner::v1::INT64:
+    case google::spanner::v1::TypeCode::INT64:
       return os << internal::FromProto(t, v).get<std::int64_t>().value();
 
-    case google::spanner::v1::FLOAT64:
+    case google::spanner::v1::TypeCode::FLOAT64:
       return os << internal::FromProto(t, v).get<double>().value();
 
-    case google::spanner::v1::STRING:
+    case google::spanner::v1::TypeCode::STRING:
       switch (mode) {
         case StreamMode::kScalar:
           return os << v.string_value();
@@ -134,14 +134,14 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
       }
       return os;  // Unreachable, but quiets warning.
 
-    case google::spanner::v1::BYTES:
+    case google::spanner::v1::TypeCode::BYTES:
       return os << internal::BytesFromBase64(v.string_value()).value();
 
-    case google::spanner::v1::TIMESTAMP:
-    case google::spanner::v1::DATE:
+    case google::spanner::v1::TypeCode::TIMESTAMP:
+    case google::spanner::v1::TypeCode::DATE:
       return os << v.string_value();
 
-    case google::spanner::v1::ARRAY: {
+    case google::spanner::v1::TypeCode::ARRAY: {
       const char* delimiter = "";
       os << '[';
       for (auto const& e : v.list_value().values()) {
@@ -152,7 +152,7 @@ std::ostream& StreamHelper(std::ostream& os, google::protobuf::Value const& v,
       return os << ']';
     }
 
-    case google::spanner::v1::STRUCT: {
+    case google::spanner::v1::TypeCode::STRUCT: {
       const char* delimiter = "";
       os << '(';
       for (int i = 0; i < v.list_value().values_size(); ++i) {

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -944,7 +944,7 @@ TEST(Value, GetBadStruct) {
 TEST(Value, CommitTimestamp) {
   auto const v = Value(CommitTimestamp{});
   auto tv = internal::ToProto(v);
-  EXPECT_EQ(google::spanner::v1::TIMESTAMP, tv.first.code());
+  EXPECT_EQ(google::spanner::v1::TypeCode::TIMESTAMP, tv.first.code());
 
   google::protobuf::Value pv;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(


### PR DESCRIPTION
Always use `TypeCode` when spelling the name of a type-code value,
just like if `TypeCode` was a scoped enum (`enum class`).  This is
a readability aid.  Previously we were inconsistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1463)
<!-- Reviewable:end -->
