### PR TITLE
chore: upgrade grpc to 1.28.1

### DIFF
--- a/bazel/google_cloud_cpp_spanner_deps.bzl
+++ b/bazel/google_cloud_cpp_spanner_deps.bzl
@@ -98,11 +98,11 @@ def google_cloud_cpp_spanner_deps():
     if "com_github_grpc_grpc" not in native.existing_rules():
         http_archive(
             name = "com_github_grpc_grpc",
-            strip_prefix = "grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b",
+            strip_prefix = "grpc-1.28.1",
             urls = [
-                "https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz",
+                "https://github.com/grpc/grpc/archive/v1.28.1.tar.gz",
             ],
-            sha256 = "a2034a1c8127e35c0cc7b86c1b5ad6d8e79a62c5e133c379b8b22a78ba370015",
+            sha256 = "4cbce7f708917b6e58b631c24c59fe720acc8fef5f959df9a58cdf9558d0a79b",
         )
 
     # We use the cc_proto_library() rule from @com_google_protobuf, which

--- a/ci/kokoro/install/Dockerfile.centos-7
+++ b/ci/kokoro/install/Dockerfile.centos-7
@@ -86,6 +86,24 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
     ldconfig
 # ```
 
+# #### Abseil
+
+# gRPC needs Abseil
+
+# ```bash
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+# ```
+
 # #### gRPC
 
 # We also need a version of gRPC that is recent enough to support the Google
@@ -93,11 +111,21 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-    make install && \
+RUN wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/kokoro/install/Dockerfile.centos-8
+++ b/ci/kokoro/install/Dockerfile.centos-8
@@ -65,6 +65,24 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
     ldconfig
 # ```
 
+# #### Abseil
+
+# gRPC needs Abseil
+
+# ```bash
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+# ```
+
 # #### gRPC
 
 # We also need a version of gRPC that is recent enough to support the Google
@@ -72,11 +90,21 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-    make install && \
+RUN wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/kokoro/install/Dockerfile.debian-stretch
+++ b/ci/kokoro/install/Dockerfile.debian-stretch
@@ -61,6 +61,24 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
     ldconfig
 # ```
 
+# #### Abseil
+
+# gRPC needs Abseil
+
+# ```bash
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+# ```
+
 # #### gRPC
 
 # To install gRPC we first need to configure pkg-config to find the version of
@@ -68,11 +86,21 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-    make install && \
+RUN wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/kokoro/install/Dockerfile.opensuse-leap
+++ b/ci/kokoro/install/Dockerfile.opensuse-leap
@@ -81,6 +81,24 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
     ldconfig
 # ```
 
+# #### Abseil
+
+# gRPC needs Abseil
+
+# ```bash
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+# ```
+
 # #### gRPC
 
 # We also need a version of gRPC that is recent enough to support the Google
@@ -88,11 +106,21 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-    make install && \
+RUN wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/kokoro/install/Dockerfile.ubuntu-bionic
+++ b/ci/kokoro/install/Dockerfile.ubuntu-bionic
@@ -54,6 +54,24 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
     ldconfig
 # ```
 
+# #### Abseil
+
+# gRPC needs Abseil
+
+# ```bash
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+# ```
+
 # #### gRPC
 
 # We also need a version of gRPC that is recent enough to support the Google
@@ -61,11 +79,21 @@ RUN wget -q https://github.com/google/protobuf/archive/v3.11.3.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-    make install && \
+RUN wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/ci/kokoro/install/Dockerfile.ubuntu-xenial
+++ b/ci/kokoro/install/Dockerfile.ubuntu-xenial
@@ -69,6 +69,24 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
     ldconfig
 # ```
 
+# #### Abseil
+
+# gRPC needs Abseil
+
+# ```bash
+WORKDIR /var/tmp/build
+RUN wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+    ldconfig
+# ```
+
 # #### gRPC
 
 # We also need a version of gRPC that is recent enough to support the Google
@@ -76,11 +94,21 @@ RUN wget -q https://github.com/c-ares/c-ares/archive/cares-1_14_0.tar.gz && \
 
 # ```bash
 WORKDIR /var/tmp/build
