### PR TITLE
fix: sync spanner's clang-tidy warnings w/ -cpp

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,11 @@
 #  -modernize-return-braced-init-list: We think removing typenames and using
 #      only braced-init can hurt readability.
 #
+#  -modernize-avoid-c-arrays: We only use C arrays when they seem to be the
+#      right tool for the job, such as `char foo[] = "hello"`. In these cases,
+#      avoiding C arrays often makes the code less readable, and std::array is
+#      not a drop-in replacement because it doesn't deduce the size.
+#
 #  -performance-move-const-arg: This warning requires the developer to
 #      know/care more about the implementation details of types/functions than
 #      should be necessary. For example, `A a; F(std::move(a));` will trigger a
@@ -24,6 +29,7 @@
 #      counts as a declaration, so if we also declare that friend outside the
 #      class in order to document it as part of the public API, that will
 #      trigger a redundant declaration warning from this check.
+#
 Checks: >
   -*,
   bugprone-*,
@@ -39,17 +45,18 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -modernize-return-braced-init-list,
   -modernize-use-trailing-return-type,
+  -modernize-avoid-c-arrays,
   -performance-move-const-arg,
-  -readability-named-parameter,
   -readability-braces-around-statements,
   -readability-magic-numbers,
+  -readability-named-parameter,
   -readability-redundant-declaration
 
 # Turn all the warnings from the checks above into errors.
 WarningsAsErrors: "*"
 
-# Enable clang-tidy checks in our headers.
-HeaderFilterRegex: "google/cloud/spanner/.*"
+# TODO(#3920) - Enable clang-tidy checks in our headers.
+HeaderFilterRegex: "google/cloud/(pubsub|spanner)/.*"
 
 CheckOptions:
   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }

--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -63,7 +63,6 @@ google::cloud::StatusOr<Config> ParseArgs(std::vector<std::string> args) {
     std::function<void(Config&, std::string)> parser;
   };
 
-  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   Flag flags[] = {
       {"--experiment=",
        [](Config& c, std::string v) { c.experiment = std::move(v); }},


### PR DESCRIPTION
This PR installs an exact copy of the .clang-tidy file from `-cpp`. The
only real change is that we now ignore the warning about using C arrays.
So I also removed the one NOLINT warning that's no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1480)
<!-- Reviewable:end -->
