### PR TITLE
cleanup: Enable PartitionRead() and ExecuteBatchDml() with emulator

### DIFF
--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -587,7 +587,6 @@ TEST_F(ClientIntegrationTest, PartitionRead) {
   auto read_partitions =
       client_->PartitionRead(ro_transaction, "Singers", KeySet::All(),
                              {"SingerId", "FirstName", "LastName"});
-  if (EmulatorUnimplemented(read_partitions.status())) return;
   ASSERT_STATUS_OK(read_partitions);
 
   std::vector<std::string> serialized_partitions;
@@ -686,7 +685,6 @@ TEST_F(ClientIntegrationTest, ExecuteBatchDml) {
         return Mutations{};
       });
 
-  if (EmulatorUnimplemented(commit_result.status())) return;
   ASSERT_STATUS_OK(commit_result);
   ASSERT_STATUS_OK(batch_result);
   ASSERT_STATUS_OK(batch_result->status);
@@ -756,7 +754,6 @@ TEST_F(ClientIntegrationTest, ExecuteBatchDmlMany) {
         return Mutations{};
       });
 
-  if (EmulatorUnimplemented(commit_result.status())) return;
   ASSERT_STATUS_OK(commit_result);
 
   ASSERT_STATUS_OK(batch_result_left);
@@ -815,7 +812,6 @@ TEST_F(ClientIntegrationTest, ExecuteBatchDmlFailure) {
       });
 
   ASSERT_FALSE(commit_result.ok());
-  if (EmulatorUnimplemented(batch_result.status())) return;
   ASSERT_STATUS_OK(batch_result);
   ASSERT_FALSE(batch_result->status.ok());
   ASSERT_EQ(batch_result->stats.size(), 2);


### PR DESCRIPTION
The Cloud Spanner SDK emulator now supports `ExecuteBatchDml()` and
(in the imminent release) `PartitionRead()`, so remove the checks that
allowed for `StatusCode::kUnimplemented`.

We currently don't test automatically against the emulator, so this
only affects manual/internal testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1474)
<!-- Reviewable:end -->