-RUN wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-    make install && \
+RUN wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
     ldconfig
 # ```
 

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -207,6 +207,24 @@ sudo make install && \
 sudo ldconfig
 ```
 
+#### Abseil
+
+gRPC needs Abseil
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
 #### gRPC
 
 We also need a version of gRPC that is recent enough to support the Google
@@ -214,11 +232,21 @@ Cloud Platform proto files. We manually install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-sudo make install && \
+wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -297,6 +325,24 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
+#### Abseil
+
+gRPC needs Abseil
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
 #### gRPC
 
 We also need a version of gRPC that is recent enough to support the Google
@@ -304,11 +350,21 @@ Cloud Platform proto files. We install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-sudo make install && \
+wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -402,6 +458,24 @@ sudo make install && \
 sudo ldconfig
 ```
 
+#### Abseil
+
+gRPC needs Abseil
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
 #### gRPC
 
 We also need a version of gRPC that is recent enough to support the Google
@@ -409,11 +483,21 @@ Cloud Platform proto files. We can install gRPC from source using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-sudo make install && \
+wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -563,6 +647,24 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
+#### Abseil
+
+gRPC needs Abseil
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
 #### gRPC
 
 To install gRPC we first need to configure pkg-config to find the version of
@@ -570,11 +672,21 @@ Protobuf we just installed in `/usr/local`:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-sudo make install && \
+wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -664,6 +776,24 @@ sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
+#### Abseil
+
+gRPC needs Abseil
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
 #### gRPC
 
 We also need a version of gRPC that is recent enough to support the Google
@@ -671,11 +801,21 @@ Cloud Platform proto files. We manually install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-sudo make install && \
+wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 
@@ -786,6 +926,24 @@ sudo make install && \
 sudo ldconfig
 ```
 
+#### Abseil
+
+gRPC needs Abseil
+
+```bash
+cd $HOME/Downloads
+wget -q https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz && \
+    tar -xf 20200225.2.tar.gz && \
+    cd abseil-cpp-20200225.2 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
+sudo ldconfig
+```
+
 #### gRPC
 
 We also need a version of gRPC that is recent enough to support the Google
@@ -793,11 +951,21 @@ Cloud Platform proto files. We manually install it using:
 
 ```bash
 cd $HOME/Downloads
-wget -q https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    tar -xf 78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz && \
-    cd grpc-78ace4cd5dfcc1f2eced44d22d752f103f377e7b && \
-    make -j ${NCPU:-4} && \
-sudo make install && \
+wget -q https://github.com/grpc/grpc/archive/v1.28.1.tar.gz && \
+    tar -xf v1.28.1.tar.gz && \
+    cd grpc-1.28.1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DgRPC_INSTALL=ON \
+        -DgRPC_ABSL_PROVIDER=package \
+        -DgRPC_CARES_PROVIDER=package \
+        -DgRPC_PROTOBUF_PROVIDER=package \
+        -DgRPC_SSL_PROVIDER=package \
+        -DgRPC_ZLIB_PROVIDER=package \
+        -H. -Bcmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+sudo cmake --build cmake-out --target install -- -j ${NCPU:-4} && \
 sudo ldconfig
 ```
 

--- a/super/external/grpc.cmake
+++ b/super/external/grpc.cmake
@@ -23,10 +23,9 @@ if (NOT TARGET grpc-project)
     # Give application developers a hook to configure the version and hash
     # downloaded from GitHub.
     set(GOOGLE_CLOUD_CPP_GRPC_URL
-        "https://github.com/grpc/grpc/archive/78ace4cd5dfcc1f2eced44d22d752f103f377e7b.tar.gz"
-    )
+        "https://github.com/grpc/grpc/archive/v1.28.1.tar.gz")
     set(GOOGLE_CLOUD_CPP_GRPC_SHA256
-        "a2034a1c8127e35c0cc7b86c1b5ad6d8e79a62c5e133c379b8b22a78ba370015")
+        "4cbce7f708917b6e58b631c24c59fe720acc8fef5f959df9a58cdf9558d0a79b")
 
     set_external_project_build_parallel_level(PARALLEL)
     set_external_project_vars()


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp-spanner/issues/310
... probably. 1.28.1 contains a fix in gRPC where it uses a SHA256 for
its boringssl dep, and using this SHA256 allows bazel to cache the
downloaded archive. So the `bazel fetch` should download boringssl, and
the subsequent `bazel build` should reuse the cached boringssl.

Also this PR adds a dep on Abseil, which is needed by gRPC now. Additionally, I
changed our code to _use_ `absl::make_unique` in the implementation of our code
just as a demonstration to prove that we can use Abseil code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp-spanner/1492)
<!-- Reviewable:end -->
