### PR TITLE
ci: avoid modifying the developer's gcloud config

### DIFF
--- a/ci/colors.sh
+++ b/ci/colors.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Prefer the log_* functions, such as log_yellow, instead of directly using
+# these variables. The functions don't require the caller to remember to reset
+# the terminal.
 if [ -z "${COLOR_RESET+x}" ]; then
   if type tput >/dev/null 2>&1; then
     readonly COLOR_RED="$(tput setaf 1)"
@@ -26,3 +29,35 @@ if [ -z "${COLOR_RESET+x}" ]; then
     readonly COLOR_RESET=""
   fi
 fi
+
+# Logs a message using the given color. The first argument must be one of the
+# COLOR_* variables defined above, such as "${COLOR_YELLOW}". The remaining
+# arguments will be logged in the given color. The log message will also have
+# an RFC-3339 timestamp prepended (in UTC).
+function log_color_impl() {
+  local color="$1"
+  shift
+  local timestamp
+  timestamp="$(date -u "+%Y-%m-%dT%H:%M:%SZ")"
+  echo "${color}${timestamp}:" "$@" "${COLOR_RESET}"
+}
+
+# Logs the given message with normal coloring and a timestamp.
+function log_normal() {
+  log_color_impl "${COLOR_RESET}" "$@"
+}
+
+# Logs the given message in green with a timestamp.
+function log_green() {
+  log_color_impl "${COLOR_GREEN}" "$@"
+}
+
+# Logs the given message in yellow with a timestamp.
+function log_yellow() {
+  log_color_impl "${COLOR_YELLOW}" "$@"
+}
+
+# Logs the given message in red with a timestamp.
+function log_red() {
+  log_color_impl "${COLOR_RED}" "$@"
+}

--- a/ci/kokoro/docker/download-cache.sh
+++ b/ci/kokoro/docker/download-cache.sh
@@ -61,7 +61,8 @@ activate_service_account_keyfile "${KEYFILE}"
 
 echo "================================================================"
 log_normal "Downloading build cache ${CACHE_NAME} from ${CACHE_FOLDER}"
