### PR TITLE
fix: moves find_package calls to common file

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -53,7 +53,11 @@ include(EnableDoxygen)
 # that repo, and these `find_package()` calls will not be necessary.
 find_package(google_cloud_cpp_common CONFIG REQUIRED)
 find_package(google_cloud_cpp_grpc_utils CONFIG REQUIRED)
-find_package(google_cloud_cpp_testing CONFIG REQUIRED)
+
+if (BUILD_TESTING)
+    find_package(GTest CONFIG REQUIRED)
+    find_package(google_cloud_cpp_testing CONFIG REQUIRED)
+endif (BUILD_TESTING)
 
 function (google_cloud_cpp_add_common_options target)
     if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CPP_LATEST)

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -48,6 +48,13 @@ include(SelectMSVCRuntime)
 # Enable doxygen
 include(EnableDoxygen)
 
+# Finds some packages that Spanner gets from the google-cloud-cpp-common repo.
+# Once Spanner moves to google-cloud-cpp, these packages will then come from
+# that repo, and these `find_package()` calls will not be necessary.
+find_package(google_cloud_cpp_common CONFIG REQUIRED)
+find_package(google_cloud_cpp_grpc_utils CONFIG REQUIRED)
+find_package(google_cloud_cpp_testing CONFIG REQUIRED)
+
 function (google_cloud_cpp_add_common_options target)
     if (GOOGLE_CLOUD_CPP_COMPILER_SUPPORTS_CPP_LATEST)
         target_compile_options(${target} INTERFACE "/std:c++latest")

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -14,8 +14,7 @@
 # limitations under the License.
 # ~~~
 
-find_package(google_cloud_cpp_common CONFIG REQUIRED)
-find_package(google_cloud_cpp_grpc_utils CONFIG REQUIRED)
+find_package(googleapis CONFIG REQUIRED)
 
 set(DOXYGEN_PROJECT_NAME "Google Cloud Spanner C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for Google Cloud Spanner")
@@ -274,8 +273,6 @@ function (spanner_client_define_tests)
     # googletest itself), because the generic `FindGTest` module does not define
     # the GTest::gmock target, and the target names are also weird.
     find_package(GTest CONFIG REQUIRED)
-
-    find_package(google_cloud_cpp_testing CONFIG REQUIRED)
 
     add_library(
         spanner_client_testing

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -21,8 +21,6 @@ function (spanner_client_define_integration_tests)
     # the GTest::gmock target, and the target names are also weird.
     find_package(GTest CONFIG REQUIRED)
 
-    find_package(google_cloud_cpp_testing CONFIG REQUIRED)
-
     set(spanner_client_integration_tests
         # cmake-format: sortable
         backup_integration_test.cc


### PR DESCRIPTION
This PR moves some calls to `find_package` into the
GoogleCloudCppCommon.cmake file, because these packages will be changing
location when Spanner moves to -cpp. Moving these into the common file
lets the CMakeLists.txt files in google/cloud/spanner/ compile in this
repo and in -cpp, without modification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1488)
<!-- Reviewable:end -->
