### PR TITLE
refactor: use SetUpTestSuite instead of Environment

### DIFF
--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -282,8 +282,8 @@ function (spanner_client_define_tests)
         testing/cleanup_stale_instances.cc
         testing/cleanup_stale_instances.h
         testing/compiler_supports_regexp.h
-        testing/database_environment.cc
-        testing/database_environment.h
+        testing/database_integration_test.cc
+        testing/database_integration_test.h
         testing/fake_clock.h
         testing/matchers.h
         testing/mock_database_admin_stub.h

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/mutations.h"
-#include "google/cloud/spanner/testing/database_environment.h"
+#include "google/cloud/spanner/testing/database_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/assert_ok.h"
@@ -31,15 +31,16 @@ namespace {
 using ::testing::UnorderedElementsAre;
 using ::testing::UnorderedElementsAreArray;
 
-class ClientIntegrationTest : public ::testing::Test {
+class ClientIntegrationTest : public spanner_testing::DatabaseIntegrationTest {
  public:
   ClientIntegrationTest()
       : emulator_(google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST")
                       .has_value()) {}
 
   static void SetUpTestSuite() {
+    spanner_testing::DatabaseIntegrationTest::SetUpTestSuite();
     client_ = google::cloud::internal::make_unique<Client>(
-        MakeConnection(spanner_testing::DatabaseEnvironment::GetDatabase()));
+        MakeConnection(GetDatabase()));
   }
 
   void SetUp() override {
@@ -57,7 +58,10 @@ class ClientIntegrationTest : public ::testing::Test {
     ASSERT_STATUS_OK(commit_result);
   }
 
-  static void TearDownTestSuite() { client_ = nullptr; }
+  static void TearDownTestSuite() {
+    client_ = nullptr;
+    spanner_testing::DatabaseIntegrationTest::TearDownTestCase();
+  }
 
  protected:
   bool EmulatorUnimplemented(Status const& status) {
@@ -887,11 +891,3 @@ TEST_F(ClientIntegrationTest, ProfileDml) {
 }  // namespace spanner
 }  // namespace cloud
 }  // namespace google
-
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleMock(&argc, argv);
-  (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::spanner_testing::DatabaseEnvironment());
-
-  return RUN_ALL_TESTS();
-}

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -14,7 +14,7 @@
 
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/database.h"
-#include "google/cloud/spanner/testing/database_environment.h"
+#include "google/cloud/spanner/testing/database_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 #include <future>
@@ -59,8 +59,10 @@ int TaskCount() {
                     : static_cast<int>(cores) * flag_threads_per_core;
 }
 
+class ClientStressTest : public spanner_testing::DatabaseIntegrationTest {};
+
 /// @test Stress test the library using ExecuteQuery calls.
-TEST(ClientSqlStressTest, UpsertAndSelect) {
+TEST_F(ClientStressTest, UpsertAndSelect) {
   int const task_count = TaskCount();
 
   auto select_task = [](Client client) {
@@ -107,8 +109,7 @@ TEST(ClientSqlStressTest, UpsertAndSelect) {
     return result;
   };
 
-  Client client(
-      MakeConnection(spanner_testing::DatabaseEnvironment::GetDatabase()));
+  Client client(MakeConnection(GetDatabase()));
 
   std::vector<std::future<Result>> tasks(task_count);
   for (auto& t : tasks) {
@@ -125,7 +126,7 @@ TEST(ClientSqlStressTest, UpsertAndSelect) {
 }
 
 /// @test Stress test the library using Read calls.
-TEST(ClientStressTest, UpsertAndRead) {
+TEST_F(ClientStressTest, UpsertAndRead) {
   int const task_count = TaskCount();
 
   auto read_task = [](Client client) {
@@ -171,8 +172,7 @@ TEST(ClientStressTest, UpsertAndRead) {
     return result;
   };
 
-  Client client(
-      MakeConnection(spanner_testing::DatabaseEnvironment::GetDatabase()));
+  Client client(MakeConnection(GetDatabase()));
 
   std::vector<std::future<Result>> tasks(task_count);
   for (auto& t : tasks) {
@@ -224,9 +224,6 @@ int main(int argc, char* argv[]) {
       std::cerr << "Unknown flag: " << arg << "\n";
     }
   }
-
-  (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::spanner_testing::DatabaseEnvironment());
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/mutations.h"
-#include "google/cloud/spanner/testing/database_environment.h"
+#include "google/cloud/spanner/testing/database_integration_test.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/assert_ok.h"
@@ -62,11 +62,13 @@ StatusOr<T> WriteReadData(Client& client, T const& data,
   return actual;
 }
 
-class DataTypeIntegrationTest : public ::testing::Test {
+class DataTypeIntegrationTest
+    : public spanner_testing::DatabaseIntegrationTest {
  public:
   static void SetUpTestSuite() {
+    spanner_testing::DatabaseIntegrationTest::SetUpTestSuite();
     client_ = google::cloud::internal::make_unique<Client>(
-        MakeConnection(spanner_testing::DatabaseEnvironment::GetDatabase()));
+        MakeConnection(GetDatabase()));
   }
 
   void SetUp() override {
@@ -76,7 +78,10 @@ class DataTypeIntegrationTest : public ::testing::Test {
     EXPECT_STATUS_OK(commit_result);
   }
 
-  static void TearDownTestSuite() { client_ = nullptr; }
+  static void TearDownTestSuite() {
+    client_ = nullptr;
+    spanner_testing::DatabaseIntegrationTest::TearDownTestCase();
+  }
 
  protected:
   static std::unique_ptr<Client> client_;
@@ -344,11 +349,3 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
 }  // namespace spanner
 }  // namespace cloud
 }  // namespace google
-
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleMock(&argc, argv);
-  (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::spanner_testing::DatabaseEnvironment());
-
-  return RUN_ALL_TESTS();
-}

--- a/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/session_pool_integration_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/session_pool.h"
-#include "google/cloud/spanner/testing/database_environment.h"
+#include "google/cloud/spanner/testing/database_integration_test.h"
 #include "google/cloud/testing_util/assert_ok.h"
 #include <gmock/gmock.h>
 
@@ -47,10 +47,13 @@ struct SessionPoolFriendForTest {
 };
 namespace {
 
-TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
+class SessionPoolIntegrationTest
+    : public spanner_testing::DatabaseIntegrationTest {};
+
+TEST_F(SessionPoolIntegrationTest, SessionAsyncCRUD) {
   google::cloud::CompletionQueue cq;
   std::thread t([&cq] { cq.Run(); });
-  auto const db = spanner_testing::DatabaseEnvironment::GetDatabase();
+  auto const db = GetDatabase();
   auto stub = CreateDefaultSpannerStub(ConnectionOptions{}, /*channel_id=*/0);
   auto session_pool =
       MakeSessionPool(db, {stub}, SessionPoolOptions{}, cq,
@@ -112,11 +115,3 @@ TEST(SessionPoolIntegrationTest, SessionAsyncCRUD) {
 }  // namespace spanner
 }  // namespace cloud
 }  // namespace google
-
-int main(int argc, char* argv[]) {
-  ::testing::InitGoogleMock(&argc, argv);
-  (void)::testing::AddGlobalTestEnvironment(
-      new google::cloud::spanner_testing::DatabaseEnvironment());
-
-  return RUN_ALL_TESTS();
-}

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -19,7 +19,7 @@
 spanner_client_testing_hdrs = [
     "testing/cleanup_stale_instances.h",
     "testing/compiler_supports_regexp.h",
-    "testing/database_environment.h",
+    "testing/database_integration_test.h",
     "testing/fake_clock.h",
     "testing/matchers.h",
     "testing/mock_database_admin_stub.h",
@@ -37,7 +37,7 @@ spanner_client_testing_hdrs = [
 
 spanner_client_testing_srcs = [
     "testing/cleanup_stale_instances.cc",
-    "testing/database_environment.cc",
+    "testing/database_integration_test.cc",
     "testing/pick_instance_config.cc",
     "testing/pick_random_instance.cc",
     "testing/random_backup_name.cc",

--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/spanner/testing/database_environment.h"
+#include "google/cloud/spanner/testing/database_integration_test.h"
 #include "google/cloud/spanner/database_admin_client.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
@@ -24,10 +24,10 @@ namespace cloud {
 namespace spanner_testing {
 inline namespace SPANNER_CLIENT_NS {
 
-google::cloud::spanner::Database* DatabaseEnvironment::db_;
-google::cloud::internal::DefaultPRNG* DatabaseEnvironment::generator_;
+google::cloud::spanner::Database* DatabaseIntegrationTest::db_;
+google::cloud::internal::DefaultPRNG* DatabaseIntegrationTest::generator_;
 
-void DatabaseEnvironment::SetUp() {
+void DatabaseIntegrationTest::SetUpTestSuite() {
   auto project_id =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
   ASSERT_FALSE(project_id.empty());
@@ -82,7 +82,7 @@ void DatabaseEnvironment::SetUp() {
   std::cout << "DONE\n";
 }
 
-void DatabaseEnvironment::TearDown() {
+void DatabaseIntegrationTest::TearDownTestSuite() {
   spanner::DatabaseAdminClient admin_client;
   auto drop_status = admin_client.DropDatabase(*db_);
   EXPECT_STATUS_OK(drop_status);

--- a/google/cloud/spanner/testing/database_integration_test.h
+++ b/google/cloud/spanner/testing/database_integration_test.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_DATABASE_ENVIRONMENT_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_DATABASE_ENVIRONMENT_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_DATABASE_INTEGRATION_TEST_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_DATABASE_INTEGRATION_TEST_H
 
 #include "google/cloud/spanner/database.h"
 #include "google/cloud/spanner/version.h"
@@ -27,13 +27,12 @@ namespace spanner_testing {
 /// An inlined, versioned namespace for the testing helpers.
 inline namespace SPANNER_CLIENT_NS {
 
-class DatabaseEnvironment : public ::testing::Environment {
+class DatabaseIntegrationTest : public ::testing::Test {
  public:
-  static google::cloud::spanner::Database const& GetDatabase() { return *db_; }
+  static void SetUpTestSuite();
+  static void TearDownTestSuite();
 
- protected:
-  void SetUp() override;
-  void TearDown() override;
+  static google::cloud::spanner::Database const& GetDatabase() { return *db_; }
 
  private:
   static google::cloud::spanner::Database* db_;
@@ -45,4 +44,4 @@ class DatabaseEnvironment : public ::testing::Environment {
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_DATABASE_ENVIRONMENT_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_DATABASE_INTEGRATION_TEST_H


### PR DESCRIPTION
This removes our need to define a custom `main()` function only to
create the Environment object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1486)
<!-- Reviewable:end -->
