### PR TITLE
cleanup: make unit test target names unique

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -382,9 +382,11 @@ function (spanner_client_define_tests)
 
     # Generate a target for each unit test.
     foreach (fname ${spanner_client_unit_tests})
-        string(REPLACE "/" "_" target ${fname})
-        string(REPLACE ".cc" "" target ${target})
+        string(REPLACE "/" "_" basename ${fname})
+        string(REPLACE ".cc" "" basename ${basename})
+        set(target "spanner_${basename}")
         add_executable(${target} ${fname})
+        set_target_properties(${target} PROPERTIES OUTPUT_NAME ${basename})
         target_link_libraries(
             ${target}
             PRIVATE spanner_client_testing googleapis-c++::spanner_client


### PR DESCRIPTION
CMake requires target names to be unique, even in different directories.
Fortunately the target name can be different from the binary name,
though it requires a little more work to make it so. Unit tests are more
likely to repeat names, so use a prefix to minimize the possibility of
collisions. The other targets can be handled on a ad-hoc basis when and
if we have a target name collision.

Part of the work for googleapis/google-cloud-cpp#3548

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1471)
<!-- Reviewable:end -->