-gsutil -q cp "gs://${CACHE_FOLDER}/${CACHE_NAME}.tar.gz" "${HOME_DIR}"
+env CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG} \
+    gsutil -q cp "gs://${CACHE_FOLDER}/${CACHE_NAME}.tar.gz" "${HOME_DIR}"
 
 # Ignore timestamp warnings, Bazel has files with timestamps 10 years
 # into the future :shrug:

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -20,6 +20,13 @@ if [[ $# != 3 ]]; then
   exit 1
 fi
 
+if [[ -z "${PROJECT_ROOT+x}" ]]; then
+  readonly PROJECT_ROOT="$(cd "$(dirname "$0")/../../.."; pwd)"
+fi
+GCLOUD=gcloud
+source "${PROJECT_ROOT}/ci/colors.sh"
+source "${PROJECT_ROOT}/ci/kokoro/gcloud-functions.sh"
+
 readonly CACHE_FOLDER="$1"
 readonly CACHE_NAME="$2"
 readonly HOME_DIR="$3"
@@ -27,26 +34,28 @@ readonly HOME_DIR="$3"
 readonly KEYFILE="${KOKORO_GFILE_DIR:-/dev/shm}/build-results-service-account.json"
 if [[ ! -f "${KEYFILE}" ]]; then
   echo "================================================================"
-  echo "Service account for cache access is not configured."
-  echo "No attempt will be made to download the cache, exit with success."
+  log_normal "Service account for cache access is not configured."
+  log_normal "No attempt will be made to upload the cache, exit with success."
   exit 0
 fi
 
 if [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GERRIT_ON_BORG" ]] || \
    [[ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ]]; then
   echo "================================================================"
-  echo "This is a presubmit build, cache will not be updated, exit with success."
+  log_normal "Cache not updated as this is a PR build."
   exit 0
 fi
 
 echo "================================================================"
-echo "$(date -u): Uploading build cache ${CACHE_NAME} to ${CACHE_FOLDER}"
+log_normal "Uploading build cache ${CACHE_NAME} to ${CACHE_FOLDER}"
 
-set -v
 tar -zcf "${HOME_DIR}/${CACHE_NAME}.tar.gz" \
     "${HOME_DIR}/.cache" "${HOME_DIR}/.ccache"
-gcloud --quiet auth activate-service-account --key-file "${KEYFILE}"
+
+trap delete_gcloud_config EXIT
+create_gcloud_config
+activate_service_account_keyfile "${KEYFILE}"
 gsutil -q cp "${HOME_DIR}/${CACHE_NAME}.tar.gz" "gs://${CACHE_FOLDER}/"
-gcloud --quiet auth revoke --all >/dev/null 2>&1 || echo "Ignore revoke failure"
+revoke_service_account_keyfile "${KEYFILE}"
 
 exit 0

--- a/ci/kokoro/docker/upload-cache.sh
+++ b/ci/kokoro/docker/upload-cache.sh
@@ -62,7 +62,8 @@ cleanup() {
 
 create_gcloud_config
 activate_service_account_keyfile "${KEYFILE}"
-gsutil -q cp "${HOME_DIR}/${CACHE_NAME}.tar.gz" "gs://${CACHE_FOLDER}/"
+env CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG} \
+    gsutil -q cp "${HOME_DIR}/${CACHE_NAME}.tar.gz" "gs://${CACHE_FOLDER}/"
 
 echo "================================================================"
 log_normal "Upload completed"

--- a/ci/kokoro/gcloud-functions.sh
+++ b/ci/kokoro/gcloud-functions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if [[ -z "${GCLOUD_CONFIG:-}" ]]; then
+  readonly GCLOUD_CONFIG="cloud-cpp-integration"
+  readonly GCLOUD_ARGS=(
+      # Do not seek confirmation for any actions, assume the default
+      "--quiet"
+
+      # Run the command using a custom configuration, this avoids affecting the
+      # user's `default` configuration
+      "--configuration=${GCLOUD_CONFIG}"
+  )
+fi
+
+activate_service_account_keyfile() {
+  local -r keyfile="$1"
+  local -r account="$(sed -n 's/.*"client_email": "\(.*\)",.*/\1/p' "${keyfile}")"
+  "${GCLOUD}" "${GCLOUD_ARGS[@]}" auth activate-service-account \
+      --key-file "${keyfile}" >/dev/null
+  "${GCLOUD}" "${GCLOUD_ARGS[@]}" config set account "${account}"
+}
+
+revoke_service_account_keyfile() {
+  local -r keyfile="$1"
+  local -r account="$(sed -n 's/.*"client_email": "\(.*\)",.*/\1/p' "${keyfile}")"
+  "${GCLOUD}" "${GCLOUD_ARGS[@]}" auth revoke "${account}" >/dev/null
+}
+
+delete_gcloud_config() {
+  "${GCLOUD}" --quiet config configurations delete "${GCLOUD_CONFIG}"
+}
+
+create_gcloud_config() {
+  echo
+  echo "================================================================"
+  if ! "${GCLOUD}" --quiet config configurations \
+           describe "${GCLOUD_CONFIG}" >/dev/null 2>&1; then
+    log_normal "Create the gcloud configuration for the cloud-cpp tests."
+    "${GCLOUD}" --quiet --no-user-output-enabled config configurations \
+        create --no-activate "${GCLOUD_CONFIG}" >/dev/null
+  fi
+  if [[ -n "${GOOGLE_CLOUD_PROJECT:-}" ]]; then
+    "${GCLOUD}" "${GCLOUD_ARGS[@]}" config set project "${GOOGLE_CLOUD_PROJECT}"
+  fi
+}

--- a/ci/kokoro/gcloud-functions.sh
+++ b/ci/kokoro/gcloud-functions.sh
@@ -17,6 +17,9 @@ set -eu
 
 if [[ -z "${GCLOUD_CONFIG:-}" ]]; then
   readonly GCLOUD_CONFIG="cloud-cpp-integration"
+fi
+
+if [[ -z "${GCLOUD_ARGS:-}" ]]; then
   readonly GCLOUD_ARGS=(
       # Do not seek confirmation for any actions, assume the default
       "--quiet"
@@ -46,10 +49,10 @@ delete_gcloud_config() {
 }
 
 create_gcloud_config() {
-  echo
-  echo "================================================================"
   if ! "${GCLOUD}" --quiet config configurations \
            describe "${GCLOUD_CONFIG}" >/dev/null 2>&1; then
+    echo
+    echo "================================================================"
     log_normal "Create the gcloud configuration for the cloud-cpp tests."
     "${GCLOUD}" --quiet --no-user-output-enabled config configurations \
         create --no-activate "${GCLOUD_CONFIG}" >/dev/null


### PR DESCRIPTION
To upload and download the cache we need to add a service account to the
developer's environment. For the CI builds this does not matter, as the
CI runs with a clean environment. When running the builds locally this
was annoying because it revoked the developer's credentials.

These changes fix that, probably using more changes than strictily
necessary, but it was easier to copy the code from g-c-cpp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1466)
<!-- Reviewable:end -->
