### PR TITLE
chore: adds spanner-integration-tests labels

### DIFF
--- a/google/cloud/spanner/benchmarks/BUILD
+++ b/google/cloud/spanner/benchmarks/BUILD
@@ -37,7 +37,10 @@ cc_library(
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
-    tags = ["integration-tests"],
+    tags = [
+        "integration-tests",
+        "spanner-integration-tests",
+    ],
     deps = [
         ":spanner_client_benchmarks",
         "//google/cloud/spanner:spanner_client",

--- a/google/cloud/spanner/benchmarks/CMakeLists.txt
+++ b/google/cloud/spanner/benchmarks/CMakeLists.txt
@@ -88,7 +88,9 @@ function (spanner_client_define_benchmarks)
         add_test(NAME ${target} COMMAND ${target})
         # To automatically smoke-test the benchmarks as part of the CI build we
         # label them as tests.
-        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
+        set_tests_properties(
+            ${target} PROPERTIES LABELS
+                                 "integration-tests;spanner-integration-tests")
     endforeach ()
 endfunction ()
 

--- a/google/cloud/spanner/integration_tests/BUILD
+++ b/google/cloud/spanner/integration_tests/BUILD
@@ -22,7 +22,10 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
     name = "spanner_client_" + test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
-    tags = ["integration-tests"],
+    tags = [
+        "integration-tests",
+        "spanner-integration-tests",
+    ],
     deps = [
         "//google/cloud/spanner:spanner_client",
         "//google/cloud/spanner:spanner_client_mocks",

--- a/google/cloud/spanner/integration_tests/CMakeLists.txt
+++ b/google/cloud/spanner/integration_tests/CMakeLists.txt
@@ -58,7 +58,9 @@ function (spanner_client_define_integration_tests)
             target_compile_options(${target} PRIVATE "/bigobj")
         endif ()
         add_test(NAME ${target} COMMAND ${target})
-        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
+        set_tests_properties(
+            ${target} PROPERTIES LABELS
+                                 "integration-tests;spanner-integration-tests")
         add_dependencies(spanner-client-integration-tests ${target})
     endforeach ()
 
@@ -76,16 +78,6 @@ function (spanner_client_define_integration_tests)
     if (NOT GOOGLE_CLOUD_CPP_ENABLE_CXX_EXCEPTIONS)
         return()
     endif ()
-
-    foreach (fname ${spanner_client_install_tests})
-        google_cloud_cpp_add_executable(target "spanner" "${fname}")
-        target_link_libraries(${target} PRIVATE googleapis-c++::spanner_client)
-        google_cloud_cpp_add_clang_tidy(${target})
-        google_cloud_cpp_add_common_options(${target})
-
-        add_test(NAME ${target} COMMAND ${target})
-        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
-    endforeach ()
 endfunction ()
 
 # Only define the tests if testing is enabled. Package maintainers may not want

--- a/google/cloud/spanner/samples/BUILD
+++ b/google/cloud/spanner/samples/BUILD
@@ -25,7 +25,10 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
     name = test.replace("/", "_").replace(".cc", ""),
     timeout = "long",
     srcs = [test],
-    tags = ["integration-tests"],
+    tags = [
+        "integration-tests",
+        "spanner-integration-tests",
+    ],
     deps = [
         "//google/cloud/spanner:spanner_client",
         "//google/cloud/spanner:spanner_client_testing",

--- a/google/cloud/spanner/samples/CMakeLists.txt
+++ b/google/cloud/spanner/samples/CMakeLists.txt
@@ -43,7 +43,9 @@ function (spanner_client_define_samples)
 
     foreach (fname ${spanner_client_integration_samples})
         google_cloud_cpp_set_target_name(target "spanner" "${fname}")
-        set_tests_properties(${target} PROPERTIES LABELS "integration-tests")
+        set_tests_properties(
+            ${target} PROPERTIES LABELS
+                                 "integration-tests;spanner-integration-tests")
     endforeach ()
 endfunction ()
 


### PR DESCRIPTION
This label will be used in `-cpp`. This PR also removes a loop in cmake
that appears to be dead code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1490)
<!-- Reviewable:end -->
