### PR TITLE
chore: link with gtest_main

### DIFF
--- a/google/cloud/spanner/BUILD
+++ b/google/cloud/spanner/BUILD
@@ -64,7 +64,7 @@ cc_library(
         ":spanner_client",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -79,7 +79,7 @@ cc_library(
         ":spanner_client_mocks",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -95,7 +95,7 @@ load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 ) for test in spanner_client_unit_tests]
 

--- a/google/cloud/spanner/benchmarks/BUILD
+++ b/google/cloud/spanner/benchmarks/BUILD
@@ -29,7 +29,7 @@ cc_library(
         "//google/cloud/spanner:spanner_client_testing",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -45,6 +45,6 @@ cc_library(
         "//google/cloud/spanner:spanner_client_testing",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 ) for test in spanner_client_benchmark_programs]

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -29,6 +29,6 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
         "//google/cloud/spanner:spanner_client_testing",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 ) for test in spanner_client_integration_tests]

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -20,7 +20,6 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -894,7 +893,7 @@ TEST_F(ClientIntegrationTest, ProfileDml) {
 }  // namespace google
 
 int main(int argc, char* argv[]) {
-  ::google::cloud::testing_util::InitGoogleMock(argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
       new google::cloud::spanner_testing::DatabaseEnvironment());
 

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/testing/database_environment.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 #include <future>
 #include <random>
@@ -196,7 +195,7 @@ TEST(ClientStressTest, UpsertAndRead) {
 }  // namespace google
 
 int main(int argc, char* argv[]) {
-  ::google::cloud::testing_util::InitGoogleMock(argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
 
   // TODO(#...) - refactor google-cloud-cpp code for command-line parsing.
   std::string const table_size_arg = "--table-size=";

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -20,7 +20,6 @@
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 #include <chrono>
 
@@ -347,7 +346,7 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
 }  // namespace google
 
 int main(int argc, char* argv[]) {
-  ::google::cloud::testing_util::InitGoogleMock(argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
       new google::cloud::spanner_testing::DatabaseEnvironment());
 

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/spanner/internal/session_pool.h"
 #include "google/cloud/spanner/testing/database_environment.h"
 #include "google/cloud/testing_util/assert_ok.h"
-#include "google/cloud/testing_util/init_google_mock.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -115,7 +114,7 @@ TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
 }  // namespace google
 
 int main(int argc, char* argv[]) {
-  ::google::cloud::testing_util::InitGoogleMock(argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   (void)::testing::AddGlobalTestEnvironment(
       new google::cloud::spanner_testing::DatabaseEnvironment());
 

--- a/google/cloud/spanner/samples/BUILD
+++ b/google/cloud/spanner/samples/BUILD
@@ -31,7 +31,7 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
         "//google/cloud/spanner:spanner_client_testing",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 ) for test in spanner_client_integration_samples]
 
@@ -43,6 +43,6 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
         "//google/cloud/spanner:spanner_client_testing",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud:google_cloud_cpp_common",
         "@com_github_googleapis_google_cloud_cpp_common//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
     ],
 ) for test in spanner_client_unit_samples]


### PR DESCRIPTION
Fixes googleapis/google-cloud-cpp#3713

Currently, the `:google_cloud_cpp_testing` target _also_ includes a
`main()`, that is exactly the same as `:gtest_main`. However, that
target is losing its implementation of main (it's gone in `-cpp`
already). So to keep the `-spanner` code working when it moves into
`-cpp`, it should explicitly link with `:gtest_main` now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1472)
<!-- Reviewable:end -->
