### PR TITLE
cleanup: enable clang-tidy for testing and (macro) benchmark libraries

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -309,6 +309,7 @@ function (spanner_client_define_tests)
                google_cloud_cpp_testing GTest::gmock_main GTest::gmock
                GTest::gtest)
     create_bazel_config(spanner_client_testing YEAR "2019")
+    google_cloud_cpp_add_clang_tidy(spanner_client_testing)
 
     target_include_directories(
         spanner_client_testing

--- a/google/cloud/spanner/benchmarks/CMakeLists.txt
+++ b/google/cloud/spanner/benchmarks/CMakeLists.txt
@@ -47,6 +47,7 @@ function (spanner_client_define_benchmarks)
                GTest::gmock
                GTest::gtest)
     create_bazel_config(spanner_client_benchmarks YEAR "2019")
+    google_cloud_cpp_add_clang_tidy(spanner_client_benchmarks)
 
     target_include_directories(
         spanner_client_benchmarks

--- a/google/cloud/spanner/testing/pick_instance_config.cc
+++ b/google/cloud/spanner/testing/pick_instance_config.cc
@@ -42,7 +42,7 @@ std::string PickInstanceConfig(
     }
     return ret;
   }();
-  if (instance_configs.size() > 0) {
+  if (!instance_configs.empty()) {
     auto random_index = std::uniform_int_distribution<std::size_t>(
         0, instance_configs.size() - 1);
     instance_config_name = instance_configs[random_index(generator)];

--- a/google/cloud/spanner/testing/validate_metadata.cc
+++ b/google/cloud/spanner/testing/validate_metadata.cc
@@ -147,7 +147,7 @@ StatusOr<std::map<std::string, std::string> > ExtractMDFromHeaders(
 }
 
 /// A poor man's check if a value matches a glob used in URL patterns.
-bool ValueMatchesPattern(std::string val, std::string pattern) {
+bool ValueMatchesPattern(std::string const& val, std::string const& pattern) {
   std::string regexified_pattern =
       regex_replace(pattern, std::regex("\\*"), std::string("[^/]+"));
   return std::regex_match(val, std::regex(regexified_pattern));
@@ -248,11 +248,12 @@ Status IsContextMDValid(grpc::ClientContext& context, std::string const& method,
                     "Expected param \"" + param + "\" not found in metadata");
     }
     if (!ValueMatchesPattern(found_it->second, expected_pattern)) {
-      return Status(StatusCode::kInvalidArgument,
-                    "Expected param \"" + param +
-                        "\" found, but its value (\"" + found_it->second +
-                        "\") does not satisfy the pattern (\"" +
-                        expected_pattern + "\").");
+      return Status(
+          StatusCode::kInvalidArgument,
+          "Expected param \"" + param + "\" found, but its value (\"" +
+              // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
+              found_it->second + "\") does not satisfy the pattern (\"" +
+              expected_pattern + "\").");
     }
   }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1481)
<!-- Reviewable:end -->
